### PR TITLE
[ADVAPP-32] & [ADVAPP-35] Ensure handling of invalid refresh_token for Outlook and Google

### DIFF
--- a/app-modules/engagement/src/Notifications/EngagementEmailNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementEmailNotification.php
@@ -41,6 +41,7 @@ use AdvisingApp\Notification\Models\OutboundDeliverable;
 use AdvisingApp\Notification\Notifications\BaseNotification;
 use AdvisingApp\Notification\Notifications\EmailNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\Notifications\Concerns\EmailChannelTrait;
 
 class EngagementEmailNotification extends BaseNotification implements EmailNotification
@@ -51,7 +52,7 @@ class EngagementEmailNotification extends BaseNotification implements EmailNotif
         public EngagementDeliverable $deliverable
     ) {}
 
-    public function toEmail(object $notifiable): MailMessage
+    public function toEmail(NotifiableInterface $notifiable): MailMessage
     {
         return MailMessage::make()
             ->subject($this->deliverable->engagement->subject)
@@ -60,7 +61,7 @@ class EngagementEmailNotification extends BaseNotification implements EmailNotif
             ->salutation("Regards, {$this->deliverable->engagement->user->name}");
     }
 
-    public function beforeSendHook(object $notifiable, OutboundDeliverable $deliverable, string $channel): void
+    public function beforeSendHook(NotifiableInterface $notifiable, OutboundDeliverable $deliverable, string $channel): void
     {
         $deliverable->update([
             'related_id' => $this->deliverable->id,
@@ -68,7 +69,7 @@ class EngagementEmailNotification extends BaseNotification implements EmailNotif
         ]);
     }
 
-    public function afterSendHook(object $notifiable, OutboundDeliverable $deliverable): void
+    public function afterSendHook(NotifiableInterface $notifiable, OutboundDeliverable $deliverable): void
     {
         $updateData = array_filter([
             'external_reference_id' => $deliverable->external_reference_id,

--- a/app-modules/engagement/src/Notifications/EngagementEmailSentNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementEmailSentNotification.php
@@ -44,6 +44,7 @@ use AdvisingApp\Notification\Notifications\EmailNotification;
 use AdvisingApp\Notification\Notifications\DatabaseNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use Filament\Notifications\Notification as FilamentNotification;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\Notifications\Concerns\EmailChannelTrait;
 use AdvisingApp\Notification\Notifications\Concerns\DatabaseChannelTrait;
 
@@ -56,7 +57,7 @@ class EngagementEmailSentNotification extends BaseNotification implements EmailN
         public Engagement $engagement
     ) {}
 
-    public function toEmail(object $notifiable): MailMessage
+    public function toEmail(NotifiableInterface $notifiable): MailMessage
     {
         return MailMessage::make()
             ->settings($this->resolveNotificationSetting($notifiable))
@@ -64,7 +65,7 @@ class EngagementEmailSentNotification extends BaseNotification implements EmailN
             ->line("Your engagement was successfully delivered to {$this->engagement->recipient->display_name}.");
     }
 
-    public function toDatabase(object $notifiable): array
+    public function toDatabase(NotifiableInterface $notifiable): array
     {
         return FilamentNotification::make()
             ->success()
@@ -73,8 +74,8 @@ class EngagementEmailSentNotification extends BaseNotification implements EmailN
             ->getDatabaseMessage();
     }
 
-    private function resolveNotificationSetting(User $notifiable): ?NotificationSetting
+    private function resolveNotificationSetting(NotifiableInterface $notifiable): ?NotificationSetting
     {
-        return $this->engagement->createdBy->teams()->first()?->division?->notificationSetting?->setting;
+        return $notifiable instanceof User ? $this->engagement->createdBy->teams()->first()?->division?->notificationSetting?->setting : null;
     }
 }

--- a/app-modules/engagement/src/Notifications/EngagementSmsNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementSmsNotification.php
@@ -40,6 +40,7 @@ use AdvisingApp\Engagement\Models\EngagementDeliverable;
 use AdvisingApp\Notification\Models\OutboundDeliverable;
 use AdvisingApp\Notification\Notifications\SmsNotification;
 use AdvisingApp\Notification\Notifications\BaseNotification;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\Notifications\Messages\TwilioMessage;
 use AdvisingApp\Notification\Notifications\Concerns\SmsChannelTrait;
 
@@ -51,13 +52,13 @@ class EngagementSmsNotification extends BaseNotification implements SmsNotificat
         public EngagementDeliverable $deliverable
     ) {}
 
-    public function toSms(object $notifiable): TwilioMessage
+    public function toSms(NotifiableInterface $notifiable): TwilioMessage
     {
         return TwilioMessage::make($notifiable)
             ->content($this->deliverable->engagement->getBody());
     }
 
-    public function beforeSendHook(object $notifiable, OutboundDeliverable $deliverable, string $channel): void
+    public function beforeSendHook(NotifiableInterface $notifiable, OutboundDeliverable $deliverable, string $channel): void
     {
         $deliverable->update([
             'related_id' => $this->deliverable->id,
@@ -65,7 +66,7 @@ class EngagementSmsNotification extends BaseNotification implements SmsNotificat
         ]);
     }
 
