### PR TITLE
Add documentation for GraphQL Union field bug

### DIFF
--- a/spectaql.yml
+++ b/spectaql.yml
@@ -34,6 +34,14 @@ info:
   x-introItems:
     - title: Authorization
       description: Add additional details for authentication. Supports `markdown`, more sections can be added.
+    - title: Querying the same field for different union types
+      description: |
+        When querying a field that returns a union type, you may get back an error "conflict because they return conflicting types". For example, if you query for interactable on a union type of `Student | Prospect` and request `full_name` you may get back this error.
+        
+        This is due to the fields having different type definitions. In order to get around this you will need to define an alias for the field you are querying.
+        
+        For example, you can query for `student_full_name: full_name` and `prospect_full_name: full_name` to get back the data you are looking for.
+
 
 servers:
   - url: ${APP_URL}/graphql


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-115

### Technical Description

There is no fix for this issue. It comes from our usage of Union types that share the same field names but no the same type definition for that field. There is currently no way around this, and it is much discussed in the GraphQL community. https://github.com/graphql/graphql-js/issues/53

Technically, the specification is not hard on this limitation being required. So, I have opened an issue in the underlying PHP GraphQL package to see if it can be fixed. https://github.com/webonyx/graphql-php/issues/1500

But I have added some documentation for now for the workaround.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Content or styling update (Changes which don't affect functionality)
- [ ] DevOps
- [x] Documentation

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [ ] Yes, please specify
- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.
