### PR TITLE
[ADVAPP-199] & [ADVAPP-200]: Retention / Recuitment CRM navigation group and dashboard should not be visible when unlicensed.

### DIFF
--- a/app-modules/prospect/src/Filament/Pages/RecruitmentCrmDashboard.php
+++ b/app-modules/prospect/src/Filament/Pages/RecruitmentCrmDashboard.php
@@ -36,7 +36,9 @@
 
 namespace AdvisingApp\Prospect\Filament\Pages;
 
+use App\Models\User;
 use Filament\Pages\Page;
+use AdvisingApp\Prospect\Models\Prospect;
 
 class RecruitmentCrmDashboard extends Page
 {
@@ -49,4 +51,20 @@ class RecruitmentCrmDashboard extends Page
     protected static ?int $navigationSort = 10;
 
     protected static ?string $title = 'Dashboard';
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        return $user->hasLicense(Prospect::getLicenseType());
+    }
+
+    public function mount(): void
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        abort_unless($user->hasLicense(Prospect::getLicenseType()), 403);
+    }
 }

--- a/app-modules/student-data-model/src/Filament/Pages/RetentionCrmDashboard.php
+++ b/app-modules/student-data-model/src/Filament/Pages/RetentionCrmDashboard.php
@@ -36,7 +36,9 @@
 
 namespace AdvisingApp\StudentDataModel\Filament\Pages;
 
+use App\Models\User;
 use Filament\Pages\Page;
+use AdvisingApp\StudentDataModel\Models\Student;
 
 class RetentionCrmDashboard extends Page
 {
@@ -49,4 +51,20 @@ class RetentionCrmDashboard extends Page
     protected static ?int $navigationSort = 10;
 
     protected static ?string $title = 'Dashboard';
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        return $user->hasLicense(Student::getLicenseType());
+    }
+
+    public function mount(): void
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        abort_unless($user->hasLicense(Student::getLicenseType()), 403);
+    }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-199
- https://canyongbs.atlassian.net/browse/ADVAPP-200

### Technical Description

As per ticket.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Content or styling update (Changes which don't affect functionality)
- [ ] DevOps
- [ ] Documentation

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [ ] Yes, please specify
- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.
