### PR TITLE
[ADVISING-945]: Track and display assignment/reassignments of service requests in the timeline 

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 // @formatter:off
 /**
  * A helper file for your Eloquent Models

--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1,39 +1,5 @@
 <?php
 
-/*
-<COPYRIGHT>
-
-    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
-
-    Advising App™ is licensed under the Elastic License 2.0. For more details,
-    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
-
-    Notice:
-
-    - You may not provide the software to third parties as a hosted or managed
-      service, where the service provides users with access to any substantial set of
-      the features or functionality of the software.
-    - You may not move, change, disable, or circumvent the license key functionality
-      in the software, and you may not remove or obscure any functionality in the
-      software that is protected by the license key.
-    - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
-      to applicable law.
-    - Canyon GBS LLC respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
-      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
-      vigorously.
-    - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS LLC.
-    - Use of this software implies agreement to the license terms and conditions as stated
-      in the Elastic License 2.0.
-
-    For more information or inquiries please visit our website at
-    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
-
-</COPYRIGHT>
-*/
-
 // @formatter:off
 /**
  * A helper file for your Eloquent Models
@@ -243,9 +209,11 @@ namespace App\Models{
  * @property bool $are_teams_visible_on_profile
  * @property bool $is_division_visible_on_profile
  * @property string $timezone
+ * @property bool $has_enabled_public_profile
+ * @property string|null $public_profile_slug
  * @property bool $office_hours_are_enabled
  * @property bool $appointments_are_restricted_to_existing_students
- * @property mixed|null $office_hours_days
+ * @property array|null $office_hours
  * @property bool $out_of_office_is_enabled
  * @property \Illuminate\Support\Carbon|null $out_of_office_starts_at
  * @property \Illuminate\Support\Carbon|null $out_of_office_ends_at
@@ -297,8 +265,8 @@ namespace App\Models{
  * @property-read int|null $role_groups_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Authorization\Models\Role> $roles
  * @property-read int|null $roles_count
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\ServiceManagement\Models\ServiceRequest> $serviceRequests
- * @property-read int|null $service_requests_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\ServiceManagement\Models\ServiceRequestAssignment> $serviceRequestAssignments
+ * @property-read int|null $service_request_assignments_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\AssistDataModel\Models\Student> $studentCareTeams
  * @property-read int|null $student_care_teams_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\AssistDataModel\Models\Student> $studentSubscriptions
@@ -329,19 +297,21 @@ namespace App\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|User whereEmail($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereEmailVerifiedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereEmplid($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|User whereHasEnabledPublicProfile($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereIsBioVisibleOnProfile($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereIsDivisionVisibleOnProfile($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereIsExternal($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereLocale($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|User whereOfficeHours($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereOfficeHoursAreEnabled($value)
- * @method static \Illuminate\Database\Eloquent\Builder|User whereOfficeHoursDays($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereOutOfOfficeEndsAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereOutOfOfficeIsEnabled($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereOutOfOfficeStartsAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User wherePassword($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User wherePronounsId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|User wherePublicProfileSlug($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereRememberToken($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereTimezone($value)
  * @method static \Illuminate\Database\Eloquent\Builder|User whereType($value)
@@ -393,6 +363,175 @@ namespace Assist\Alert\Models{
  */
 	#[\AllowDynamicProperties]
  class IdeHelperAlert {}
