### PR TITLE
[ADVISING-1067]: Introduce My Team filter for selecting email or text message templates

### DIFF
--- a/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
@@ -115,6 +115,10 @@ class BulkEngagementAction
                                                     $get('onlyMyTemplates'),
                                                     fn (Builder $query) => $query->whereBelongsTo(auth()->user())
                                                 )
+                                                ->when(
+                                                    $get('onlyMyTeamTemplates'),
+                                                    fn (Builder $query) => $query->whereIn('user_id', auth()->user()->teams->users->pluck('id'))
+                                                )
                                                 ->where(new Expression('lower(name)'), 'like', "%{$search}%")
                                                 ->orderBy('name')
                                                 ->limit(50)
@@ -123,6 +127,10 @@ class BulkEngagementAction
                                         }),
                                     Checkbox::make('onlyMyTemplates')
                                         ->label('Only show my templates')
+                                        ->live()
+                                        ->afterStateUpdated(fn (Set $set) => $set('emailTemplate', null)),
+                                    Checkbox::make('onlyMyTeamTemplates')
+                                        ->label("Only show my team's templates")
                                         ->live()
                                         ->afterStateUpdated(fn (Set $set) => $set('emailTemplate', null)),
                                 ])

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
@@ -115,6 +115,10 @@ class CreateEngagement extends CreateRecord
                                                     $get('onlyMyTemplates'),
                                                     fn (Builder $query) => $query->whereBelongsTo(auth()->user())
                                                 )
+                                                ->when(
+                                                    $get('onlyMyTeamTemplates'),
+                                                    fn (Builder $query) => $query->whereIn('user_id', auth()->user()->teams->users->pluck('id'))
+                                                )
                                                 ->where(new Expression('lower(name)'), 'like', "%{$search}%")
                                                 ->orderBy('name')
                                                 ->limit(50)
@@ -123,6 +127,10 @@ class CreateEngagement extends CreateRecord
                                         }),
                                     Checkbox::make('onlyMyTemplates')
                                         ->label('Only show my templates')
+                                        ->live()
+                                        ->afterStateUpdated(fn (Set $set) => $set('emailTemplate', null)),
+                                    Checkbox::make('onlyMyTeamTemplates')
+                                        ->label("Only show my team's templates")
                                         ->live()
                                         ->afterStateUpdated(fn (Set $set) => $set('emailTemplate', null)),
                                 ])

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
@@ -105,6 +105,10 @@ class EditEngagement extends EditRecord
                                             $get('onlyMyTemplates'),
                                             fn (Builder $query) => $query->whereBelongsTo(auth()->user())
                                         )
+                                        ->when(
+                                            $get('onlyMyTeamTemplates'),
+                                            fn (Builder $query) => $query->whereIn('user_id', auth()->user()->teams->users->pluck('id'))
+                                        )
                                         ->where(new Expression('lower(name)'), 'like', "%{$search}%")
                                         ->orderBy('name')
                                         ->limit(50)
@@ -113,6 +117,10 @@ class EditEngagement extends EditRecord
                                 }),
                             Checkbox::make('onlyMyTemplates')
                                 ->label('Only show my templates')
+                                ->live()
+                                ->afterStateUpdated(fn (Set $set) => $set('emailTemplate', null)),
+                            Checkbox::make('onlyMyTeamTemplates')
+                                ->label("Only show my team's templates")
                                 ->live()
                                 ->afterStateUpdated(fn (Set $set) => $set('emailTemplate', null)),
                         ])

--- a/app-modules/team/database/factories/TeamFactory.php
+++ b/app-modules/team/database/factories/TeamFactory.php
@@ -45,13 +45,10 @@ use Illuminate\Database\Eloquent\Factories\Factory;
  */
 class TeamFactory extends Factory
 {
-    /**
-     * @return array<string, mixed>
-     */
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->words(asText: true),
+            'name' => fake()->unique()->catchPhrase(),
             'description' => fake()->sentence(),
         ];
     }

--- a/database/migrations/2023_03_06_000004_create_users_table.php
+++ b/database/migrations/2023_03_06_000004_create_users_table.php
@@ -63,7 +63,7 @@ class CreateUsersTable extends Migration
             $table->string('public_profile_slug')->nullable()->unique();
             $table->boolean('office_hours_are_enabled')->default(false);
             $table->boolean('appointments_are_restricted_to_existing_students')->default(false);
-            $table->json('office_hours')->nullable();
+            $table->jsonb('office_hours')->nullable();
             $table->boolean('out_of_office_is_enabled')->default(false);
             $table->datetime('out_of_office_starts_at')->nullable();
             $table->datetime('out_of_office_ends_at')->nullable();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/1067/

### Technical Description

This PR adds a "My Team" checkbox filter to the email template selection modal for engagements. It also resolves [an issue](https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/1091/) with attaching users because of a newly introduced `json` column to the users table. See the following for reference: https://github.com/filamentphp/filament/issues/8698, https://www.postgresql.org/docs/current/datatype-json.html

We may want to use `jsonb` as the column type in other situations as well, to avoid this issue elsewhere in the future.

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.