### PR TITLE
[ADVAPP-106]: Improve UI/UX at 1024x768 to match design for 800x600 for Office Hours, Out of Office, and Working Hours to resolve field display issues.

### DIFF
--- a/app/Filament/Pages/EditProfile.php
+++ b/app/Filament/Pages/EditProfile.php
@@ -278,16 +278,26 @@ class EditProfile extends Page
                 Section::make('Out of Office')
                     ->aside()
                     ->schema([
-                        Grid::make(3)
+                        Grid::make()
+                            ->columns([
+                                'sm' => 1,
+                                'md' => 1,
+                                'lg' => 1,
+                                'xl' => 2,
+                                '2xl' => 2,
+                            ])
                             ->schema([
                                 Toggle::make('out_of_office_is_enabled')
+                                    ->columnSpanFull()
                                     ->label('Enable Out of Office')
                                     ->live(),
                                 DateTimePicker::make('out_of_office_starts_at')
+                                    ->columnSpan(1)
                                     ->label('Start')
                                     ->required()
                                     ->visible(fn (Get $get) => $get('out_of_office_is_enabled')),
                                 DateTimePicker::make('out_of_office_ends_at')
+                                    ->columnSpan(1)
                                     ->label('End')
                                     ->required()
                                     ->visible(fn (Get $get) => $get('out_of_office_is_enabled')),
@@ -526,7 +536,14 @@ class EditProfile extends Page
             'friday',
             'saturday',
         ])->map(
-            fn ($day) => Grid::make(3)
+            fn ($day) => Grid::make()
+                ->columns([
+                    'sm' => 1,
+                    'md' => 1,
+                    'lg' => 1,
+                    'xl' => 3,
+                    '2xl' => 3,
+                ])
                 ->schema([
                     Toggle::make("{$key}.{$day}.enabled")
                         ->label(str($day)->ucfirst())


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

https://canyongbs.atlassian.net/browse/ADVAPP-106

### Technical Description

This PR resolves responsive display issues for office hours, out of office, and working hours so that there is never an overlap between inputs.

### Types of changes

- [x] Content or styling update (Changes which don't affect functionality)

### Screenshots (if appropriate)


![Screenshot 2023-12-26 at 12 59 38 PM](https://github.com/canyongbs/advisingapp/assets/10821263/653b48bc-6221-4e5e-84ed-86c8fa4175cd)

![Screenshot 2023-12-26 at 12 59 47 PM](https://github.com/canyongbs/advisingapp/assets/10821263/64fd43a9-7b9c-48b1-8c2b-f41c9d4cea64)


### Any deployment steps required?

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.
