### PR TITLE
Skip unnecessary health checks on local

### DIFF
--- a/app/Filament/Pages/ProductHealth.php
+++ b/app/Filament/Pages/ProductHealth.php
@@ -69,7 +69,7 @@ class ProductHealth extends HealthCheckResults
         $count = app(ResultStore::class)
             ->latestResults()
             ?->storedCheckResults
-            ->filter(fn ($check) => $check->status !== Status::ok()->value)
+            ->filter(fn ($check) => ! in_array($check->status, [Status::ok()->value, Status::skipped()->value]))
             ->count();
 
         return $count > 0 ? $count : null;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

### Technical Description

Skipped the 3 failing health checks on local. Because we now have a constant scheduler it keeps trying to send the failing health check notification every hour.

Removed `UsedDiskSpaceCheck` because originally it was configured to work on the `local` disk, and when I tried to make it use `s3` it failed.

Enabled the previously disabled `RedisCheck` because we now have a constant redis connection also configured.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots (if appropriate)

<img width="1725" alt="image" src="https://github.com/canyongbs/advisingapp/assets/11588575/d728e1dd-dc95-47ba-b7ed-c2d940250ea9">

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `main` branch.
