### PR TITLE
[ADVISING-1077]: Rename Response with Error Details in Delivery Information for Text Messages 

### DIFF
--- a/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/assist-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -95,9 +95,11 @@ class EngagementsRelationManager extends RelationManager
                             })
                             ->label('Status'),
                         TextEntry::make('deliverable.delivered_at')
-                            ->label('Delivered At'),
+                            ->label('Delivered At')
+                            ->hidden(fn (Engagement $engagement): bool => is_null($engagement->deliverable->delivered_at)),
                         TextEntry::make('deliverable.delivery_response')
-                            ->label('Response'),
+                            ->label('Error Details')
+                            ->hidden(fn (Engagement $engagement): bool => is_null($engagement->deliverable->delivery_response)),
                     ])
                     ->columns(2),
             ]);

--- a/app-modules/engagement/database/factories/EngagementDeliverableFactory.php
+++ b/app-modules/engagement/database/factories/EngagementDeliverableFactory.php
@@ -94,7 +94,7 @@ class EngagementDeliverableFactory extends Factory
         return $this->state([
             'delivery_status' => EngagementDeliveryStatus::Failed,
             'delivered_at' => null,
-            'delivery_response' => 'The deliverable was not successfully delivered.',
+            'delivery_response' => 'Something went wrong when trying to deliver the engagement.',
         ]);
     }
 

--- a/app-modules/engagement/src/Filament/Concerns/EngagementInfolist.php
+++ b/app-modules/engagement/src/Filament/Concerns/EngagementInfolist.php
@@ -79,9 +79,11 @@ trait EngagementInfolist
                         })
                         ->label('Status'),
                     TextEntry::make('deliverable.delivered_at')
-                        ->label('Delivered At'),
+                        ->label('Delivered At')
+                        ->hidden(fn (Engagement $engagement): bool => is_null($engagement->deliverable->delivered_at)),
                     TextEntry::make('deliverable.delivery_response')
-                        ->label('Response'),
+                        ->label('Error Details')
+                        ->hidden(fn (Engagement $engagement): bool => is_null($engagement->deliverable->delivery_response)),
                 ])
                 ->columns(2),
         ];

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementsRelationManager.php
@@ -95,9 +95,11 @@ class EngagementsRelationManager extends RelationManager
                             })
                             ->label('Status'),
                         TextEntry::make('deliverable.delivered_at')
-                            ->label('Delivered At'),
+                            ->label('Delivered At')
+                            ->hidden(fn (Engagement $engagement): bool => is_null($engagement->deliverable->delivered_at)),
                         TextEntry::make('deliverable.delivery_response')
-                            ->label('Response'),
+                            ->label('Error Details')
+                            ->hidden(fn (Engagement $engagement): bool => is_null($engagement->deliverable->delivery_response)),
                     ])
                     ->columns(2),
             ]);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/1077/

### Technical Description

This PR updates the display/text of Engagement Deliverable response content. It also hides the "Delivered At" field if the deliverable was not delivered.

### Types of changes

- [x] Content or styling update (Changes which don't affect functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.