+}
+
+namespace Assist\Application\Models{
+/**
+ * Assist\Application\Models\Application
+ *
+ * @property string $id
+ * @property string $name
+ * @property string|null $description
+ * @property bool $embed_enabled
+ * @property array|null $allowed_domains
+ * @property string|null $primary_color
+ * @property \Assist\Form\Enums\Rounding|null $rounding
+ * @property bool $is_wizard
+ * @property array|null $content
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property string|null $deleted_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Application\Models\ApplicationField> $fields
+ * @property-read int|null $fields_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Application\Models\ApplicationStep> $steps
+ * @property-read int|null $steps_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Application\Models\ApplicationSubmission> $submissions
+ * @property-read int|null $submissions_count
+ * @method static \Assist\Application\Database\Factories\ApplicationFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder|Application newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Application newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Application query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereAllowedDomains($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereContent($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereEmbedEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereIsWizard($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application wherePrimaryColor($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereRounding($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Application whereUpdatedAt($value)
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperApplication {}
+}
+
+namespace Assist\Application\Models{
+/**
+ * Assist\Application\Models\ApplicationAuthentication
+ *
+ * @property string $id
+ * @property string|null $author_id
+ * @property string|null $author_type
+ * @property string|null $code
+ * @property string $application_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent $author
+ * @property-read \Assist\Application\Models\Application $submissible
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationAuthentication newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationAuthentication newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationAuthentication query()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationAuthentication whereApplicationId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationAuthentication whereAuthorId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationAuthentication whereAuthorType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationAuthentication whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationAuthentication whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationAuthentication whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationAuthentication whereUpdatedAt($value)
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperApplicationAuthentication {}
+}
+
+namespace Assist\Application\Models{
+/**
+ * Assist\Application\Models\ApplicationField
+ *
+ * @property string $id
+ * @property string $label
+ * @property string $type
+ * @property bool $is_required
+ * @property array $config
+ * @property string $application_id
+ * @property string|null $step_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Assist\Application\Models\ApplicationStep|null $step
+ * @property-read \Assist\Application\Models\Application $submissible
+ * @method static \Assist\Application\Database\Factories\ApplicationFieldFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField query()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField whereApplicationId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField whereConfig($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField whereIsRequired($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField whereLabel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField whereStepId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationField whereUpdatedAt($value)
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperApplicationField {}
+}
+
+namespace Assist\Application\Models{
+/**
+ * Assist\Application\Models\ApplicationStep
+ *
+ * @property string $id
+ * @property string $label
+ * @property array|null $content
+ * @property string $application_id
+ * @property int $sort
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Application\Models\ApplicationField> $fields
+ * @property-read int|null $fields_count
+ * @property-read \Assist\Application\Models\Application $submissible
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationStep newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationStep newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationStep query()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationStep whereApplicationId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationStep whereContent($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationStep whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationStep whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationStep whereLabel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationStep whereSort($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationStep whereUpdatedAt($value)
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperApplicationStep {}
+}
+
+namespace Assist\Application\Models{
+/**
+ * Assist\Application\Models\ApplicationSubmission
+ *
+ * @property string $id
+ * @property string $application_id
+ * @property string|null $author_id
+ * @property string|null $author_type
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property string|null $deleted_at
+ * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent $author
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Application\Models\ApplicationField> $fields
+ * @property-read int|null $fields_count
+ * @property-read \Assist\Application\Models\Application $submissible
+ * @method static \Assist\Application\Database\Factories\ApplicationSubmissionFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationSubmission newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationSubmission newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationSubmission query()
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationSubmission whereApplicationId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationSubmission whereAuthorId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationSubmission whereAuthorType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationSubmission whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationSubmission whereDeletedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationSubmission whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ApplicationSubmission whereUpdatedAt($value)
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperApplicationSubmission {}
 }
 
 namespace Assist\AssistDataModel\Models{
@@ -1187,6 +1326,7 @@ namespace Assist\Engagement\Models{
  * @property string $engagement_id
  * @property \Assist\Engagement\Enums\EngagementDeliveryMethod $channel
  * @property string|null $external_reference_id
+ * @property string|null $external_status
  * @property \Assist\Engagement\Enums\EngagementDeliveryStatus $delivery_status
  * @property \Illuminate\Support\Carbon|null $delivered_at
  * @property \Illuminate\Support\Carbon|null $last_delivery_attempt
@@ -1209,6 +1349,7 @@ namespace Assist\Engagement\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|EngagementDeliverable whereDeliveryStatus($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagementDeliverable whereEngagementId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagementDeliverable whereExternalReferenceId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EngagementDeliverable whereExternalStatus($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagementDeliverable whereId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagementDeliverable whereLastDeliveryAttempt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|EngagementDeliverable whereUpdatedAt($value)
@@ -1393,7 +1534,7 @@ namespace Assist\Form\Models{
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read \Illuminate\Database\Eloquent\Model|\Eloquent $author
- * @property-read \Assist\Form\Models\Form $form
+ * @property-read \Assist\Form\Models\Form $submissible
  * @method static \Illuminate\Database\Eloquent\Builder|FormAuthentication newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|FormAuthentication newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|FormAuthentication query()
@@ -1423,8 +1564,8 @@ namespace Assist\Form\Models{
  * @property string|null $step_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
- * @property-read \Assist\Form\Models\Form $form
  * @property-read \Assist\Form\Models\FormStep|null $step
+ * @property-read \Assist\Form\Models\Form $submissible
  * @method static \Assist\Form\Database\Factories\FormFieldFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|FormField newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|FormField newQuery()
@@ -1457,7 +1598,7 @@ namespace Assist\Form\Models{
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Form\Models\FormField> $fields
  * @property-read int|null $fields_count
- * @property-read \Assist\Form\Models\Form $form
+ * @property-read \Assist\Form\Models\Form $submissible
  * @method static \Illuminate\Database\Eloquent\Builder|FormStep newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|FormStep newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|FormStep query()
@@ -1488,7 +1629,7 @@ namespace Assist\Form\Models{
  * @property string|null $deleted_at
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Form\Models\FormField> $fields
  * @property-read int|null $fields_count
- * @property-read \Assist\Form\Models\Form $form
+ * @property-read \Assist\Form\Models\Form $submissible
  * @method static \Assist\Form\Database\Factories\FormSubmissionFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|FormSubmission newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|FormSubmission newQuery()
@@ -2193,16 +2334,18 @@ namespace Assist\ServiceManagement\Models{
  * @property string|null $status_id
  * @property string|null $type_id
  * @property string|null $priority_id
- * @property string|null $assigned_to_id
  * @property string|null $created_by_id
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
- * @property-read \App\Models\User|null $assignedTo
+ * @property-read \Assist\ServiceManagement\Models\ServiceRequestAssignment|null $assignedTo
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\ServiceManagement\Models\ServiceRequestAssignment> $assignments
+ * @property-read int|null $assignments_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Audit\Models\Audit> $audits
  * @property-read int|null $audits_count
  * @property-read \App\Models\User|null $createdBy
  * @property-read \Assist\Division\Models\Division|null $division
+ * @property-read \Assist\ServiceManagement\Models\ServiceRequestAssignment|null $initialAssignment
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Interaction\Models\Interaction> $interactions
  * @property-read int|null $interactions_count
  * @property-read \Assist\ServiceManagement\Models\ServiceRequestPriority|null $priority
@@ -2216,7 +2359,6 @@ namespace Assist\ServiceManagement\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequest onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequest open()
  * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequest query()
- * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequest whereAssignedToId($value)
  * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequest whereCloseDetails($value)
  * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequest whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequest whereCreatedById($value)
@@ -2237,6 +2379,38 @@ namespace Assist\ServiceManagement\Models{
  */
 	#[\AllowDynamicProperties]
  class IdeHelperServiceRequest {}
+}
+
+namespace Assist\ServiceManagement\Models{
+/**
+ * Assist\ServiceManagement\Models\ServiceRequestAssignment
+ *
+ * @property string $id
+ * @property string $service_request_id
+ * @property string $user_id
+ * @property \Illuminate\Support\Carbon|null $assigned_at
+ * @property \Assist\ServiceManagement\Enums\ServiceRequestAssignmentStatus $status
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \Assist\Audit\Models\Audit> $audits
+ * @property-read int|null $audits_count
+ * @property-read \Assist\ServiceManagement\Models\ServiceRequest $serviceRequest
+ * @property-read \App\Models\User $user
+ * @method static \Assist\ServiceManagement\Database\Factories\ServiceRequestAssignmentFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequestAssignment newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequestAssignment newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequestAssignment query()
+ * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequestAssignment whereAssignedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequestAssignment whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequestAssignment whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequestAssignment whereServiceRequestId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequestAssignment whereStatus($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequestAssignment whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ServiceRequestAssignment whereUserId($value)
+ * @mixin \Eloquent
+ */
+	#[\AllowDynamicProperties]
+ class IdeHelperServiceRequestAssignment {}
 }
 
 namespace Assist\ServiceManagement\Models{

--- a/app-modules/campaign/src/Filament/Blocks/ServiceRequestBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/ServiceRequestBlock.php
@@ -92,7 +92,7 @@ class ServiceRequestBlock extends CampaignActionBlock
                 ->required()
                 ->exists((new ServiceRequestType())->getTable(), 'id'),
             Select::make($fieldPrefix . 'assigned_to_id')
-                ->relationship('assignedTo', 'name')
+                ->relationship('assignedTo.user', 'name')
                 ->searchable()
                 ->label('Assign Service Request to')
                 ->nullable()

--- a/app-modules/service-management/config/roles/web/service_management.php
+++ b/app-modules/service-management/config/roles/web/service_management.php
@@ -51,5 +51,8 @@ return [
         'service_request_update' => [
             '*',
         ],
+        'service_request_assignment' => [
+            '*',
+        ],
     ],
 ];

--- a/app-modules/service-management/config/roles/web/service_request_assignment_management.php
+++ b/app-modules/service-management/config/roles/web/service_request_assignment_management.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'model' => [
+        'service_request_assignment' => [
+            '*',
+        ],
+    ],
+];

--- a/app-modules/service-management/config/roles/web/service_request_assignment_management.php
+++ b/app-modules/service-management/config/roles/web/service_request_assignment_management.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 return [
     'model' => [
         'service_request_assignment' => [

--- a/app-modules/service-management/database/factories/ServiceRequestAssignmentFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestAssignmentFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Assist\ServiceManagement\Database\Factories;
+
+use App\Models\User;
+use Assist\ServiceManagement\Models\ServiceRequest;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Assist\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\Assist\ServiceManagement\Models\ServiceRequestAssignment>
+ */
+class ServiceRequestAssignmentFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'service_request_id' => ServiceRequest::factory(),
+            'user_id' => User::factory(),
+            'assigned_at' => fake()->dateTimeBetween('-1 year', now()),
+        ];
+    }
+
+    public function active(): self
+    {
+        return $this->state([
+            'status' => ServiceRequestAssignmentStatus::Active,
+        ]);
+    }
+}

