### PR TITLE
Add Jira URL to template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Ticket(s) or GitHub Issue
 
-- [LINK_TO_TICKET] OR [LINK_TO_GITHUB_ISSUE]
+- https://canyongbs.atlassian.net/browse/ADVAPP-
 
 ### Technical Description
 


### PR DESCRIPTION
I don't think we lose any clarity that a GitHub issue may also be pasted here, but we do save a couple of seconds by not needing to visit Jira to copy the ticket URL each time 😁 