-    public function afterSendHook(object $notifiable, OutboundDeliverable $deliverable): void
+    public function afterSendHook(NotifiableInterface $notifiable, OutboundDeliverable $deliverable): void
     {
         $this->deliverable->update([
             'external_reference_id' => $deliverable->external_reference_id,

--- a/app-modules/form/src/Notifications/FormSubmissionRequestSmsNotification.php
+++ b/app-modules/form/src/Notifications/FormSubmissionRequestSmsNotification.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Form\Notifications;
 use AdvisingApp\Form\Models\FormSubmission;
 use AdvisingApp\Notification\Notifications\SmsNotification;
 use AdvisingApp\Notification\Notifications\BaseNotification;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\Notifications\Messages\TwilioMessage;
 use AdvisingApp\Notification\Notifications\Concerns\SmsChannelTrait;
 
@@ -50,7 +51,7 @@ class FormSubmissionRequestSmsNotification extends BaseNotification implements S
         public FormSubmission $submission,
     ) {}
 
-    public function toSms(object $notifiable): TwilioMessage
+    public function toSms(NotifiableInterface $notifiable): TwilioMessage
     {
         $body = "You have been sent a request to complete {$this->submission->submissible->name} by {$this->submission->requester->name}." .
                     (filled($this->submission->request_note) ? " {$this->submission->request_note}" : '') .

--- a/app-modules/integration-aws-ses-event-handling/tests/Unit/SesConfigurationSetTest.php
+++ b/app-modules/integration-aws-ses-event-handling/tests/Unit/SesConfigurationSetTest.php
@@ -42,6 +42,7 @@ use AdvisingApp\Notification\Models\OutboundDeliverable;
 use AdvisingApp\Notification\Notifications\BaseNotification;
 use AdvisingApp\Notification\Notifications\EmailNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\IntegrationAwsSesEventHandling\Settings\SesSettings;
 use AdvisingApp\Notification\Notifications\Concerns\EmailChannelTrait;
 
@@ -102,7 +103,7 @@ class TestEmailNotification extends BaseNotification implements EmailNotificatio
 {
     use EmailChannelTrait;
 
-    public function toEmail(object $notifiable): MailMessage
+    public function toEmail(NotifiableInterface $notifiable): MailMessage
     {
         return MailMessage::make()
             ->subject('Test Subject')

--- a/app-modules/meeting-center/database/migrations/2023_10_16_133341_create_calendars_table.php
+++ b/app-modules/meeting-center/database/migrations/2023_10_16_133341_create_calendars_table.php
@@ -49,12 +49,12 @@ return new class () extends Migration {
             $table->string('provider_type');
             $table->text('provider_id')->nullable();
             $table->text('provider_email');
-            $table->text('oauth_token');
-            $table->text('oauth_refresh_token');
+            $table->text('oauth_token')->nullable();
+            $table->text('oauth_refresh_token')->nullable();
 
             $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
 
-            $table->timestamp('oauth_token_expires_at');
+            $table->timestamp('oauth_token_expires_at')->nullable();
 
             $table->timestamps();
         });

--- a/app-modules/meeting-center/resources/views/filament/components/calendar-setup-modal.blade.php
+++ b/app-modules/meeting-center/resources/views/filament/components/calendar-setup-modal.blade.php
@@ -31,18 +31,25 @@
 
 </COPYRIGHT>
 --}}
-<div class="flex justify-evenly">
-    <a href="{{ route('calendar.google.login') }}">
-        <x-filament::icon
-            class="h-16 w-16"
-            icon="icon-google"
-        />
-    </a>
 
-    <a href="{{ route('calendar.outlook.login') }}">
-        <x-filament::icon
-            class="h-16 w-16"
-            icon="icon-outlook"
-        />
-    </a>
+@php use AdvisingApp\MeetingCenter\Enums\CalendarProvider; @endphp
+
+<div class="flex justify-evenly">
+    @if(is_null($calendar->provider_type) || $calendar->provider_type === CalendarProvider::Google)
+        <a href="{{ route('calendar.google.login') }}">
+            <x-filament::icon
+                    class="h-16 w-16"
+                    icon="icon-google"
+            />
+        </a>
+    @endif
+
+    @if(is_null($calendar->provider_type) || $calendar->provider_type === CalendarProvider::Outlook)
+        <a href="{{ route('calendar.outlook.login') }}">
+            <x-filament::icon
+                    class="h-16 w-16"
+                    icon="icon-outlook"
+            />
+        </a>
+    @endif
 </div>

--- a/app-modules/meeting-center/resources/views/filament/components/calendar-setup-modal.blade.php
+++ b/app-modules/meeting-center/resources/views/filament/components/calendar-setup-modal.blade.php
@@ -32,7 +32,9 @@
 </COPYRIGHT>
 --}}
 
-@php use AdvisingApp\MeetingCenter\Enums\CalendarProvider; @endphp
+@php
+    use AdvisingApp\MeetingCenter\Enums\CalendarProvider;
+@endphp
 
 <div class="flex justify-evenly">
     @if (is_null($calendar->provider_type) || $calendar->provider_type === CalendarProvider::Google)

--- a/app-modules/meeting-center/resources/views/filament/components/calendar-setup-modal.blade.php
+++ b/app-modules/meeting-center/resources/views/filament/components/calendar-setup-modal.blade.php
@@ -35,20 +35,20 @@
 @php use AdvisingApp\MeetingCenter\Enums\CalendarProvider; @endphp
 
 <div class="flex justify-evenly">
-    @if(is_null($calendar->provider_type) || $calendar->provider_type === CalendarProvider::Google)
+    @if (is_null($calendar->provider_type) || $calendar->provider_type === CalendarProvider::Google)
         <a href="{{ route('calendar.google.login') }}">
             <x-filament::icon
-                    class="h-16 w-16"
-                    icon="icon-google"
+                class="h-16 w-16"
+                icon="icon-google"
             />
         </a>
     @endif
 
-    @if(is_null($calendar->provider_type) || $calendar->provider_type === CalendarProvider::Outlook)
+    @if (is_null($calendar->provider_type) || $calendar->provider_type === CalendarProvider::Outlook)
         <a href="{{ route('calendar.outlook.login') }}">
             <x-filament::icon