--- a/app-modules/service-management/database/factories/ServiceRequestAssignmentFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestAssignmentFactory.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace Assist\ServiceManagement\Database\Factories;
 
 use App\Models\User;

--- a/app-modules/service-management/database/factories/ServiceRequestAssignmentFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestAssignmentFactory.php
@@ -51,6 +51,7 @@ class ServiceRequestAssignmentFactory extends Factory
         return [
             'service_request_id' => ServiceRequest::factory(),
             'user_id' => User::factory(),
+            'assigned_by_id' => User::factory(),
             'assigned_at' => fake()->dateTimeBetween('-1 year', now()),
         ];
     }

--- a/app-modules/service-management/database/migrations/2023_09_05_144251_create_service_requests_table.php
+++ b/app-modules/service-management/database/migrations/2023_09_05_144251_create_service_requests_table.php
@@ -54,7 +54,6 @@ return new class () extends Migration {
             $table->foreignUuid('status_id')->nullable()->constrained('service_request_statuses');
             $table->foreignUuid('type_id')->nullable()->constrained('service_request_types');
             $table->foreignUuid('priority_id')->nullable()->constrained('service_request_priorities');
-            $table->foreignUuid('assigned_to_id')->nullable()->constrained('users');
             $table->foreignUuid('created_by_id')->nullable()->constrained('users');
 
             $table->timestamps();

--- a/app-modules/service-management/database/migrations/2023_12_01_015036_create_service_request_assignments_table.php
+++ b/app-modules/service-management/database/migrations/2023_12_01_015036_create_service_request_assignments_table.php
@@ -46,6 +46,7 @@ return new class () extends Migration {
             $table->uuid('id')->primary();
             $table->foreignUuid('service_request_id')->constrained('service_requests');
             $table->foreignUuid('user_id')->constrained('users');
+            $table->foreignUuid('assigned_by_id')->nullable()->constrained('users');
             $table->timestamp('assigned_at');
             $table->string('status')->default(ServiceRequestAssignmentStatus::Active);
             $table->timestamps();

--- a/app-modules/service-management/database/migrations/2023_12_01_015036_create_service_request_assignments_table.php
+++ b/app-modules/service-management/database/migrations/2023_12_01_015036_create_service_request_assignments_table.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Assist\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('service_request_assignments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('service_request_id')->constrained('service_requests');
+            $table->foreignUuid('user_id')->constrained('users');
+            $table->timestamp('assigned_at')->nullable();
+            $table->string('status')->default(ServiceRequestAssignmentStatus::Active);
+            $table->timestamps();
+        });
+    }
+};

--- a/app-modules/service-management/database/migrations/2023_12_01_015036_create_service_request_assignments_table.php
+++ b/app-modules/service-management/database/migrations/2023_12_01_015036_create_service_request_assignments_table.php
@@ -46,7 +46,7 @@ return new class () extends Migration {
             $table->uuid('id')->primary();
             $table->foreignUuid('service_request_id')->constrained('service_requests');
             $table->foreignUuid('user_id')->constrained('users');
-            $table->timestamp('assigned_at')->nullable();
+            $table->timestamp('assigned_at');
             $table->string('status')->default(ServiceRequestAssignmentStatus::Active);
             $table->timestamps();
         });

--- a/app-modules/service-management/database/migrations/2023_12_01_015036_create_service_request_assignments_table.php
+++ b/app-modules/service-management/database/migrations/2023_12_01_015036_create_service_request_assignments_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;

--- a/app-modules/service-management/database/seeders/ServiceRequestSeeder.php
+++ b/app-modules/service-management/database/seeders/ServiceRequestSeeder.php
@@ -36,14 +36,23 @@
 
 namespace Assist\ServiceManagement\Database\Seeders;
 
+use App\Models\User;
 use Illuminate\Database\Seeder;
 use Assist\ServiceManagement\Models\ServiceRequest;
