### PR TITLE
[ADVAPP-253]: EditInteractionTest.php fails when a ServiceRequest is used

### DIFF
--- a/app-modules/interaction/database/factories/InteractionFactory.php
+++ b/app-modules/interaction/database/factories/InteractionFactory.php
@@ -58,7 +58,7 @@ class InteractionFactory extends Factory
     public function definition(): array
     {
         $interactable = fake()->randomElement([
-            Student::inRandomOrder()->first()->sisid ?? Student::factory()->create(),
+            Student::inRandomOrder()->first() ?? Student::factory()->create(),
             Prospect::factory()->create(),
             ServiceRequest::factory()->create(),
         ]);

--- a/app-modules/interaction/database/factories/InteractionFactory.php
+++ b/app-modules/interaction/database/factories/InteractionFactory.php
@@ -48,6 +48,7 @@ use AdvisingApp\Interaction\Models\InteractionStatus;
 use AdvisingApp\Interaction\Models\InteractionOutcome;
 use AdvisingApp\Interaction\Models\InteractionCampaign;
 use AdvisingApp\Interaction\Models\InteractionRelation;
+use AdvisingApp\ServiceManagement\Models\ServiceRequest;
 
 /**
  * @extends Factory<Interaction>
@@ -57,17 +58,14 @@ class InteractionFactory extends Factory
     public function definition(): array
     {
         $interactable = fake()->randomElement([
-            Student::class,
-            Prospect::class,
-            // Disabled until ADVAPP-253
-            //ServiceRequest::class,
+            Student::inRandomOrder()->first()->sisid ?? Student::factory()->create(),
+            Prospect::factory()->create(),
+            ServiceRequest::factory()->create(),
         ]);
-
-        $interactable = $interactable::factory()->create();
 
         return [
             'user_id' => User::factory(),
-            'interactable_id' => $interactable->identifier(),
+            'interactable_id' => $interactable->getKey(),
             'interactable_type' => $interactable->getMorphClass(),
             'interaction_type_id' => InteractionType::factory(),
             'interaction_relation_id' => InteractionRelation::factory(),

--- a/app-modules/interaction/src/Filament/Resources/InteractionResource/Pages/EditInteraction.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionResource/Pages/EditInteraction.php
@@ -36,8 +36,8 @@
 
 namespace AdvisingApp\Interaction\Filament\Resources\InteractionResource\Pages;
 
-use Filament\Actions;
 use Filament\Forms\Form;
+use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Textarea;
@@ -145,7 +145,7 @@ class EditInteraction extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\DeleteAction::make(),
+            DeleteAction::make(),
         ];
     }
 }

--- a/app-modules/interaction/src/Filament/Resources/InteractionResource/RelationManagers/HasManyMorphedInteractionsRelationManager.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionResource/RelationManagers/HasManyMorphedInteractionsRelationManager.php
@@ -117,8 +117,6 @@ class HasManyMorphedInteractionsRelationManager extends RelationManager
             ->actions([
                 ViewAction::make(),
                 EditAction::make(),
-            ])
-            ->bulkActions([
             ]);
     }
 }

--- a/app-modules/interaction/src/Models/Concerns/HasManyMorphedInteractions.php
+++ b/app-modules/interaction/src/Models/Concerns/HasManyMorphedInteractions.php
@@ -46,6 +46,8 @@ trait HasManyMorphedInteractions
         return $this->morphMany(
             related: Interaction::class,
             name: 'interactable',
+            type: 'interactable_type',
+            id: 'interactable_id'
         );
     }
 }

--- a/app-modules/interaction/src/Models/Interaction.php
+++ b/app-modules/interaction/src/Models/Interaction.php
@@ -175,13 +175,11 @@ class Interaction extends BaseModel implements Auditable, CanTriggerAutoSubscrip
         static::addGlobalScope('licensed', function (Builder $builder) {
             $builder
                 ->tap(new LicensedToEducatable('interactable'))
-                ->where(fn (Builder $builder) => $builder
-                    ->where('interactable_type', '!=', app(ServiceRequest::class)->getMorphClass())
-                    ->orWhereDoesntHaveMorph(
-                        'interactable',
-                        ServiceRequest::class,
-                        fn (Builder $builder) => $builder->tap(new LicensedToEducatable('respondent')),
-                    ));
+                ->orWhereHasMorph(
+                    'interactable',
+                    ServiceRequest::class,
+                    fn (Builder $builder) => $builder->tap(new LicensedToEducatable('respondent')),
+                );
         });
     }
 }

--- a/app-modules/interaction/src/Policies/InteractionPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionPolicy.php
@@ -38,16 +38,19 @@ namespace AdvisingApp\Interaction\Policies;
 
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
-use AdvisingApp\Prospect\Models\Prospect;
+use App\Concerns\PerformsLicenseChecks;
 use AdvisingApp\Interaction\Models\Interaction;
-use AdvisingApp\StudentDataModel\Models\Student;
+use AdvisingApp\Authorization\Enums\LicenseType;
+use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 
-class InteractionPolicy
+class InteractionPolicy implements PerformsChecksBeforeAuthorization
 {
+    use PerformsLicenseChecks;
+
     public function before(Authenticatable $authenticatable): ?Response
     {
-        if (! $authenticatable->hasAnyLicense([Student::getLicenseType(), Prospect::getLicenseType()])) {
-            return Response::deny('You are not licensed for the Retention or Recruitment CRM.');
+        if (! is_null($response = $this->hasAnyLicense($authenticatable, [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]))) {
+            return $response;
         }
 
         return null;

--- a/app-modules/service-management/database/factories/ServiceRequestFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestFactory.php
@@ -53,7 +53,7 @@ class ServiceRequestFactory extends Factory
     public function definition(): array
     {
         $respondent = fake()->randomElement([
-            Student::inRandomOrder()->first() ?? Student::factory(),
+            Student::inRandomOrder()->first() ?? Student::factory()->create(),
             Prospect::factory()->create(),
         ]);
 

--- a/app-modules/service-management/database/factories/ServiceRequestFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestFactory.php
@@ -38,7 +38,6 @@ namespace AdvisingApp\ServiceManagement\Database\Factories;
 
 use App\Models\User;
 use AdvisingApp\Division\Models\Division;
-use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use AdvisingApp\ServiceManagement\Models\ServiceRequest;
@@ -52,14 +51,11 @@ class ServiceRequestFactory extends Factory
 {
     public function definition(): array
     {
-        $respondent = fake()->randomElement([
-            Student::inRandomOrder()->first() ?? Student::factory()->create(),
-            Prospect::factory()->create(),
-        ]);
-
         return [
-            'respondent_id' => $respondent->getKey(),
-            'respondent_type' => $respondent->getMorphClass(),
+            'respondent_id' => Student::inRandomOrder()->first()->sisid ?? Student::factory(),
+            'respondent_type' => function (array $attributes) {
+                return Student::find($attributes['respondent_id'])->getMorphClass();
+            },
             'close_details' => $this->faker->sentence(),
             'res_details' => $this->faker->sentence(),
             'division_id' => Division::inRandomOrder()->first()?->id ?? Division::factory(),

--- a/app-modules/service-management/database/factories/ServiceRequestFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestFactory.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\ServiceManagement\Database\Factories;
 
 use App\Models\User;
 use AdvisingApp\Division\Models\Division;
+use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use AdvisingApp\ServiceManagement\Models\ServiceRequest;
@@ -51,11 +52,14 @@ class ServiceRequestFactory extends Factory
 {
     public function definition(): array
     {
+        $respondent = fake()->randomElement([
+            Student::inRandomOrder()->first()->sisid ?? Student::factory(),
+            Prospect::factory()->create(),
+        ]);
+
         return [
-            'respondent_id' => Student::inRandomOrder()->first()->sisid ?? Student::factory(),
-            'respondent_type' => function (array $attributes) {
-                return Student::find($attributes['respondent_id'])->getMorphClass();
-            },
+            'respondent_id' => $respondent->getKey(),
+            'respondent_type' => $respondent->getMorphClass(),
             'close_details' => $this->faker->sentence(),
             'res_details' => $this->faker->sentence(),
             'division_id' => Division::inRandomOrder()->first()?->id ?? Division::factory(),

--- a/app-modules/service-management/database/factories/ServiceRequestFactory.php
+++ b/app-modules/service-management/database/factories/ServiceRequestFactory.php
@@ -53,7 +53,7 @@ class ServiceRequestFactory extends Factory
     public function definition(): array
     {
         $respondent = fake()->randomElement([
-            Student::inRandomOrder()->first()->sisid ?? Student::factory(),
+            Student::inRandomOrder()->first() ?? Student::factory(),
             Prospect::factory()->create(),
         ]);
 

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -51,7 +51,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use AdvisingApp\Campaign\Models\CampaignAction;
 use AdvisingApp\StudentDataModel\Models\Student;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -84,7 +83,6 @@ class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubsc
     use SoftDeletes;
     use PowerJoins;
     use AuditableTrait;
-    use HasUuids;
     use HasManyMorphedInteractions;
     use HasRelationships;
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-253

### Technical Description

This PR fixes a query scoping issue that was resulting in a test intermittently failing when a ServiceRequest was picked at random as the interactable type of an Interaction. 

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots (if appropriate)

### Any deployment steps required?

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `develop` branch.