-                    class="h-16 w-16"
-                    icon="icon-outlook"
+                class="h-16 w-16"
+                icon="icon-outlook"
             />
         </a>
     @endif

--- a/app-modules/meeting-center/src/Console/Commands/RefreshCalendarRefreshTokens.php
+++ b/app-modules/meeting-center/src/Console/Commands/RefreshCalendarRefreshTokens.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\MeetingCenter\Console\Commands;
 
 use Illuminate\Console\Command;

--- a/app-modules/meeting-center/src/Console/Commands/RefreshCalendarRefreshTokens.php
+++ b/app-modules/meeting-center/src/Console/Commands/RefreshCalendarRefreshTokens.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AdvisingApp\MeetingCenter\Console\Commands;
+
+use Illuminate\Console\Command;
+use AdvisingApp\MeetingCenter\Models\Calendar;
+use AdvisingApp\MeetingCenter\Jobs\RefreshCalendarRefreshToken;
+
+class RefreshCalendarRefreshTokens extends Command
+{
+    protected $signature =
+        'meeting-center:refresh-calendar-refresh-tokens';
+
+    protected $description = 'Triggers a refresh of all calendar refresh tokens that are needed.';
+
+    public function handle(): void
+    {
+        Calendar::query()
+            ->whereNotNull('oauth_refresh_token')
+            ->where('updated_at', '<=', now()->subDays(14))
+            ->each(fn (Calendar $calendar) => RefreshCalendarRefreshToken::dispatch($calendar));
+    }
+}

--- a/app-modules/meeting-center/src/Filament/Resources/CalendarEventResource.php
+++ b/app-modules/meeting-center/src/Filament/Resources/CalendarEventResource.php
@@ -59,11 +59,6 @@ class CalendarEventResource extends Resource
 
     protected static ?string $modelLabel = 'appointment';
 
-    public static function getRelations(): array
-    {
-        return [];
-    }
-
     public static function getPages(): array
     {
         return [

--- a/app-modules/meeting-center/src/Filament/Resources/CalendarEventResource/Pages/ListCalendarEvents.php
+++ b/app-modules/meeting-center/src/Filament/Resources/CalendarEventResource/Pages/ListCalendarEvents.php
@@ -74,7 +74,7 @@ class ListCalendarEvents extends ListRecords
         return Action::make('setupCalendarProviderAction')
             ->modalHeading('Choose a provider')
             ->modalDescription('This feature requires synchronization with Google Calendar or Outlook Calendar. Please select the service you would like to connect to by selecting the appropriate icon below.')
-            ->modalContent(view('meeting-center::filament.components.calendar-setup-modal'))
+            ->modalContent(view('meeting-center::filament.components.calendar-setup-modal', ['calendar' => auth()->user()->calendar]))
             ->modalSubmitAction(false)
             ->modalCancelAction(Action::make('cancel')->color('gray')->url(Filament::getUrl()))
             ->modalCloseButton(false)

--- a/app-modules/meeting-center/src/Jobs/RefreshCalendarRefreshToken.php
+++ b/app-modules/meeting-center/src/Jobs/RefreshCalendarRefreshToken.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AdvisingApp\MeetingCenter\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use AdvisingApp\MeetingCenter\Models\Calendar;
+use AdvisingApp\MeetingCenter\Managers\CalendarManager;
+use AdvisingApp\MeetingCenter\Managers\Contracts\CalendarInterface;
+
+class RefreshCalendarRefreshToken implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public Calendar $calendar) {}
+
+    public function handle(): void
+    {
+        /** @var CalendarInterface $calendarManager */
+        $calendarManager = resolve(CalendarManager::class)
+            ->driver($this->calendar->provider_type->value);
+
+        $calendarManager->refreshToken($this->calendar);
+    }
+}

--- a/app-modules/meeting-center/src/Jobs/RefreshCalendarRefreshToken.php
+++ b/app-modules/meeting-center/src/Jobs/RefreshCalendarRefreshToken.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\MeetingCenter\Jobs;
 
 use Illuminate\Bus\Queueable;

--- a/app-modules/meeting-center/src/Managers/Contracts/CalendarInterface.php
+++ b/app-modules/meeting-center/src/Managers/Contracts/CalendarInterface.php
@@ -57,5 +57,7 @@ interface CalendarInterface
 
     public function syncEvents(Calendar $calendar, ?Datetime $start = null, ?Datetime $end = null, ?int $perPage = null): void;
 
+    public function refreshToken(Calendar $calendar): Calendar;
+
     public function revokeToken(Calendar $calendar): bool;
 }

--- a/app-modules/meeting-center/src/Managers/GoogleCalendarManager.php
+++ b/app-modules/meeting-center/src/Managers/GoogleCalendarManager.php
@@ -217,7 +217,7 @@ class GoogleCalendarManager implements CalendarInterface
             ]);
 
             if ($calendar->oauth_token_expires_at < now()) {
-                $calendar = static::refreshToken($calendar);
+                $calendar = (new self())->refreshToken($calendar);
             }
 
             $client->setAccessToken($calendar->oauth_token);