+use Assist\ServiceManagement\Models\ServiceRequestAssignment;
 
 class ServiceRequestSeeder extends Seeder
 {
     public function run(): void
     {
         ServiceRequest::factory()
+            ->has(
+                factory: ServiceRequestAssignment::factory()
+                    ->for(User::where('email', 'sampleadmin@advising.app')->first())
+                    ->count(1)
+                    ->active(),
+                relationship: 'assignments'
+            )
             ->count(30)
             ->create();
     }

--- a/app-modules/service-management/database/seeders/ServiceRequestSeeder.php
+++ b/app-modules/service-management/database/seeders/ServiceRequestSeeder.php
@@ -45,10 +45,12 @@ class ServiceRequestSeeder extends Seeder
 {
     public function run(): void
     {
+        $superAdmin = User::where('email', 'sampleadmin@advising.app')->first();
+
         ServiceRequest::factory()
             ->has(
                 factory: ServiceRequestAssignment::factory()
-                    ->for(User::where('email', 'sampleadmin@advising.app')->first())
+                    ->for($superAdmin, 'user')
                     ->count(1)
                     ->active(),
                 relationship: 'assignments'

--- a/app-modules/service-management/database/seeders/ServiceRequestUpdateSeeder.php
+++ b/app-modules/service-management/database/seeders/ServiceRequestUpdateSeeder.php
@@ -42,9 +42,6 @@ use Assist\ServiceManagement\Models\ServiceRequestUpdate;
 
 class ServiceRequestUpdateSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
         ServiceRequest::each(function (ServiceRequest $serviceRequest) {

--- a/app-modules/service-management/resources/views/components/service-request-assignment-timeline-item.blade.php
+++ b/app-modules/service-management/resources/views/components/service-request-assignment-timeline-item.blade.php
@@ -41,7 +41,6 @@
         <h3 class="mb-1 flex items-center text-lg font-semibold text-gray-500 dark:text-gray-100">
 
             <span class="ml-2 flex space-x-2">
-                {{-- TODO How do we want to determine whether or not this was the "first" assignment or a reassignment??? --}}
                 @if ($record->id === $record->serviceRequest->initialAssignment->id)
                     Service Request Assigned
                 @else

--- a/app-modules/service-management/resources/views/components/service-request-assignment-timeline-item.blade.php
+++ b/app-modules/service-management/resources/views/components/service-request-assignment-timeline-item.blade.php
@@ -1,6 +1,4 @@
-<?php
-
-/*
+{{--
 <COPYRIGHT>
 
     Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
@@ -32,38 +30,41 @@
     https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
 
 </COPYRIGHT>
-*/
+--}}
 
-namespace Assist\ServiceManagement\Database\Factories;
+@php
+    use App\Filament\Resources\UserResource;
+@endphp
 
-use App\Models\User;
-use Assist\Division\Models\Division;
-use Assist\AssistDataModel\Models\Student;
-use Assist\ServiceManagement\Models\ServiceRequest;
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Assist\ServiceManagement\Models\ServiceRequestType;
-use Assist\ServiceManagement\Models\ServiceRequestStatus;
-use Assist\ServiceManagement\Models\ServiceRequestPriority;
+<div>
+    <div class="flex flex-row justify-between">
+        <h3 class="mb-1 flex items-center text-lg font-semibold text-gray-500 dark:text-gray-100">
 
-/**
- * @extends Factory<ServiceRequest>
- */
-class ServiceRequestFactory extends Factory
-{
-    public function definition(): array
-    {
-        return [
-            'respondent_id' => Student::inRandomOrder()->first()->sisid ?? Student::factory(),
-            'respondent_type' => function (array $attributes) {
-                return Student::find($attributes['respondent_id'])->getMorphClass();
-            },
-            'close_details' => $this->faker->sentence(),
-            'res_details' => $this->faker->sentence(),
-            'division_id' => Division::inRandomOrder()->first()?->id ?? Division::factory(),
-            'status_id' => ServiceRequestStatus::inRandomOrder()->first() ?? ServiceRequestStatus::factory(),
-            'type_id' => ServiceRequestType::inRandomOrder()->first() ?? ServiceRequestType::factory(),
-            'priority_id' => ServiceRequestPriority::inRandomOrder()->first() ?? ServiceRequestPriority::factory(),
-            'created_by_id' => User::factory(),
-        ];
-    }
-}
+            <span class="ml-2 flex space-x-2">
+                {{-- TODO How do we want to determine whether or not this was the "first" assignment or a reassignment??? --}}
+                @if ($record->id === $record->serviceRequest->initialAssignment->id)
+                    Service Request Assigned
+                @else
+                    Service Request Reassigned
+                @endif
+            </span>
+        </h3>
+
+        <div>
+            {{ $viewRecordIcon }}
+        </div>
+    </div>
+
+    <time class="mb-2 block text-sm font-normal leading-none text-gray-400 dark:text-gray-500">
+        {{ $record->created_at->diffForHumans() }}
+    </time>
+
+    <div
+        class="my-4 rounded-lg border-2 border-gray-200 p-2 text-base font-normal text-gray-500 dark:border-gray-800 dark:text-gray-400">
+        Assigned to:
+        <a
+            class="primary underline"
+            href="{{ UserResource::getUrl('view', ['record' => $record->user]) }}"
+        >{{ $record->user->name }}</a>
+    </div>
+</div>

--- a/app-modules/service-management/src/Enums/ServiceRequestAssignmentStatus.php
+++ b/app-modules/service-management/src/Enums/ServiceRequestAssignmentStatus.php
@@ -34,36 +34,18 @@
 </COPYRIGHT>
 */
 
-namespace Assist\ServiceManagement\Database\Factories;
+namespace Assist\ServiceManagement\Enums;
 
-use App\Models\User;
-use Assist\Division\Models\Division;
-use Assist\AssistDataModel\Models\Student;
-use Assist\ServiceManagement\Models\ServiceRequest;
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Assist\ServiceManagement\Models\ServiceRequestType;
-use Assist\ServiceManagement\Models\ServiceRequestStatus;
-use Assist\ServiceManagement\Models\ServiceRequestPriority;
+use Filament\Support\Contracts\HasLabel;
 
-/**
- * @extends Factory<ServiceRequest>
- */
-class ServiceRequestFactory extends Factory
+enum ServiceRequestAssignmentStatus: string implements HasLabel
 {
-    public function definition(): array
+    case Active = 'active';
+
+    case Inactive = 'inactive';
+
+    public function getLabel(): ?string
     {
-        return [
-            'respondent_id' => Student::inRandomOrder()->first()->sisid ?? Student::factory(),
-            'respondent_type' => function (array $attributes) {
-                return Student::find($attributes['respondent_id'])->getMorphClass();
-            },
-            'close_details' => $this->faker->sentence(),
-            'res_details' => $this->faker->sentence(),
-            'division_id' => Division::inRandomOrder()->first()?->id ?? Division::factory(),
-            'status_id' => ServiceRequestStatus::inRandomOrder()->first() ?? ServiceRequestStatus::factory(),
-            'type_id' => ServiceRequestType::inRandomOrder()->first() ?? ServiceRequestType::factory(),
-            'priority_id' => ServiceRequestPriority::inRandomOrder()->first() ?? ServiceRequestPriority::factory(),
-            'created_by_id' => User::factory(),
-        ];
+        return $this->name;
     }
 }

--- a/app-modules/service-management/src/Filament/Concerns/ServiceRequestAssignmentInfolist.php
+++ b/app-modules/service-management/src/Filament/Concerns/ServiceRequestAssignmentInfolist.php
@@ -34,36 +34,28 @@
 </COPYRIGHT>
 */
 
-namespace Assist\ServiceManagement\Database\Factories;
+namespace Assist\ServiceManagement\Filament\Concerns;
 
-use App\Models\User;
-use Assist\Division\Models\Division;
-use Assist\AssistDataModel\Models\Student;
-use Assist\ServiceManagement\Models\ServiceRequest;
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Assist\ServiceManagement\Models\ServiceRequestType;
-use Assist\ServiceManagement\Models\ServiceRequestStatus;
-use Assist\ServiceManagement\Models\ServiceRequestPriority;
+use App\Filament\Resources\UserResource;
+use Filament\Infolists\Components\TextEntry;
+use Assist\ServiceManagement\Models\ServiceRequestAssignment;
+use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource;
 
-/**
- * @extends Factory<ServiceRequest>
- */
-class ServiceRequestFactory extends Factory
+// TODO Re-use this trait across other places where infolist is rendered
+trait ServiceRequestAssignmentInfolist
 {
-    public function definition(): array
+    public function serviceRequestAssignmentInfolist(): array
     {
         return [
-            'respondent_id' => Student::inRandomOrder()->first()->sisid ?? Student::factory(),
-            'respondent_type' => function (array $attributes) {
-                return Student::find($attributes['respondent_id'])->getMorphClass();
-            },
-            'close_details' => $this->faker->sentence(),
-            'res_details' => $this->faker->sentence(),
-            'division_id' => Division::inRandomOrder()->first()?->id ?? Division::factory(),
-            'status_id' => ServiceRequestStatus::inRandomOrder()->first() ?? ServiceRequestStatus::factory(),
-            'type_id' => ServiceRequestType::inRandomOrder()->first() ?? ServiceRequestType::factory(),
-            'priority_id' => ServiceRequestPriority::inRandomOrder()->first() ?? ServiceRequestPriority::factory(),
-            'created_by_id' => User::factory(),
+            TextEntry::make('serviceRequest.service_request_number')
+                ->label('Service Request')
+                ->translateLabel()
+                ->url(fn (ServiceRequestAssignment $serviceRequestAssignment): string => ServiceRequestResource::getUrl('view', ['record' => $serviceRequestAssignment->serviceRequest]))
+                ->color('primary'),
+            TextEntry::make('user.name')
+                ->label('Assigned To')
+                ->url(fn (ServiceRequestAssignment $serviceRequestAssignment): string => UserResource::getUrl('view', ['record' => $serviceRequestAssignment->user]))
+                ->color('primary'),
         ];
     }
 }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource.php
@@ -44,8 +44,8 @@ use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages\Vie
 use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages\ListServiceRequests;
 use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages\CreateServiceRequest;
 use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages\ServiceRequestTimeline;
-use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages\ManageServiceRequestUser;
 use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages\ManageServiceRequestUpdate;
+use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages\ManageServiceRequestAssignment;
 use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages\ManageServiceRequestInteraction;
 
 class ServiceRequestResource extends Resource
@@ -69,7 +69,7 @@ class ServiceRequestResource extends Resource
         return $page->generateNavigationItems([
             ViewServiceRequest::class,
             EditServiceRequest::class,
-            ManageServiceRequestUser::class,
+            ManageServiceRequestAssignment::class,
             ManageServiceRequestUpdate::class,
             ManageServiceRequestInteraction::class,
             ServiceRequestTimeline::class,
@@ -80,7 +80,7 @@ class ServiceRequestResource extends Resource
     {
         return [
             'index' => ListServiceRequests::route('/'),
-            'manage-users' => ManageServiceRequestUser::route('/{record}/users'),
+            'manage-assignments' => ManageServiceRequestAssignment::route('/{record}/users'),
             'manage-service-request-updates' => ManageServiceRequestUpdate::route('/{record}/updates'),
             'manage-interactions' => ManageServiceRequestInteraction::route('/{record}/interactions'),
             'create' => CreateServiceRequest::route('/create'),

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ListServiceRequests.php
@@ -36,9 +36,9 @@
 
 namespace Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pages;
 
-use Filament\Actions;
 use Filament\Tables\Table;
 use App\Filament\Columns\IdColumn;
+use Filament\Actions\CreateAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -95,7 +95,7 @@ class ListServiceRequests extends ListRecords
                     ->label('Division')
                     ->searchable()
                     ->sortable(),
-                TextColumn::make('assignedTo.name')
+                TextColumn::make('assignedTo.user.name')
                     ->label('Assigned to')
                     ->searchable()
                     ->sortable(),
@@ -124,7 +124,7 @@ class ListServiceRequests extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make()
+            CreateAction::make()
                 ->label('Add Service Request'),
         ];
     }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ServiceRequestTimeline.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/Pages/ServiceRequestTimeline.php
@@ -38,6 +38,7 @@ namespace Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\Pag
 
 use Assist\Timeline\Filament\Pages\TimelinePage;
 use Assist\ServiceManagement\Models\ServiceRequestUpdate;
+use Assist\ServiceManagement\Models\ServiceRequestAssignment;
 use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource;
 
 class ServiceRequestTimeline extends TimelinePage
@@ -52,5 +53,6 @@ class ServiceRequestTimeline extends TimelinePage
 
     public array $modelsToTimeline = [
         ServiceRequestUpdate::class,
+        ServiceRequestAssignment::class,
     ];
 }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/AssignedToRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/AssignedToRelationManager.php
@@ -36,15 +36,20 @@
 
 namespace Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\RelationManagers;
 
-use Filament\Forms;
 use App\Models\User;
-use Filament\Tables;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use App\Filament\Columns\IdColumn;
+use Filament\Tables\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Tables\Actions\ViewAction;
+use Filament\Tables\Columns\TextColumn;
 use App\Filament\Resources\UserResource;
+use Filament\Forms\Components\TextInput;
 use Assist\ServiceManagement\Models\ServiceRequest;
 use App\Filament\Resources\RelationManagers\RelationManager;
+use Assist\ServiceManagement\Models\ServiceRequestAssignment;
+use Assist\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
 
 class AssignedToRelationManager extends RelationManager
 {
@@ -56,7 +61,7 @@ class AssignedToRelationManager extends RelationManager
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('full')
+                TextInput::make('user.full')
                     ->required()
                     ->maxLength(255),
             ]);
@@ -67,24 +72,27 @@ class AssignedToRelationManager extends RelationManager
         return $table
             ->columns([
                 IdColumn::make(),
-                Tables\Columns\TextColumn::make('name')
+                TextColumn::make('user.name')
                     ->label('Name'),
             ])
             ->paginated(false)
             ->headerActions([
-                // TODO: Figure out how to make it so this only displays on the edit page
-                Tables\Actions\Action::make('reassign-service-request')
+                Action::make('reassign-service-request')
                     ->label('Reassign Service Request')
                     ->color('gray')
                     ->action(function (array $data): void {
                         /** @var ServiceRequest $serviceRequest */
                         $serviceRequest = $this->ownerRecord;
 
-                        $serviceRequest->assignedTo()->associate($data['userId'])->save();
+                        $serviceRequest->assignments()->create([
+                            'user_id' => $data['userId'],
+                            'assigned_at' => now(),
+                            'status' => ServiceRequestAssignmentStatus::Active,
+                        ]);
                     })
                     ->form([
-                        Forms\Components\Select::make('userId')
-                            ->label('Assigned User')
+                        Select::make('userId')
+                            ->label('Reassign Service Request To')
                             ->searchable()
                             ->getSearchResultsUsing(fn (string $search): array => User::whereRaw('LOWER(name) LIKE ? ', ['%' . str($search)->lower() . '%'])->pluck('name', 'id')->toArray())
                             ->getOptionLabelUsing(fn ($value): ?string => User::find($value)?->name)
@@ -93,8 +101,8 @@ class AssignedToRelationManager extends RelationManager
                     ]),
             ])
             ->actions([
-                Tables\Actions\ViewAction::make()
-                    ->url(fn (User $user) => UserResource::getUrl('view', ['record' => $user])),
+                ViewAction::make()
+                    ->url(fn (ServiceRequestAssignment $assignment) => UserResource::getUrl('view', ['record' => $assignment->user])),
             ]);
     }
 }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/AssignedToRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/AssignedToRelationManager.php
@@ -86,6 +86,7 @@ class AssignedToRelationManager extends RelationManager
 
                         $serviceRequest->assignments()->create([
                             'user_id' => $data['userId'],
+                            'assigned_by_id' => auth()->user()?->id ?? null,
                             'assigned_at' => now(),
                             'status' => ServiceRequestAssignmentStatus::Active,
                         ]);

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/CreatedByRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/CreatedByRelationManager.php
@@ -36,13 +36,14 @@
 
 namespace Assist\ServiceManagement\Filament\Resources\ServiceRequestResource\RelationManagers;
 
-use Filament\Forms;
 use App\Models\User;
-use Filament\Tables;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
 use App\Filament\Columns\IdColumn;
+use Filament\Tables\Actions\ViewAction;
+use Filament\Tables\Columns\TextColumn;
 use App\Filament\Resources\UserResource;
+use Filament\Forms\Components\TextInput;
 use App\Filament\Resources\RelationManagers\RelationManager;
 
 class CreatedByRelationManager extends RelationManager
@@ -55,7 +56,7 @@ class CreatedByRelationManager extends RelationManager
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('full')
+                TextInput::make('full')
                     ->required()
                     ->maxLength(255),
             ]);
