### PR TITLE
[ADVISING-1071]: Add Rich Text Capabilities to Email Templates

### DIFF
--- a/app-modules/division/src/Filament/Resources/DivisionResource/Pages/CreateDivision.php
+++ b/app-modules/division/src/Filament/Resources/DivisionResource/Pages/CreateDivision.php
@@ -62,9 +62,15 @@ class CreateDivision extends CreateRecord
                 Textarea::make('description')
                     ->string(),
                 TiptapEditor::make('header')
+                    ->disk('s3-public')
+                    ->visibility('public')
+                    ->directory('editor-images/division-header')
                     ->string()
                     ->columnSpanFull(),
                 TiptapEditor::make('footer')
+                    ->disk('s3-public')
+                    ->visibility('public')
+                    ->directory('editor-images/division-footer')
                     ->string()
                     ->columnSpanFull(),
             ]);

--- a/app-modules/division/src/Filament/Resources/DivisionResource/Pages/EditDivision.php
+++ b/app-modules/division/src/Filament/Resources/DivisionResource/Pages/EditDivision.php
@@ -67,9 +67,15 @@ class EditDivision extends EditRecord
                     ->string()
                     ->columnSpanFull(),
                 TiptapEditor::make('header')
+                    ->disk('s3-public')
+                    ->visibility('public')
+                    ->directory('editor-images/division-header')
                     ->string()
                     ->columnSpanFull(),
                 TiptapEditor::make('footer')
+                    ->disk('s3-public')
+                    ->visibility('public')
+                    ->directory('editor-images/division-footer')
                     ->string()
                     ->columnSpanFull(),
                 Select::make('notification_setting_id')

--- a/app-modules/engagement/src/Actions/GenerateEmailMarkdownContent.php
+++ b/app-modules/engagement/src/Actions/GenerateEmailMarkdownContent.php
@@ -46,6 +46,7 @@ class GenerateEmailMarkdownContent
                 'doc' => $this($component['content'], $mergeData),
                 'heading' => PHP_EOL . PHP_EOL . str_repeat('#', $component['attrs']['level'] ?? 1) . ' ' . $this($component['content'] ?? [], $mergeData),
                 'horizontalRule' => PHP_EOL . PHP_EOL . '---',
+                'image' => ' ' . '![' . ($component['attrs']['alt'] ?? '') . '](' . ($component['attrs']['src'] ?? '') . ')',
                 'listItem' => PHP_EOL . '- ' . $this($component['content'] ?? [], $mergeData),
                 'mergeTag' => ' ' . $this->text($mergeData[$component['attrs']['id'] ?? null] ?? '', $component),
                 'orderedList' => PHP_EOL . PHP_EOL . $this->orderedList($component, $mergeData),

--- a/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
@@ -85,6 +85,9 @@ class BulkEngagementAction
                             ->hidden(fn (Get $get): bool => $get('delivery_method') === EngagementDeliveryMethod::Sms->value)
                             ->columnSpanFull(),
                         TiptapEditor::make('body')