--- a/app-modules/meeting-center/src/Managers/GoogleCalendarManager.php
+++ b/app-modules/meeting-center/src/Managers/GoogleCalendarManager.php
@@ -217,27 +217,7 @@ class GoogleCalendarManager implements CalendarInterface
             ]);
 
             if ($calendar->oauth_token_expiress_at < now()) {
-                try {
-                    $token = $client->fetchAccessTokenWithRefreshToken($calendar->oauth_refresh_token);
-
-                    if (empty($token['access_token']) || empty($token['expires_in']) || empty($token['created'])) {
-                        throw new Exception('fetchAccessTokenWithRefreshToken did not return a valid token');
-                    }
-
-                    $calendar->oauth_token = $token['access_token'];
-                    $calendar->oauth_token_expires_at = Carbon::parse($token['created'] + $token['expires_in']);
-                    $calendar->save();
-                } catch (Exception $e) {
-                    $calendar->update([
-                        'oauth_token' => null,
-                        'oauth_refresh_token' => null,
-                        'oauth_token_expires_at' => null,
-                    ]);
-
-                    $calendar->user->notify(new CalendarRequiresReconnect($calendar));
-
-                    throw $e;
-                }
+                static::refreshToken($calendar, $client);
             } else {
                 $client->setAccessToken($calendar->oauth_token);
             }
@@ -259,6 +239,43 @@ class GoogleCalendarManager implements CalendarInterface
         }
 
         return $client;
+    }
+
+    public function refreshToken(Calendar $calendar, ?Client $client = null): void
+    {
+        try {
+            if (! $client) {
+                $client = new Client([
+                    'client_id' => config('services.google_calendar.client_id'),
+                    'client_secret' => config('services.google_calendar.client_secret'),
+                    'scopes' => [
+                        GoogleCalendar::CALENDAR,
+                        GoogleCalendar::CALENDAR_EVENTS,
+                    ],
+                ]);
+            }
+
+            $token = $client->fetchAccessTokenWithRefreshToken($calendar->oauth_refresh_token);
+
+            if (empty($token['access_token']) || empty($token['expires_in']) || empty($token['created']) || empty($token['refresh_token'])) {
+                throw new Exception('fetchAccessTokenWithRefreshToken did not return a valid token');
+            }
+
+            $calendar->oauth_token = $token['access_token'];
+            $calendar->oauth_token_expires_at = Carbon::parse($token['created'] + $token['expires_in']);
+            $calendar->oauth_refresh_token = $token['refresh_token'];
+            $calendar->save();
+        } catch (Exception $e) {
+            $calendar->update([
+                'oauth_token' => null,
+                'oauth_refresh_token' => null,
+                'oauth_token_expires_at' => null,
+            ]);
+
+            $calendar->user->notify(new CalendarRequiresReconnect($calendar));
+
+            throw $e;
+        }
     }
 
     private function toGoogleEvent(CalendarEvent $event): Event

--- a/app-modules/meeting-center/src/Managers/OutlookCalendarManager.php
+++ b/app-modules/meeting-center/src/Managers/OutlookCalendarManager.php
@@ -37,7 +37,6 @@
 namespace AdvisingApp\MeetingCenter\Managers;
 
 use DateTime;
-use Exception;
 use Carbon\Carbon;
 use DateTimeInterface;
 use Microsoft\Graph\Graph;
@@ -253,16 +252,6 @@ class OutlookCalendarManager implements CalendarInterface
                 'refresh_token' => $calendar->oauth_refresh_token,
             ]
         );