@@ -66,12 +67,12 @@ class CreatedByRelationManager extends RelationManager
         return $table
             ->columns([
                 IdColumn::make(),
-                Tables\Columns\TextColumn::make('name')
+                TextColumn::make('name')
                     ->label('Name'),
             ])
             ->paginated(false)
             ->actions([
-                Tables\Actions\ViewAction::make()
+                ViewAction::make()
                     ->url(fn (User $user) => UserResource::getUrl('view', ['record' => $user])),
             ]);
     }

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource/Components/ServiceRequestAssignmentViewAction.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource/Components/ServiceRequestAssignmentViewAction.php
@@ -34,36 +34,19 @@
 </COPYRIGHT>
 */
 
-namespace Assist\ServiceManagement\Database\Factories;
+namespace Assist\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource\Components;
 
-use App\Models\User;
-use Assist\Division\Models\Division;
-use Assist\AssistDataModel\Models\Student;
-use Assist\ServiceManagement\Models\ServiceRequest;
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Assist\ServiceManagement\Models\ServiceRequestType;
-use Assist\ServiceManagement\Models\ServiceRequestStatus;
-use Assist\ServiceManagement\Models\ServiceRequestPriority;
+use Filament\Actions\ViewAction;
+use Assist\ServiceManagement\Filament\Concerns\ServiceRequestAssignmentInfolist;
 