+                            ->disk('s3-public')
+                            ->visibility('public')
+                            ->directory('editor-images/engagements')
                             ->label('Body')
                             ->mergeTags([
                                 'student full name',

--- a/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/CreateEmailTemplate.php
+++ b/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/CreateEmailTemplate.php
@@ -70,6 +70,9 @@ class CreateEmailTemplate extends CreateRecord
                 Textarea::make('description')
                     ->string(),
                 TiptapEditor::make('content')
+                    ->disk('s3-public')
+                    ->visibility('public')
+                    ->directory('editor-images/email-templates')
                     ->mergeTags([
                         'student full name',
                         'student email',

--- a/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/EditEmailTemplate.php
+++ b/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/EditEmailTemplate.php
@@ -70,6 +70,9 @@ class EditEmailTemplate extends EditRecord
                 Textarea::make('description')
                     ->string(),
                 TiptapEditor::make('content')
+                    ->disk('s3-public')
+                    ->visibility('public')
+                    ->directory('editor-images/email-templates')
                     ->mergeTags([
                         'student full name',
                         'student email',

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
@@ -85,6 +85,9 @@ class CreateEngagement extends CreateRecord
                             ->hidden(fn (Get $get): bool => $get('delivery_method') === EngagementDeliveryMethod::Sms->value)
                             ->columnSpanFull(),
                         TiptapEditor::make('body')
+                            ->disk('s3-public')
+                            ->visibility('public')
+                            ->directory('editor-images/engagements')
                             ->label('Body')
                             ->mergeTags([
                                 'student full name',

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
@@ -78,6 +78,9 @@ class EditEngagement extends EditRecord
                     ->columnSpanFull()
                     ->visible(fn (Engagement $record): bool => $record->deliverable->channel === EngagementDeliveryMethod::Email),
                 TiptapEditor::make('body')
+                    ->disk('s3-public')
+                    ->visibility('public')
+                    ->directory('editor-images/engagements')
                     ->label('Body')
                     ->mergeTags([
                         'student full name',

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/CreateKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/CreateKnowledgeBaseItem.php
@@ -95,12 +95,14 @@ class CreateKnowledgeBaseItem extends CreateRecord
                     ->preload()
                     ->exists((new Division())->getTable(), (new Division())->getKeyName()),
                 TiptapEditor::make('solution')
+                    ->directory('kb-images')
                     ->label('Solution')
                     ->translateLabel()
                     ->columnSpanFull()
                     ->extraInputAttributes(['style' => 'min-height: 12rem;'])
                     ->string(),
                 TiptapEditor::make('notes')
+                    ->directory('kb-images')
                     ->label('Notes')
                     ->translateLabel()
                     ->columnSpanFull()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/EditKnowledgeBaseItem.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseItemResource/Pages/EditKnowledgeBaseItem.php
@@ -96,12 +96,14 @@ class EditKnowledgeBaseItem extends EditRecord
                     ->preload()
                     ->exists((new Division())->getTable(), (new Division())->getKeyName()),
                 TiptapEditor::make('solution')
+                    ->directory('kb-images')
                     ->label('Solution')
                     ->translateLabel()
                     ->columnSpanFull()
                     ->extraInputAttributes(['style' => 'min-height: 12rem;'])
                     ->string(),
                 TiptapEditor::make('notes')
+                    ->directory('kb-images')
                     ->label('Notes')
                     ->translateLabel()
                     ->columnSpanFull()

--- a/config/filament-tiptap-editor.php
+++ b/config/filament-tiptap-editor.php
@@ -73,7 +73,7 @@ return [
         ],
         'simple' => ['heading', 'hr', 'bullet-list', 'ordered-list', 'checked-list', '|', 'bold', 'italic', 'lead', 'small', '|', 'link', 'media'],
         'minimal' => ['bold', 'italic', 'link', 'bullet-list', 'ordered-list'],
-        'email' => ['bold', 'italic', 'small', 'link', '|', 'heading', 'bullet-list', 'ordered-list', 'hr'],
+        'email' => ['bold', 'italic', 'small', 'link', '|', 'heading', 'bullet-list', 'ordered-list', 'hr', 'media'],
         'sms' => [],
     ],
 
@@ -112,13 +112,14 @@ return [
     */
     'accepted_file_types' => ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml', 'application/pdf'],
     'disk' => 's3',
-    'directory' => 'kb-images',
+    'directory' => 'editor-images',
     'visibility' => 'private',
     'preserve_file_names' => false,
     'max_file_size' => 2042,
     'image_crop_aspect_ratio' => null,
     'image_resize_target_width' => null,
     'image_resize_target_height' => null,
+    'use_relative_paths' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -87,6 +87,19 @@ return [
             'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
             'throw' => false,
         ],
+
+        's3-public' => [
+            'driver' => 's3',
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'region' => env('AWS_DEFAULT_REGION'),
+            'bucket' => env('AWS_BUCKET'),
+            'url' => env('AWS_URL'),
+            'endpoint' => env('AWS_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw' => false,
+            'root' => 'PUBLIC',
+        ],
     ],
 
     /*

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -121,7 +121,32 @@ source .env ; gunzip < resources/sql/assist-adm-data.gz | PGPASSWORD=$SIS_DB_PAS
 ### Minio (S3 Compatible Storage)
 Minio is a S3 compatible storage solution that is used for storing files locally.
 
-When first setting up you will need to create a bucket. This can be done by going to `localhost:8900` in your browser and logging in with `sail` as the username and `password` as the password. Once logged in, you can create a bucket and set access to `public`.
+When first setting up you will need to create a bucket. This can be done by going to `localhost:8900` in your browser and logging in with `sail` as the username and `password` as the password. Once logged in, you can create a bucket.
+
+By default, the application is set up in the `.env.example` to reference a bucket named `local`. Create a bucket with this name in Minio. Then change its access policy to "Custom" with the following policy configuration:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowPublicRead",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": [
+                    "*"
+                ]
+            },
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::local/PUBLIC/*"
+            ]
+        }
+    ]
+}
+```
 
 In order to facilitate proper file upload with Livewire you will need to set the following in your local etc/hosts file:
 ```


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://engage.canyongbs.com/workgroups/group/3/tasks/task/view/1071/

### Technical Description

Adds the ability to add and render images in Email Templates and email content.

In order to facilitate access to the media, any media uploaded is now stored in a public path in our storage. Docs have been updated on what to change locally within Minio to replicate this locally.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] New feature (non-breaking change which adds functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/assistbycanyongbs/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.