-
-        $calendar->oauth_token = null;
-        $calendar->oauth_refresh_token = null;
-        $calendar->oauth_token_expires_at = null;
-
-        $calendar->save();
-
-        $calendar->user->notify(new CalendarRequiresReconnect($calendar));
-
-        throw new Exception($response->body());
 
         if ($response->clientError() || $response->serverError()) {
             if ($response->status() === Response::HTTP_UNAUTHORIZED) {

--- a/app-modules/meeting-center/src/Models/EventAttendee.php
+++ b/app-modules/meeting-center/src/Models/EventAttendee.php
@@ -44,12 +44,13 @@ use AdvisingApp\StudentDataModel\Models\Student;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use AdvisingApp\MeetingCenter\Enums\EventAttendeeStatus;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 
 #[NoPermissions]
 /**
  * @mixin IdeHelperEventAttendee
  */
-class EventAttendee extends BaseModel
+class EventAttendee extends BaseModel implements NotifiableInterface
 {
     use Notifiable;
 

--- a/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnect.php
+++ b/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnect.php
@@ -11,9 +11,9 @@ use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\MeetingCenter\Models\EventAttendee;
 use AdvisingApp\Notification\Notifications\BaseNotification;
 use AdvisingApp\Notification\Notifications\EmailNotification;
-use Filament\Notifications\Notification as FilamentNotification;
 use AdvisingApp\Notification\Notifications\DatabaseNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
+use Filament\Notifications\Notification as FilamentNotification;
 use AdvisingApp\Notification\Notifications\Concerns\EmailChannelTrait;
 use AdvisingApp\MeetingCenter\Filament\Resources\CalendarEventResource;
 
@@ -28,6 +28,7 @@ class CalendarRequiresReconnect extends BaseNotification implements EmailNotific
         return MailMessage::make()
             ->settings($this->resolveNotificationSetting($notifiable))
             ->line('The calendar connection for your account needs to be reconnected.')
+            ->line('Please reconnect your calendar connection to continue using the calendar for schedules and appointments.')
             ->action('View Schedule and Appointments', CalendarEventResource::getUrl());
     }
 

--- a/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnect.php
+++ b/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnect.php
@@ -38,16 +38,14 @@ namespace AdvisingApp\MeetingCenter\Notifications;
 
 use App\Models\User;
 use App\Models\NotificationSetting;
-use AdvisingApp\Prospect\Models\Prospect;
 use Filament\Notifications\Actions\Action;
 use AdvisingApp\MeetingCenter\Models\Calendar;
-use AdvisingApp\StudentDataModel\Models\Student;
-use AdvisingApp\MeetingCenter\Models\EventAttendee;
 use AdvisingApp\Notification\Notifications\BaseNotification;
 use AdvisingApp\Notification\Notifications\EmailNotification;
 use AdvisingApp\Notification\Notifications\DatabaseNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use Filament\Notifications\Notification as FilamentNotification;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\Notifications\Concerns\EmailChannelTrait;
 use AdvisingApp\MeetingCenter\Filament\Resources\CalendarEventResource;
 use AdvisingApp\Notification\Notifications\Concerns\DatabaseChannelTrait;
@@ -59,7 +57,7 @@ class CalendarRequiresReconnect extends BaseNotification implements EmailNotific
 
     public function __construct(public Calendar $calendar) {}
 
-    public function toEmail(User|Student|Prospect|EventAttendee $notifiable): MailMessage
+    public function toEmail(NotifiableInterface $notifiable): MailMessage
     {
         return MailMessage::make()
             ->settings($this->resolveNotificationSetting($notifiable))
@@ -68,7 +66,7 @@ class CalendarRequiresReconnect extends BaseNotification implements EmailNotific
             ->action('View Schedule and Appointments', CalendarEventResource::getUrl());
     }
 
-    public function toDatabase(object $notifiable): array
+    public function toDatabase(NotifiableInterface $notifiable): array
     {
         return FilamentNotification::make()
             ->danger()
@@ -82,8 +80,8 @@ class CalendarRequiresReconnect extends BaseNotification implements EmailNotific
             ->getDatabaseMessage();
     }
 
-    private function resolveNotificationSetting(User $notifiable): ?NotificationSetting
+    private function resolveNotificationSetting(NotifiableInterface $notifiable): ?NotificationSetting
     {
-        return $notifiable->teams()->first()?->division?->notificationSetting?->setting;
+        return $notifiable instanceof User ? $notifiable->teams()->first()?->division?->notificationSetting?->setting : null;
     }
 }

--- a/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnect.php
+++ b/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnect.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\MeetingCenter\Notifications;
 
 use App\Models\User;

--- a/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnect.php
+++ b/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnect.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace AdvisingApp\MeetingCenter\Notifications;
+
+use App\Models\User;
+use Filament\Actions\Action;
+use App\Models\NotificationSetting;
+use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\MeetingCenter\Models\Calendar;
+use AdvisingApp\StudentDataModel\Models\Student;
+use AdvisingApp\MeetingCenter\Models\EventAttendee;
+use AdvisingApp\Notification\Notifications\BaseNotification;
+use AdvisingApp\Notification\Notifications\EmailNotification;
+use Filament\Notifications\Notification as FilamentNotification;
+use AdvisingApp\Notification\Notifications\DatabaseNotification;
+use AdvisingApp\Notification\Notifications\Messages\MailMessage;
+use AdvisingApp\Notification\Notifications\Concerns\EmailChannelTrait;
+use AdvisingApp\MeetingCenter\Filament\Resources\CalendarEventResource;
+
+class CalendarRequiresReconnect extends BaseNotification implements EmailNotification, DatabaseNotification
+{
+    use EmailChannelTrait;
+
+    public function __construct(public Calendar $calendar) {}
+
+    public function toEmail(User|Student|Prospect|EventAttendee $notifiable): MailMessage
+    {
+        return MailMessage::make()
+            ->settings($this->resolveNotificationSetting($notifiable))
+            ->line('The calendar connection for your account needs to be reconnected.')
+            ->action('View Schedule and Appointments', CalendarEventResource::getUrl());
+    }
+
+    public function toDatabase(object $notifiable): array
+    {
+        return FilamentNotification::make()
+            ->success()
+            ->title('Your calendar connection needs to be reconnected.')
+            ->body('Please reconnect your calendar connection to continue using the calendar for schedules and appointments.')
+            ->actions([
+                Action::make('reconnect_calendar')
+                    ->label('Reconnect Calendar')
+                    ->url(CalendarEventResource::getUrl()),
+            ])
+            ->getDatabaseMessage();
+    }
+
+    private function resolveNotificationSetting(User $notifiable): ?NotificationSetting
+    {
+        return $notifiable->teams()->first()?->division?->notificationSetting?->setting;
+    }
+}

--- a/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnect.php
+++ b/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnect.php
@@ -3,9 +3,9 @@
 namespace AdvisingApp\MeetingCenter\Notifications;
 
 use App\Models\User;
-use Filament\Actions\Action;
 use App\Models\NotificationSetting;
 use AdvisingApp\Prospect\Models\Prospect;
+use Filament\Notifications\Actions\Action;
 use AdvisingApp\MeetingCenter\Models\Calendar;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\MeetingCenter\Models\EventAttendee;
@@ -16,10 +16,12 @@ use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use Filament\Notifications\Notification as FilamentNotification;
 use AdvisingApp\Notification\Notifications\Concerns\EmailChannelTrait;
 use AdvisingApp\MeetingCenter\Filament\Resources\CalendarEventResource;
+use AdvisingApp\Notification\Notifications\Concerns\DatabaseChannelTrait;
 
 class CalendarRequiresReconnect extends BaseNotification implements EmailNotification, DatabaseNotification
 {
     use EmailChannelTrait;
+    use DatabaseChannelTrait;
 
     public function __construct(public Calendar $calendar) {}
 
@@ -35,7 +37,7 @@ class CalendarRequiresReconnect extends BaseNotification implements EmailNotific
     public function toDatabase(object $notifiable): array
     {
         return FilamentNotification::make()
-            ->success()
+            ->danger()
             ->title('Your calendar connection needs to be reconnected.')
             ->body('Please reconnect your calendar connection to continue using the calendar for schedules and appointments.')
             ->actions([

--- a/app-modules/notification/src/Models/Contracts/NotifiableInterface.php
+++ b/app-modules/notification/src/Models/Contracts/NotifiableInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AdvisingApp\Notification\Models\Contracts;
+
+interface NotifiableInterface
+{
+    public function notify($instance);
+
+    public function notifyNow($instance, array $channels = null);
+
+    public function routeNotificationFor($driver, $notification = null);
+
+    public function notifications();
+
+    public function readNotifications();
+
+    public function unreadNotifications();
+}

--- a/app-modules/notification/src/Models/Contracts/NotifiableInterface.php
+++ b/app-modules/notification/src/Models/Contracts/NotifiableInterface.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2022-2023, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Notification\Models\Contracts;
 
 interface NotifiableInterface

--- a/app-modules/notification/src/Notifications/BaseNotification.php
+++ b/app-modules/notification/src/Notifications/BaseNotification.php
@@ -47,6 +47,7 @@ use AdvisingApp\Notification\Actions\CreateOutboundDeliverable;
 use AdvisingApp\Notification\Notifications\Channels\SmsChannel;
 use AdvisingApp\Notification\Notifications\Channels\EmailChannel;
 use AdvisingApp\Notification\Notifications\Concerns\ChannelTrait;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\Notifications\Channels\DatabaseChannel;
 use AdvisingApp\Notification\DataTransferObjects\SmsChannelResultData;
 use AdvisingApp\Notification\DataTransferObjects\EmailChannelResultData;
@@ -60,7 +61,7 @@ abstract class BaseNotification extends Notification implements ShouldQueue
 
     protected array $metadata = [];
 
-    public function via(object $notifiable): array
+    public function via(NotifiableInterface $notifiable): array
     {
         $traits = collect(class_uses_recursive(static::class));
 
@@ -84,7 +85,7 @@ abstract class BaseNotification extends Notification implements ShouldQueue
             ->toArray();
     }
 
-    public function beforeSend(object $notifiable, string $channel): OutboundDeliverable|false
+    public function beforeSend(NotifiableInterface $notifiable, string $channel): OutboundDeliverable|false
     {
         $deliverable = resolve(CreateOutboundDeliverable::class)->handle($this, $notifiable, $channel);
 
@@ -97,7 +98,7 @@ abstract class BaseNotification extends Notification implements ShouldQueue
         return $deliverable;
     }
 
-    public function afterSend(object $notifiable, OutboundDeliverable $deliverable, NotificationResultData $result): void
+    public function afterSend(NotifiableInterface $notifiable, OutboundDeliverable $deliverable, NotificationResultData $result): void
     {
         match (true) {
             $result instanceof SmsChannelResultData => SmsChannel::afterSending($notifiable, $deliverable, $result),
@@ -109,7 +110,7 @@ abstract class BaseNotification extends Notification implements ShouldQueue
         $this->afterSendHook($notifiable, $deliverable);
     }
 
-    protected function beforeSendHook(object $notifiable, OutboundDeliverable $deliverable, string $channel): void {}
+    protected function beforeSendHook(NotifiableInterface $notifiable, OutboundDeliverable $deliverable, string $channel): void {}
 
-    protected function afterSendHook(object $notifiable, OutboundDeliverable $deliverable): void {}
+    protected function afterSendHook(NotifiableInterface $notifiable, OutboundDeliverable $deliverable): void {}
 }

--- a/app-modules/notification/src/Notifications/Channels/DatabaseChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/DatabaseChannel.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Notification\Notifications\Channels;
 use Illuminate\Notifications\Notification;
 use AdvisingApp\Notification\Models\OutboundDeliverable;
 use AdvisingApp\Notification\Notifications\BaseNotification;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\DataTransferObjects\NotificationResultData;
 use AdvisingApp\Notification\DataTransferObjects\DatabaseChannelResultData;
 use Illuminate\Notifications\Channels\DatabaseChannel as BaseDatabaseChannel;
@@ -51,7 +52,7 @@ class DatabaseChannel extends BaseDatabaseChannel
         $deliverable = $notification->beforeSend($notifiable, DatabaseChannel::class);
 
         if ($deliverable === false) {
-            // Do anything else we need to to notify sending party that notification was not sent
+            // Do anything else we need to notify sending party that notification was not sent
             return;
         }
 
@@ -60,7 +61,7 @@ class DatabaseChannel extends BaseDatabaseChannel
         $notification->afterSend($notifiable, $deliverable, $result);
     }
 
-    public function handle(object $notifiable, BaseNotification $notification): NotificationResultData
+    public function handle(NotifiableInterface $notifiable, BaseNotification $notification): NotificationResultData
     {
         parent::send($notifiable, $notification);
 
@@ -69,7 +70,7 @@ class DatabaseChannel extends BaseDatabaseChannel
         );
     }
 
-    public static function afterSending(object $notifiable, OutboundDeliverable $deliverable, DatabaseChannelResultData $result): void
+    public static function afterSending(NotifiableInterface $notifiable, OutboundDeliverable $deliverable, DatabaseChannelResultData $result): void
     {
         if ($result->success) {
             $deliverable->markDeliverySuccessful();

--- a/app-modules/notification/src/Notifications/Channels/EmailChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/EmailChannel.php
@@ -54,7 +54,6 @@ class EmailChannel extends MailChannel
     public function send($notifiable, Notification $notification): void
     {
         /** @var NotifiableInterface $notifiable */
-
         try {
             DB::beginTransaction();
 

--- a/app-modules/notification/src/Notifications/Channels/EmailChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/EmailChannel.php
@@ -45,6 +45,7 @@ use AdvisingApp\Notification\Models\OutboundDeliverable;
 use AdvisingApp\Notification\Notifications\BaseNotification;
 use AdvisingApp\Notification\Notifications\EmailNotification;
 use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\DataTransferObjects\EmailChannelResultData;
 use AdvisingApp\Notification\DataTransferObjects\NotificationResultData;
 
@@ -52,6 +53,8 @@ class EmailChannel extends MailChannel
 {
     public function send($notifiable, Notification $notification): void
     {
+        /** @var NotifiableInterface $notifiable */
+
         try {
             DB::beginTransaction();
 

--- a/app-modules/notification/src/Notifications/Channels/SmsChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/SmsChannel.php
@@ -42,18 +42,19 @@ use AdvisingApp\Notification\Models\OutboundDeliverable;
 use AdvisingApp\Notification\Notifications\SmsNotification;
 use AdvisingApp\Notification\Notifications\BaseNotification;
 use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\Notifications\Messages\TwilioMessage;
 use AdvisingApp\Notification\DataTransferObjects\SmsChannelResultData;
 use AdvisingApp\Notification\DataTransferObjects\NotificationResultData;
 
 class SmsChannel
 {
-    public function send(object $notifiable, BaseNotification $notification): void
+    public function send(NotifiableInterface $notifiable, BaseNotification $notification): void
     {
         $deliverable = $notification->beforeSend($notifiable, SmsChannel::class);
 
         if ($deliverable === false) {
-            // Do anything else we need to to notify sending party that notification was not sent
+            // Do anything else we need to notify sending party that notification was not sent
             return;
         }
 
@@ -62,7 +63,7 @@ class SmsChannel
         $notification->afterSend($notifiable, $deliverable, $smsData);
     }
 
-    public function handle(object $notifiable, BaseNotification $notification): NotificationResultData
+    public function handle(NotifiableInterface $notifiable, BaseNotification $notification): NotificationResultData
     {
         /** @var SmsNotification $notification */
 
@@ -99,7 +100,7 @@ class SmsChannel
         return $result;
     }
 
-    public static function afterSending(object $notifiable, OutboundDeliverable $deliverable, SmsChannelResultData $result): void
+    public static function afterSending(NotifiableInterface $notifiable, OutboundDeliverable $deliverable, SmsChannelResultData $result): void
     {
         if ($result->success) {
             $deliverable->update([

--- a/app-modules/notification/src/Notifications/Concerns/EmailChannelTrait.php
+++ b/app-modules/notification/src/Notifications/Concerns/EmailChannelTrait.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Notification\Notifications\Concerns;
 use Symfony\Component\Mime\Email;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use AdvisingApp\Notification\Notifications\Channels\EmailChannel;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\IntegrationAwsSesEventHandling\Settings\SesSettings;
 
 trait EmailChannelTrait
@@ -50,7 +51,7 @@ trait EmailChannelTrait
         return EmailChannel::class;
     }
 
-    public function toMail(object $notifiable): MailMessage
+    public function toMail(NotifiableInterface $notifiable): MailMessage
     {
         return $this->toEmail($notifiable)
             ->withSymfonyMessage(function (Email $message) {

--- a/app-modules/notification/src/Notifications/DatabaseNotification.php
+++ b/app-modules/notification/src/Notifications/DatabaseNotification.php
@@ -36,7 +36,9 @@
 
 namespace AdvisingApp\Notification\Notifications;
 
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
+
 interface DatabaseNotification
 {
-    public function toDatabase(object $notifiable): array;
+    public function toDatabase(NotifiableInterface $notifiable): array;
 }

--- a/app-modules/notification/src/Notifications/EmailNotification.php
+++ b/app-modules/notification/src/Notifications/EmailNotification.php
@@ -36,11 +36,15 @@
 
 namespace AdvisingApp\Notification\Notifications;
 
+use App\Models\User;
+use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Models\Student;
+use AdvisingApp\MeetingCenter\Models\EventAttendee;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 
 interface EmailNotification
 {
-    public function toEmail(object $notifiable): MailMessage;
+    public function toEmail(User|Student|Prospect|EventAttendee $notifiable): MailMessage;
 
     public function toMail(object $notifiable): MailMessage;
 }

--- a/app-modules/notification/src/Notifications/EmailNotification.php
+++ b/app-modules/notification/src/Notifications/EmailNotification.php
@@ -36,15 +36,12 @@
 
 namespace AdvisingApp\Notification\Notifications;
 
-use App\Models\User;
-use AdvisingApp\Prospect\Models\Prospect;
-use AdvisingApp\StudentDataModel\Models\Student;
-use AdvisingApp\MeetingCenter\Models\EventAttendee;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 
 interface EmailNotification
 {
-    public function toEmail(User|Student|Prospect|EventAttendee $notifiable): MailMessage;
+    public function toEmail(NotifiableInterface $notifiable): MailMessage;
 
-    public function toMail(object $notifiable): MailMessage;
+    public function toMail(NotifiableInterface $notifiable): MailMessage;
 }

--- a/app-modules/notification/src/Notifications/SmsNotification.php
+++ b/app-modules/notification/src/Notifications/SmsNotification.php
@@ -36,9 +36,10 @@
 
 namespace AdvisingApp\Notification\Notifications;
 
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\Notifications\Messages\TwilioMessage;
 
 interface SmsNotification
 {
-    public function toSms(object $notifiable): TwilioMessage;
+    public function toSms(NotifiableInterface $notifiable): TwilioMessage;
 }

--- a/app-modules/notification/tests/Features/NotificationSendingTest.php
+++ b/app-modules/notification/tests/Features/NotificationSendingTest.php
@@ -42,6 +42,7 @@ use AdvisingApp\Notification\Notifications\EmailNotification;
 use AdvisingApp\Notification\Notifications\DatabaseNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use Filament\Notifications\Notification as FilamentNotification;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\Notifications\Concerns\EmailChannelTrait;
 use AdvisingApp\Notification\Notifications\Concerns\DatabaseChannelTrait;
 
@@ -73,7 +74,7 @@ class TestMultipleChannelNotification extends BaseNotification implements EmailN
     use EmailChannelTrait;
     use DatabaseChannelTrait;
 
-    public function toEmail(object $notifiable): MailMessage
+    public function toEmail(NotifiableInterface $notifiable): MailMessage
     {
         return MailMessage::make()
             ->subject('Test Subject')
@@ -82,7 +83,7 @@ class TestMultipleChannelNotification extends BaseNotification implements EmailN
             ->salutation('Test Salutation');
     }
 
-    public function toDatabase(object $notifiable): array
+    public function toDatabase(NotifiableInterface $notifiable): array
     {
         return FilamentNotification::make()
             ->success()

--- a/app-modules/prospect/src/Models/Prospect.php
+++ b/app-modules/prospect/src/Models/Prospect.php
@@ -70,6 +70,7 @@ use AdvisingApp\Notification\Models\Concerns\HasSubscriptions;
 use AdvisingApp\Notification\Models\Concerns\NotifiableViaSms;
 use AdvisingApp\Timeline\Models\Contracts\HasFilamentResource;
 use AdvisingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Engagement\Models\Concerns\HasManyMorphedEngagements;
 use AdvisingApp\Interaction\Models\Concerns\HasManyMorphedInteractions;
 use AdvisingApp\Engagement\Models\Concerns\HasManyMorphedEngagementResponses;
@@ -79,7 +80,7 @@ use AdvisingApp\Engagement\Models\Concerns\HasManyMorphedEngagementResponses;
  *
  * @mixin IdeHelperProspect
  */
-class Prospect extends BaseModel implements Auditable, Subscribable, Educatable, HasFilamentResource
+class Prospect extends BaseModel implements Auditable, Subscribable, Educatable, HasFilamentResource, NotifiableInterface
 {
     use HasUuids;
     use SoftDeletes;

--- a/app-modules/student-data-model/src/Models/Student.php
+++ b/app-modules/student-data-model/src/Models/Student.php
@@ -67,6 +67,7 @@ use AdvisingApp\Notification\Models\Concerns\NotifiableViaSms;
 use AdvisingApp\Timeline\Models\Contracts\HasFilamentResource;
 use AdvisingApp\Authorization\Models\Concerns\DefinesPermissions;
 use AdvisingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource;
 use AdvisingApp\Engagement\Models\Concerns\HasManyMorphedEngagements;
 use AdvisingApp\Interaction\Models\Concerns\HasManyMorphedInteractions;
@@ -78,7 +79,7 @@ use AdvisingApp\Engagement\Models\Concerns\HasManyMorphedEngagementResponses;
  *
  * @mixin IdeHelperStudent
  */
-class Student extends Model implements Auditable, Subscribable, Educatable, HasFilamentResource
+class Student extends Model implements Auditable, Subscribable, Educatable, HasFilamentResource, NotifiableInterface
 {
     use AuditableTrait;
     use HasFactory;

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -82,6 +82,10 @@ class Kernel extends ConsoleKernel
                     ->runInBackground()
             );
 
+        $schedule->command('meeting-center:refresh-calendar-refresh-tokens')
+            ->daily()
+            ->onOneServer();
+
         // Needs to remain as the last command: https://spatie.be/docs/laravel-health/v1/available-checks/schedule
         $schedule->command(ScheduleCheckHeartbeatCommand::class)->everyMinute();
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -80,6 +80,7 @@ use AdvisingApp\InAppCommunication\Models\TwilioConversation;
 use AdvisingApp\Engagement\Models\Concerns\HasManyEngagements;
 use AdvisingApp\Authorization\Models\Pivots\RoleGroupUserPivot;
 use AdvisingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\ServiceManagement\Models\ServiceRequestAssignment;
 use AdvisingApp\Engagement\Models\Concerns\HasManyEngagementBatches;
 use AdvisingApp\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
@@ -87,7 +88,7 @@ use AdvisingApp\ServiceManagement\Enums\ServiceRequestAssignmentStatus;
 /**
  * @mixin IdeHelperUser
  */
-class User extends Authenticatable implements HasLocalePreference, FilamentUser, Auditable, HasMedia, HasAvatar
+class User extends Authenticatable implements HasLocalePreference, FilamentUser, Auditable, HasMedia, HasAvatar, NotifiableInterface
 {
     use HasFactory;
     use HasAdvancedFilter;

--- a/tests/Unit/TestEmailNotification.php
+++ b/tests/Unit/TestEmailNotification.php
@@ -39,13 +39,14 @@ namespace Tests\Unit;
 use AdvisingApp\Notification\Notifications\BaseNotification;
 use AdvisingApp\Notification\Notifications\EmailNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 use AdvisingApp\Notification\Notifications\Concerns\EmailChannelTrait;
 
 class TestEmailNotification extends BaseNotification implements EmailNotification
 {
     use EmailChannelTrait;
 
-    public function toEmail(object $notifiable): MailMessage
+    public function toEmail(NotifiableInterface $notifiable): MailMessage
     {
         return MailMessage::make()
             ->subject('Test Subject')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-35
- https://canyongbs.atlassian.net/browse/ADVAPP-32

### Technical Description

If the refresh token fails to renew the access token by being invalid we inform the User and give them a flow to reconnect.

We will now also refresh refresh_tokens to make sure they are never stale.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Content or styling update (Changes which don't affect functionality)
- [ ] DevOps
- [ ] Documentation

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [ ] Yes, please specify
- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.
