### PR TITLE
[ADVISING-1063]: Return to list view after create of Text Message and Email template

### DIFF
--- a/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/CreateEmailTemplate.php
+++ b/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/CreateEmailTemplate.php
@@ -37,6 +37,7 @@
 namespace Assist\Engagement\Filament\Resources\EmailTemplateResource\Pages;
 
 use Filament\Forms\Form;
+use Filament\Resources\Resource;
 use FilamentTiptapEditor\TiptapEditor;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -79,5 +80,13 @@ class CreateEmailTemplate extends CreateRecord
                     ->extraInputAttributes(['style' => 'min-height: 12rem;'])
                     ->required(),
             ]);
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        /** @var class-string<Resource> $resource */
+        $resource = $this->getResource();
+
+        return $resource::getUrl();
     }
 }

--- a/app-modules/engagement/src/Filament/Resources/SmsTemplateResource/Pages/CreateSmsTemplate.php
+++ b/app-modules/engagement/src/Filament/Resources/SmsTemplateResource/Pages/CreateSmsTemplate.php
@@ -37,6 +37,7 @@
 namespace Assist\Engagement\Filament\Resources\SmsTemplateResource\Pages;
 
 use Filament\Forms\Form;
+use Filament\Resources\Resource;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\RichEditor;
@@ -76,5 +77,13 @@ class CreateSmsTemplate extends CreateRecord
                     ->maxLength(320) // https://www.twilio.com/docs/glossary/what-sms-character-limit#:~:text=Twilio's%20platform%20supports%20long%20messages,best%20deliverability%20and%20user%20experience.
                     ->required(),
             ]);
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        /** @var class-string<Resource> $resource */
+        $resource = $this->getResource();
+
+        return $resource::getUrl();
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/1063/

### Technical Description

Changes the Email Template and SMS Template redirects after create to bring the User back to the respective index page.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] New feature (non-breaking change which adds functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.