-/**
- * @extends Factory<ServiceRequest>
- */
-class ServiceRequestFactory extends Factory
+class ServiceRequestAssignmentViewAction extends ViewAction
 {
-    public function definition(): array
+    use ServiceRequestAssignmentInfolist;
+
+    protected function setUp(): void
     {
-        return [
-            'respondent_id' => Student::inRandomOrder()->first()->sisid ?? Student::factory(),
-            'respondent_type' => function (array $attributes) {
-                return Student::find($attributes['respondent_id'])->getMorphClass();
-            },
-            'close_details' => $this->faker->sentence(),
-            'res_details' => $this->faker->sentence(),
-            'division_id' => Division::inRandomOrder()->first()?->id ?? Division::factory(),
-            'status_id' => ServiceRequestStatus::inRandomOrder()->first() ?? ServiceRequestStatus::factory(),
-            'type_id' => ServiceRequestType::inRandomOrder()->first() ?? ServiceRequestType::factory(),
-            'priority_id' => ServiceRequestPriority::inRandomOrder()->first() ?? ServiceRequestPriority::factory(),
-            'created_by_id' => User::factory(),
-        ];
+        parent::setUp();
+
+        $this->infolist($this->serviceRequestAssignmentInfolist());
     }
 }

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -211,7 +211,7 @@ class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubsc
     {
         try {
             $action->campaign->caseload->retrieveRecords()->each(function (Educatable $educatable) use ($action) {
-                ServiceRequest::create([
+                $request = ServiceRequest::create([
                     'respondent_type' => $educatable->getMorphClass(),
                     'respondent_id' => $educatable->getKey(),
                     'close_details' => $action->data['close_details'],
@@ -220,9 +220,16 @@ class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubsc
                     'status_id' => $action->data['status_id'],
                     'type_id' => $action->data['type_id'],
                     'priority_id' => $action->data['priority_id'],
-                    'assigned_to_id' => $action->data['assigned_to_id'] ?? null,
                     'created_by_id' => $action->campaign->user->id,
                 ]);
+
+                if ($action->data['assigned_to_id']) {
+                    $request->assignments()->create([
+                        'user_id' => $action->data['assigned_to_id'],
+                        'assigned_at' => now(),
+                        'status' => ServiceRequestAssignmentStatus::Active,
+                    ]);
+                }
             });
 
             return true;

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -185,15 +185,13 @@ class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubsc
     {
         return $this->hasOne(ServiceRequestAssignment::class)
             ->latest('assigned_at')
-            ->where('status', ServiceRequestAssignmentStatus::Active)
-            ->limit(1);
+            ->where('status', ServiceRequestAssignmentStatus::Active);
     }
 
     public function initialAssignment(): HasOne
     {
         return $this->hasOne(ServiceRequestAssignment::class)
-            ->oldest('assigned_at')
-            ->limit(1);
+            ->oldest('assigned_at');
     }
 
     public function createdBy(): BelongsTo

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -226,6 +226,7 @@ class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubsc
                 if ($action->data['assigned_to_id']) {
                     $request->assignments()->create([
                         'user_id' => $action->data['assigned_to_id'],
+                        'assigned_by_id' => $action->campaign->user->id,
                         'assigned_at' => now(),
                         'status' => ServiceRequestAssignmentStatus::Active,
                     ]);

--- a/app-modules/service-management/src/Models/ServiceRequestAssignment.php
+++ b/app-modules/service-management/src/Models/ServiceRequestAssignment.php
@@ -16,6 +16,9 @@ use Assist\Timeline\Timelines\ServiceRequestAssignmentTimeline;
 use Assist\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
 use Assist\Notifications\Models\Contracts\CanTriggerAutoSubscription;
 
+/**
+ * @mixin IdeHelperServiceRequestAssignment
+ */
 class ServiceRequestAssignment extends BaseModel implements Auditable, CanTriggerAutoSubscription, ProvidesATimeline
 {
     use HasUuids;

--- a/app-modules/service-management/src/Models/ServiceRequestAssignment.php
+++ b/app-modules/service-management/src/Models/ServiceRequestAssignment.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace Assist\ServiceManagement\Models;
 
 use App\Models\User;

--- a/app-modules/service-management/src/Models/ServiceRequestAssignment.php
+++ b/app-modules/service-management/src/Models/ServiceRequestAssignment.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Assist\ServiceManagement\Models;
+
+use App\Models\User;
+use App\Models\BaseModel;
+use Illuminate\Support\Collection;
+use Illuminate\Database\Eloquent\Model;
+use OwenIt\Auditing\Contracts\Auditable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Assist\Notifications\Models\Contracts\Subscribable;
+use Assist\Timeline\Models\Contracts\ProvidesATimeline;
+use Assist\Audit\Models\Concerns\Auditable as AuditableTrait;
+use Assist\Timeline\Timelines\ServiceRequestAssignmentTimeline;
+use Assist\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
+use Assist\Notifications\Models\Contracts\CanTriggerAutoSubscription;
+
+class ServiceRequestAssignment extends BaseModel implements Auditable, CanTriggerAutoSubscription, ProvidesATimeline
+{
+    use HasUuids;
+    use AuditableTrait;
+
+    protected $casts = [
+        'assigned_at' => 'datetime',
+        'status' => ServiceRequestAssignmentStatus::class,
+    ];
+
+    protected $fillable = [
+        'user_id',
+        'assigned_at',
+        'status',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function serviceRequest(): BelongsTo
+    {
+        return $this->belongsTo(ServiceRequest::class);
+    }
+
+    public function timeline(): ServiceRequestAssignmentTimeline
+    {
+        return new ServiceRequestAssignmentTimeline($this);
+    }
+
+    public static function getTimelineData(Model $forModel): Collection
+    {
+        return $forModel->assignments()->get();
+    }
+
+    public function getSubscribable(): ?Subscribable
+    {
+        /** @var Subscribable|Model $respondent */
+        $respondent = $this->serviceRequest->respondent;
+
+        return $respondent instanceof Subscribable
+            ? $respondent
+            : null;
+    }
+}

--- a/app-modules/service-management/src/Models/ServiceRequestAssignment.php
+++ b/app-modules/service-management/src/Models/ServiceRequestAssignment.php
@@ -63,6 +63,7 @@ class ServiceRequestAssignment extends BaseModel implements Auditable, CanTrigge
 
     protected $fillable = [
         'user_id',
+        'assigned_by_id',
         'assigned_at',
         'status',
     ];
@@ -70,6 +71,11 @@ class ServiceRequestAssignment extends BaseModel implements Auditable, CanTrigge
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function assignedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'assigned_by_id');
     }
 
     public function serviceRequest(): BelongsTo

--- a/app-modules/service-management/src/Models/ServiceRequestAssignment.php
+++ b/app-modules/service-management/src/Models/ServiceRequestAssignment.php
@@ -41,7 +41,6 @@ use App\Models\BaseModel;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Model;
 use OwenIt\Auditing\Contracts\Auditable;
-use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Assist\Notifications\Models\Contracts\Subscribable;
 use Assist\Timeline\Models\Contracts\ProvidesATimeline;
@@ -55,7 +54,6 @@ use Assist\Notifications\Models\Contracts\CanTriggerAutoSubscription;
  */
 class ServiceRequestAssignment extends BaseModel implements Auditable, CanTriggerAutoSubscription, ProvidesATimeline
 {
-    use HasUuids;
     use AuditableTrait;
 
     protected $casts = [

--- a/app-modules/service-management/src/Policies/ServiceRequestAssignmentPolicy.php
+++ b/app-modules/service-management/src/Policies/ServiceRequestAssignmentPolicy.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace Assist\ServiceManagement\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+use Assist\ServiceManagement\Models\ServiceRequestAssignment;
+
+class ServiceRequestAssignmentPolicy
+{
+    public function viewAny(User $user): Response
+    {
+        return $user->canOrElse(
+            abilities: 'service_request_assignment.view-any',
+            denyResponse: 'You do not have permissions to view service request assignments.'
+        );
+    }
+
+    public function view(User $user, ServiceRequestAssignment $serviceRequestAssignment): Response
+    {
+        return $user->canOrElse(
+            abilities: ['service_request_assignment.*.view', "service_request_assignment.{$serviceRequestAssignment->id}.view"],
+            denyResponse: 'You do not have permissions to view this service request assignment.'
+        );
+    }
+
+    public function create(User $user): Response
+    {
+        return $user->canOrElse(
+            abilities: 'service_request_assignment.create',
+            denyResponse: 'You do not have permissions to create service request assignments.'
+        );
+    }
+
+    public function update(User $user, ServiceRequestAssignment $serviceRequestAssignment): Response
+    {
+        return $user->canOrElse(
+            abilities: ['service_request_assignment.*.update', "service_request_assignment.{$serviceRequestAssignment->id}.update"],
+            denyResponse: 'You do not have permissions to update this service request assignment.'
+        );
+    }
+
+    public function delete(User $user, ServiceRequestAssignment $serviceRequestAssignment): Response
+    {
+        return $user->canOrElse(
+            abilities: ['service_request_assignment.*.delete', "service_request_assignment.{$serviceRequestAssignment->id}.delete"],
+            denyResponse: 'You do not have permissions to delete this service request assignment.'
+        );
+    }
+
+    public function restore(User $user, ServiceRequestAssignment $serviceRequestAssignment): Response
+    {
+        return $user->canOrElse(
+            abilities: ['service_request_assignment.*.restore', "service_request_assignment.{$serviceRequestAssignment->id}.restore"],
+            denyResponse: 'You do not have permissions to restore this service request assignment.'
+        );
+    }
+
+    public function forceDelete(User $user, ServiceRequestAssignment $serviceRequestAssignment): Response
+    {
+        return $user->canOrElse(
+            abilities: ['service_request_assignment.*.force-delete', "service_request_assignment.{$serviceRequestAssignment->id}.force-delete"],
+            denyResponse: 'You do not have permissions to force delete this service request assignment.'
+        );
+    }
+}

--- a/app-modules/service-management/src/Providers/ServiceManagementServiceProvider.php
+++ b/app-modules/service-management/src/Providers/ServiceManagementServiceProvider.php
@@ -47,8 +47,10 @@ use Assist\Authorization\AuthorizationPermissionRegistry;
 use Assist\ServiceManagement\Models\ServiceRequestStatus;
 use Assist\ServiceManagement\Models\ServiceRequestUpdate;
 use Assist\ServiceManagement\Models\ServiceRequestPriority;
+use Assist\ServiceManagement\Models\ServiceRequestAssignment;
 use Assist\ServiceManagement\Observers\ServiceRequestObserver;
 use Assist\ServiceManagement\Observers\ServiceRequestUpdateObserver;
+use Assist\ServiceManagement\Observers\ServiceRequestAssignmentObserver;
 use Assist\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceRequestNumberGenerator;
 use Assist\ServiceManagement\Services\ServiceRequestNumber\SqidPlusSixServiceRequestNumberGenerator;
 
@@ -65,6 +67,7 @@ class ServiceManagementServiceProvider extends ServiceProvider
     {
         Relation::morphMap([
             'service_request' => ServiceRequest::class,
+            'service_request_assignment' => ServiceRequestAssignment::class,
             'service_request_priority' => ServiceRequestPriority::class,
             'service_request_status' => ServiceRequestStatus::class,
             'service_request_type' => ServiceRequestType::class,
@@ -79,6 +82,7 @@ class ServiceManagementServiceProvider extends ServiceProvider
     {
         ServiceRequest::observe(ServiceRequestObserver::class);
         ServiceRequestUpdate::observe(ServiceRequestUpdateObserver::class);
+        ServiceRequestAssignment::observe(ServiceRequestAssignmentObserver::class);
     }
 
     protected function registerRolesAndPermissions()

--- a/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
+++ b/app-modules/service-management/tests/ServiceRequest/ListServiceRequestsTest.php
@@ -41,10 +41,17 @@ use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 use Assist\ServiceManagement\Models\ServiceRequest;
+use Assist\ServiceManagement\Models\ServiceRequestAssignment;
 use Assist\ServiceManagement\Filament\Resources\ServiceRequestResource;
 
 test('The correct details are displayed on the ListServiceRequests page', function () {
     $serviceRequests = ServiceRequest::factory()
+        ->has(
+            factory: ServiceRequestAssignment::factory()
+                ->count(1)
+                ->active(),
+            relationship: 'assignments'
+        )
         ->count(10)
         ->create();
 
@@ -84,8 +91,8 @@ test('The correct details are displayed on the ListServiceRequests page', functi
                 $serviceRequest
             )
             ->assertTableColumnStateSet(
-                'assignedTo.name',
-                $serviceRequest->assignedTo->name,
+                'assignedTo.user.name',
+                $serviceRequest->assignedTo->user->name,
                 $serviceRequest
             )
     );

--- a/app-modules/timeline/src/Timelines/ServiceRequestAssignmentTimeline.php
+++ b/app-modules/timeline/src/Timelines/ServiceRequestAssignmentTimeline.php
@@ -34,36 +34,42 @@
 </COPYRIGHT>
 */
 
-namespace Assist\ServiceManagement\Database\Factories;
+namespace Assist\Timeline\Timelines;
 
-use App\Models\User;
-use Assist\Division\Models\Division;
-use Assist\AssistDataModel\Models\Student;
-use Assist\ServiceManagement\Models\ServiceRequest;
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Assist\ServiceManagement\Models\ServiceRequestType;
-use Assist\ServiceManagement\Models\ServiceRequestStatus;
-use Assist\ServiceManagement\Models\ServiceRequestPriority;
+use Filament\Actions\ViewAction;
+use Assist\Timeline\Models\CustomTimeline;
+use Assist\ServiceManagement\Models\ServiceRequestAssignment;
+use Assist\ServiceManagement\Filament\Resources\ServiceRequestUpdateResource\Components\ServiceRequestAssignmentViewAction;
 
-/**
- * @extends Factory<ServiceRequest>
- */
-class ServiceRequestFactory extends Factory
+// TODO Decide where these belong - might want to keep these in the context of the original module
+class ServiceRequestAssignmentTimeline extends CustomTimeline
 {
-    public function definition(): array
+    public function __construct(
+        public ServiceRequestAssignment $serviceRequestAssignment
+    ) {}
+
+    public function icon(): string
     {
-        return [
-            'respondent_id' => Student::inRandomOrder()->first()->sisid ?? Student::factory(),
-            'respondent_type' => function (array $attributes) {
-                return Student::find($attributes['respondent_id'])->getMorphClass();
-            },
-            'close_details' => $this->faker->sentence(),
-            'res_details' => $this->faker->sentence(),
-            'division_id' => Division::inRandomOrder()->first()?->id ?? Division::factory(),
-            'status_id' => ServiceRequestStatus::inRandomOrder()->first() ?? ServiceRequestStatus::factory(),
-            'type_id' => ServiceRequestType::inRandomOrder()->first() ?? ServiceRequestType::factory(),
-            'priority_id' => ServiceRequestPriority::inRandomOrder()->first() ?? ServiceRequestPriority::factory(),
-            'created_by_id' => User::factory(),
-        ];
+        return 'heroicon-o-arrows-right-left';
+    }
+
+    public function sortableBy(): string
+    {
+        return $this->serviceRequestAssignment->assigned_at;
+    }
+
+    public function providesCustomView(): bool
+    {
+        return true;
+    }
+
+    public function renderCustomView(): string
+    {
+        return 'service-management::service-request-assignment-timeline-item';
+    }
+
+    public function modalViewAction(): ViewAction
+    {
+        return ServiceRequestAssignmentViewAction::make()->record($this->serviceRequestAssignment);
     }
 }

--- a/app/Filament/Widgets/MyServiceRequests.php
+++ b/app/Filament/Widgets/MyServiceRequests.php
@@ -65,7 +65,7 @@ class MyServiceRequests extends BaseWidget
                 auth()->user()
                     ->serviceRequests()
                     ->getQuery()
-                    ->latest()
+                    ->latest('service_requests.created_at')
                     ->limit(5)
             )
             ->columns([
@@ -102,10 +102,10 @@ class MyServiceRequests extends BaseWidget
             ])
             ->actions([
                 ViewAction::make()
-                    ->url(fn (ServiceRequest $record): string => ServiceRequestResource::getUrl(name: 'view', parameters: ['record' => $record])),
+                    ->url(fn (ServiceRequest $record): string => ServiceRequestResource::getUrl(name: 'view', parameters: ['record' => $record->service_request_id])),
             ])
             ->recordUrl(
-                fn (ServiceRequest $record): string => ServiceRequestResource::getUrl(name: 'view', parameters: ['record' => $record]),
+                fn (ServiceRequest $record): string => ServiceRequestResource::getUrl(name: 'view', parameters: ['record' => $record->service_request_id]),
             )
             ->paginated([5]);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -64,7 +64,6 @@ use Assist\MeetingCenter\Models\CalendarEvent;
 use Assist\Assistant\Models\AssistantChatFolder;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Assist\ServiceManagement\Models\ServiceRequest;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Assist\Assistant\Models\AssistantChatMessageLog;
@@ -80,7 +79,6 @@ use Assist\Engagement\Models\Concerns\HasManyEngagements;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Assist\Authorization\Models\Pivots\RoleGroupUserPivot;
-use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Assist\Authorization\Models\Concerns\HasRolesWithPivot;
 use Assist\Authorization\Models\Concerns\DefinesPermissions;
 use Assist\Audit\Models\Concerns\Auditable as AuditableTrait;
@@ -272,16 +270,9 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
             ->where('status', ServiceRequestAssignmentStatus::Active);
     }
 
-    public function serviceRequests(): HasManyThrough
+    public function serviceRequests(): HasManyDeep
     {
-        return $this->hasManyThrough(
-            ServiceRequest::class,
-            ServiceRequestAssignment::class,
-            'user_id',
-            'id',
-            'id',
-            'service_request_id'
-        )->where('status', ServiceRequestAssignmentStatus::Active);
+        return $this->hasManyDeepFromRelations($this->serviceRequestAssignments(), (new ServiceRequestAssignment())->serviceRequest());
     }
 
     public function getIsAdminAttribute()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -80,10 +80,13 @@ use Assist\Engagement\Models\Concerns\HasManyEngagements;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Assist\Authorization\Models\Pivots\RoleGroupUserPivot;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Assist\Authorization\Models\Concerns\HasRolesWithPivot;
 use Assist\Authorization\Models\Concerns\DefinesPermissions;
 use Assist\Audit\Models\Concerns\Auditable as AuditableTrait;
+use Assist\ServiceManagement\Models\ServiceRequestAssignment;
 use Assist\Engagement\Models\Concerns\HasManyEngagementBatches;
+use Assist\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
 
 /**
  * @mixin IdeHelperUser
@@ -263,12 +266,22 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
         return $this->hasManyDeepFromRelations($this->roles(), (new Role())->permissions());
     }
 
-    public function serviceRequests(): HasMany
+    public function serviceRequestAssignments(): HasMany
     {
-        return $this->hasMany(
-            related: ServiceRequest::class,
-            foreignKey: 'assigned_to_id',
-        );
+        return $this->hasMany(ServiceRequestAssignment::class)
+            ->where('status', ServiceRequestAssignmentStatus::Active);
+    }
+
+    public function serviceRequests(): HasManyThrough
+    {
+        return $this->hasManyThrough(
+            ServiceRequest::class,
+            ServiceRequestAssignment::class,
+            'user_id',
+            'id',
+            'id',
+            'service_request_id'
+        )->where('status', ServiceRequestAssignmentStatus::Active);
     }
 
     public function getIsAdminAttribute()


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

https://engage.canyongbs.com/company/personal/user/15/tasks/task/view/945/

### Technical Description

This PR adds the ability to track Service Request assignment/reassignment history over time. In order to facilitate this, the ServiceRequestAssignment model has been introduced to serve as an intermediary between the service request itself and the assigned user. Though this convention is currently only set up to allow for one `active` assignment at any given point in time, the architecture can support a world in which multiple users are assigned to a service request at the same time.

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.