### PR TITLE
[ADVAPP-269]: Correct SLA response trigger dependency

### DIFF
--- a/app-modules/service-management/src/Enums/SlaComplianceStatus.php
+++ b/app-modules/service-management/src/Enums/SlaComplianceStatus.php
@@ -46,14 +46,11 @@ enum SlaComplianceStatus implements HasColor, HasIcon, HasLabel
 
     case NonCompliant;
 
-    case NoResponse;
-
     public function getLabel(): ?string
     {
         return match ($this) {
             self::Compliant => 'Within SLA',
             self::NonCompliant => 'Outside of SLA',
-            self::NoResponse => 'No Response',
         };
     }
 
@@ -62,7 +59,6 @@ enum SlaComplianceStatus implements HasColor, HasIcon, HasLabel
         return match ($this) {
             self::Compliant => 'success',
             self::NonCompliant => 'danger',
-            self::NoResponse => 'warning',
         };
     }
 
@@ -71,7 +67,6 @@ enum SlaComplianceStatus implements HasColor, HasIcon, HasLabel
         return match ($this) {
             self::Compliant => 'heroicon-m-check-circle',
             self::NonCompliant => 'heroicon-m-x-circle',
-            self::NoResponse => 'heroicon-m-exclamation-circle'
         };
     }
 }

--- a/app-modules/service-management/src/Enums/SlaComplianceStatus.php
+++ b/app-modules/service-management/src/Enums/SlaComplianceStatus.php
@@ -46,11 +46,14 @@ enum SlaComplianceStatus implements HasColor, HasIcon, HasLabel
 
     case NonCompliant;
 
+    case NoResponse;
+
     public function getLabel(): ?string
     {
         return match ($this) {
             self::Compliant => 'Within SLA',
             self::NonCompliant => 'Outside of SLA',
+            self::NoResponse => 'No Response',
         };
     }
 
@@ -59,6 +62,7 @@ enum SlaComplianceStatus implements HasColor, HasIcon, HasLabel
         return match ($this) {
             self::Compliant => 'success',
             self::NonCompliant => 'danger',
+            self::NoResponse => 'warning',
         };
     }
 
@@ -67,6 +71,7 @@ enum SlaComplianceStatus implements HasColor, HasIcon, HasLabel
         return match ($this) {
             self::Compliant => 'heroicon-m-check-circle',
             self::NonCompliant => 'heroicon-m-x-circle',
+            self::NoResponse => 'heroicon-m-exclamation-circle'
         };
     }
 }

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -275,11 +275,10 @@ class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubsc
             });
     }
 
-    public function getLatestResponseSeconds(): ?int
+    public function getLatestResponseSeconds(): int
     {
         if (! $this->latestInboundServiceRequestUpdate) {
-            return null;
-            // return $this->created_at->diffInSeconds(now());
+            return $this->created_at->diffInSeconds(now());
         }
 
         if (
@@ -331,12 +330,6 @@ class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubsc
         }
 
         $latestResponseSeconds = $this->getLatestResponseSeconds();
-
-        if (is_null($latestResponseSeconds)) {
-            return $this->created_at->diffInSeconds(now()) <= $slaResponseSeconds
-                ? SlaComplianceStatus::NoResponse
-                : SlaComplianceStatus::NonCompliant;
-        }
 
         return $latestResponseSeconds <= $slaResponseSeconds
             ? SlaComplianceStatus::Compliant

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -279,6 +279,7 @@ class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubsc
     {
         if (! $this->latestInboundServiceRequestUpdate) {
             return null;
+            // return $this->created_at->diffInSeconds(now());
         }
 
         if (
@@ -331,7 +332,13 @@ class ServiceRequest extends BaseModel implements Auditable, CanTriggerAutoSubsc
 
         $latestResponseSeconds = $this->getLatestResponseSeconds();
 
-        return ($latestResponseSeconds <= $slaResponseSeconds)
+        if (is_null($latestResponseSeconds)) {
+            return $this->created_at->diffInSeconds(now()) <= $slaResponseSeconds
+                ? SlaComplianceStatus::NoResponse
+                : SlaComplianceStatus::NonCompliant;
+        }
+
+        return $latestResponseSeconds <= $slaResponseSeconds
             ? SlaComplianceStatus::Compliant
             : SlaComplianceStatus::NonCompliant;
     }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-269

### Technical Description

Added new No Response status to handle initial SLA compliance state confusion.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `main` branch.
