### PR TITLE
[ADVAPP-320]: Presentation of forms and portals is failing in prod.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 docs
 .env
 .env.example
+rr

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ public/api-docs/*
 /caddy
 frankenphp
 frankenphp-worker.php
+/rr

--- a/app-modules/application/routes/api.php
+++ b/app-modules/application/routes/api.php
@@ -50,16 +50,16 @@ Route::prefix('api')
             ->name('applications.')
             ->group(function () {
                 Route::get('/{application}', [ApplicationWidgetController::class, 'view'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('define');
                 Route::post('/{application}/authenticate/request', [ApplicationWidgetController::class, 'requestAuthentication'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('request-authentication');
                 Route::post('/{application}/authenticate/{authentication}', [ApplicationWidgetController::class, 'authenticate'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('authenticate');
                 Route::post('/{application}/submit', [ApplicationWidgetController::class, 'store'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('submit');
             });
     });

--- a/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
+++ b/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
@@ -65,7 +65,11 @@ class ApplicationWidgetController extends Controller
             [
                 'name' => $application->name,
                 'description' => $application->description,
-                'authentication_url' => URL::signedRoute('applications.request-authentication', ['application' => $application]),
+                'authentication_url' => URL::signedRoute(
+                    name: 'applications.request-authentication',
+                    parameters: ['application' => $application],
+                    absolute: false,
+                ),
                 'schema' => $generateSchema($application),
                 'primary_color' => Color::all()[$application->primary_color ?? 'blue'],
                 'rounding' => $application->rounding,
@@ -101,10 +105,14 @@ class ApplicationWidgetController extends Controller
 
         return response()->json([
             'message' => "We've sent an authentication code to {$data['email']}.",
-            'authentication_url' => URL::signedRoute('applications.authenticate', [
-                'application' => $application,
-                'authentication' => $authentication,
-            ]),
+            'authentication_url' => URL::signedRoute(
+                name: 'applications.authenticate',
+                parameters: [
+                    'application' => $application,
+                    'authentication' => $authentication,
+                ],
+                absolute: false,
+            ),
         ]);
     }
 
@@ -127,10 +135,14 @@ class ApplicationWidgetController extends Controller
         ]);
 
         return response()->json([
-            'submission_url' => URL::signedRoute('applications.submit', [
-                'authentication' => $authentication,
-                'application' => $authentication->submissible,
-            ]),
+            'submission_url' => URL::signedRoute(
+                name: 'applications.submit',
+                parameters: [
+                    'authentication' => $authentication,
+                    'application' => $authentication->submissible,
+                ],
+                absolute: false,
+            ),
         ]);
     }
 

--- a/app-modules/application/tests/ApplicationWidgetApiTest.php
+++ b/app-modules/application/tests/ApplicationWidgetApiTest.php
@@ -62,7 +62,11 @@ test('define is protected with proper feature access control', function () {
 
     $application = Application::factory()->create();
 
-    get(URL::signedRoute('applications.define', ['application' => $application]))
+    get(URL::signedRoute(
+        name: 'applications.define',
+        parameters: ['application' => $application],
+        absolute: false,
+    ))
         ->assertForbidden()
         ->assertJson([
             'error' => 'Online Admissions is not enabled.',
@@ -72,7 +76,11 @@ test('define is protected with proper feature access control', function () {
 
     $settings->save();
 
-    get(URL::signedRoute('applications.define', ['application' => $application]))
+    get(URL::signedRoute(
+        name: 'applications.define',
+        parameters: ['application' => $application],
+        absolute: false,
+    ))
         ->assertSuccessful();
 });
 
@@ -91,7 +99,11 @@ test('request-authentication is protected with proper feature access control', f
 
     $prospect = Prospect::factory()->create();
 
-    post(URL::signedRoute('applications.request-authentication', ['application' => $application, 'email' => $prospect->email]))
+    post(URL::signedRoute(
+        name: 'applications.request-authentication',
+        parameters: ['application' => $application, 'email' => $prospect->email],
+        absolute: false,
+    ))
         ->assertForbidden()
         ->assertJson([
             'error' => 'Online Admissions is not enabled.',
@@ -101,7 +113,11 @@ test('request-authentication is protected with proper feature access control', f
 
     $settings->save();
 
-    post(URL::signedRoute('applications.request-authentication', ['application' => $application, 'email' => $prospect->email]))
+    post(URL::signedRoute(
+        name: 'applications.request-authentication',
+        parameters: ['application' => $application, 'email' => $prospect->email],
+        absolute: false,
+    ))
         ->assertSuccessful();
 });
 
@@ -125,7 +141,11 @@ test('authenticate is protected with proper feature access control', function ()
         'code' => Hash::make($code),
     ]);
 
-    post(URL::signedRoute('applications.authenticate', ['application' => $application, 'authentication' => $authorization,  'code' => $code]))
+    post(URL::signedRoute(
+        name: 'applications.authenticate',
+        parameters: ['application' => $application, 'authentication' => $authorization,  'code' => $code],
+        absolute: false,
+    ))
         ->assertForbidden()
         ->assertJson([
             'error' => 'Online Admissions is not enabled.',
@@ -135,7 +155,11 @@ test('authenticate is protected with proper feature access control', function ()
 
     $settings->save();
 
-    post(URL::signedRoute('applications.authenticate', ['application' => $application, 'authentication' => $authorization, 'code' => $code]))
+    post(URL::signedRoute(
+        name: 'applications.authenticate',
+        parameters: ['application' => $application, 'authentication' => $authorization, 'code' => $code],
+        absolute: false,
+    ))
         ->assertSuccessful();
 });
 
@@ -162,7 +186,11 @@ test('submit is protected with proper feature access control', function () {
         'application_id' => $application->id,
     ]);
 
-    post(URL::signedRoute('applications.submit', ['application' => $application, 'authentication' => $authorization]))
+    post(URL::signedRoute(
+        name: 'applications.submit',
+        parameters: ['application' => $application, 'authentication' => $authorization],
+        absolute: false,
+    ))
         ->assertForbidden()
         ->assertJson([
             'error' => 'Online Admissions is not enabled.',
@@ -172,6 +200,10 @@ test('submit is protected with proper feature access control', function () {
 
     $settings->save();
 
-    post(URL::signedRoute('applications.submit', ['application' => $application, 'authentication' => $authorization]))
+    post(URL::signedRoute(
+        name: 'applications.submit',
+        parameters: ['application' => $application, 'authentication' => $authorization],
+        absolute: false,
+    ))
         ->assertSuccessful();
 });

--- a/app-modules/authorization/tests/Feature/Http/Controllers/Auth/OneTimeLoginControllerTest.php
+++ b/app-modules/authorization/tests/Feature/Http/Controllers/Auth/OneTimeLoginControllerTest.php
@@ -50,7 +50,11 @@ it('signs the user in through a signed URL', function () {
 
     assertGuest();
 
-    get(URL::signedRoute('login.one-time', ['user' => $user]))
+    get(URL::signedRoute(
+        name: 'login.one-time',
+        parameters: ['user' => $user],
+        absolute: false
+    ))
         ->assertRedirect();
 
     assertAuthenticatedAs($user);

--- a/app-modules/form/routes/api.php
+++ b/app-modules/form/routes/api.php
@@ -49,16 +49,16 @@ Route::prefix('api')
             ->name('forms.')
             ->group(function () {
                 Route::get('/{form}', [FormWidgetController::class, 'view'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('define');
                 Route::post('/{form}/authenticate/request', [FormWidgetController::class, 'requestAuthentication'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('request-authentication');
                 Route::post('/{form}/authenticate/{authentication}', [FormWidgetController::class, 'authenticate'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('authenticate');
                 Route::post('/{form}/submit', [FormWidgetController::class, 'store'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('submit');
             });
     });

--- a/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
+++ b/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
@@ -53,7 +53,11 @@ class GenerateSubmissibleEmbedCode
         return match ($submissible::class) {
             Form::class => (function () use ($submissible) {
                 $scriptUrl = url('js/widgets/form/advising-app-form-widget.js?');
-                $formDefinitionUrl = URL::signedRoute('forms.define', ['form' => $submissible]);
+                $formDefinitionUrl = URL::signedRoute(
+                    name: 'forms.define',
+                    parameters: ['form' => $submissible],
+                    absolute: false,
+                );
 
                 return <<<EOD
                 <form-embed url="{$formDefinitionUrl}"></form-embed>

--- a/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
+++ b/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
@@ -66,7 +66,11 @@ class GenerateSubmissibleEmbedCode
             })(),
             Application::class => (function () use ($submissible) {
                 $scriptUrl = url('js/widgets/application/advising-app-application-widget.js?');
-                $applicationDefinitionUrl = URL::signedRoute('applications.define', ['application' => $submissible]);
+                $applicationDefinitionUrl = URL::signedRoute(
+                    name: 'applications.define',
+                    parameters: ['application' => $submissible],
+                    absolute: false,
+                );
 
                 return <<<EOD
                 <application-embed url="{$applicationDefinitionUrl}"></application-embed>
@@ -75,7 +79,11 @@ class GenerateSubmissibleEmbedCode
             })(),
             Survey::class => (function () use ($submissible) {
                 $scriptUrl = url('js/widgets/survey/advising-app-survey-widget.js?');
-                $surveyDefinitionUrl = URL::signedRoute('surveys.define', ['survey' => $submissible]);
+                $surveyDefinitionUrl = URL::signedRoute(
+                    name: 'surveys.define',
+                    parameters: ['survey' => $submissible],
+                    absolute: false,
+                );
 
                 return <<<EOD
                 <survey-embed url="{$surveyDefinitionUrl}"></survey-embed>
@@ -85,7 +93,11 @@ class GenerateSubmissibleEmbedCode
             EventRegistrationForm::class => (function () use ($submissible) {
                 /** @var EventRegistrationForm $submissible */
                 $scriptUrl = url('js/widgets/events/advising-app-event-registration-form-widget.js?');
-                $formDefinitionUrl = URL::signedRoute('event-registration.define', ['event' => $submissible->event]);
+                $formDefinitionUrl = URL::signedRoute(
+                    name: 'event-registration.define',
+                    parameters: ['event' => $submissible->event],
+                    absolute: false,
+                );
 
                 return <<<EOD
                 <event-registration-embed url="{$formDefinitionUrl}"></event-registration-embed>
@@ -95,7 +107,11 @@ class GenerateSubmissibleEmbedCode
             ServiceRequestForm::class => (function () use ($submissible) {
                 /** @var ServiceRequestForm $submissible */
                 $scriptUrl = url('js/widgets/service-request-form/advising-app-service-request-form-widget.js?');
-                $formDefinitionUrl = URL::signedRoute('service-request-forms.define', ['serviceRequestForm' => $submissible]);
+                $formDefinitionUrl = URL::signedRoute(
+                    name: 'service-request-forms.define',
+                    parameters: ['serviceRequestForm' => $submissible],
+                    absolute: false,
+                );
 
                 return <<<EOD
                 <service-request-form-embed url="{$formDefinitionUrl}"></service-request-form-embed>

--- a/app-modules/form/src/Http/Controllers/FormWidgetController.php
+++ b/app-modules/form/src/Http/Controllers/FormWidgetController.php
@@ -68,9 +68,17 @@ class FormWidgetController extends Controller
                 'description' => $form->description,
                 'is_authenticated' => $form->is_authenticated,
                 ...($form->is_authenticated ? [
-                    'authentication_url' => URL::signedRoute('forms.request-authentication', ['form' => $form]),
+                    'authentication_url' => URL::signedRoute(
+                        name: 'forms.request-authentication',
+                        parameters: ['form' => $form],
+                        absolute: false,
+                    ),
                 ] : [
-                    'submission_url' => URL::signedRoute('forms.submit', ['form' => $form]),
+                    'submission_url' => URL::signedRoute(
+                        name: 'forms.submit',
+                        parameters: ['form' => $form],
+                        absolute: false,
+                    ),
                 ]),
                 'recaptcha_enabled' => $form->recaptcha_enabled,
                 ...($form->recaptcha_enabled ? [
@@ -112,10 +120,14 @@ class FormWidgetController extends Controller
 
         return response()->json([
             'message' => "We've sent an authentication code to {$data['email']}.",
-            'authentication_url' => URL::signedRoute('forms.authenticate', [
-                'form' => $form,
-                'authentication' => $authentication,
-            ]),
+            'authentication_url' => URL::signedRoute(
+                name: 'forms.authenticate',
+                parameters: [
+                    'form' => $form,
+                    'authentication' => $authentication,
+                ],
+                absolute: false,
+            ),
         ]);
     }
 
@@ -138,10 +150,14 @@ class FormWidgetController extends Controller
         ]);
 
         return response()->json([
-            'submission_url' => URL::signedRoute('forms.submit', [
-                'authentication' => $authentication,
-                'form' => $authentication->submissible,
-            ]),
+            'submission_url' => URL::signedRoute(
+                name: 'forms.submit',
+                parameters: [
+                    'authentication' => $authentication,
+                    'form' => $authentication->submissible,
+                ],
+                absolute: false,
+            ),
         ]);
     }
 

--- a/app-modules/meeting-center/routes/api.php
+++ b/app-modules/meeting-center/routes/api.php
@@ -47,16 +47,16 @@ Route::prefix('api')
             ->name('event-registration.')
             ->group(function () {
                 Route::get('/{event}', [EventRegistrationWidgetController::class, 'view'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('define');
                 Route::post('/{event}/authenticate/request', [EventRegistrationWidgetController::class, 'requestAuthentication'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('request-authentication');
                 Route::post('/{event}/authenticate/{authentication}', [EventRegistrationWidgetController::class, 'authenticate'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('authenticate');
                 Route::post('/{event}/submit', [EventRegistrationWidgetController::class, 'store'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('submit');
             });
     });

--- a/app-modules/meeting-center/src/Http/Controllers/EventRegistrationWidgetController.php
+++ b/app-modules/meeting-center/src/Http/Controllers/EventRegistrationWidgetController.php
@@ -70,7 +70,11 @@ class EventRegistrationWidgetController extends Controller
                 'name' => $form->event->title,
                 'description' => $form->event->description,
                 'is_authenticated' => true,
-                'authentication_url' => URL::signedRoute('event-registration.request-authentication', ['event' => $event]),
+                'authentication_url' => URL::signedRoute(
+                    name: 'event-registration.request-authentication',
+                    parameters: ['event' => $event],
+                    absolute: false,
+                ),
                 'recaptcha_enabled' => $form->recaptcha_enabled,
                 ...($form->recaptcha_enabled ? [
                     'recaptcha_site_key' => app(GoogleRecaptchaSettings::class)->site_key,
@@ -116,10 +120,14 @@ class EventRegistrationWidgetController extends Controller
 
         return response()->json([
             'message' => "We've sent an authentication code to {$attendee->email}.",
-            'authentication_url' => URL::signedRoute('event-registration.authenticate', [
-                'event' => $event,
-                'authentication' => $authentication,
-            ]),
+            'authentication_url' => URL::signedRoute(
+                name: 'event-registration.authenticate',
+                parameters: [
+                    'event' => $event,
+                    'authentication' => $authentication,
+                ],
+                absolute: false,
+            ),
         ]);
     }
 
@@ -142,10 +150,14 @@ class EventRegistrationWidgetController extends Controller
         ]);
 
         return response()->json([
-            'submission_url' => URL::signedRoute('event-registration.submit', [
-                'authentication' => $authentication,
-                'event' => $authentication->submissible->event,
-            ]),
+            'submission_url' => URL::signedRoute(
+                name: 'event-registration.submit',
+                parameters: [
+                    'authentication' => $authentication,
+                    'event' => $authentication->submissible->event,
+                ],
+                absolute: false,
+            ),
         ]);
     }
 

--- a/app-modules/portal/routes/api.php
+++ b/app-modules/portal/routes/api.php
@@ -53,10 +53,10 @@ Route::prefix('api')
             ->name('portal.knowledge-management.')
             ->group(function () {
                 Route::get('/', [KnowledgeManagementPortalController::class, 'show'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('define');
                 Route::post('/search', [KnowledgeManagementPortalSearchController::class, 'get'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('search');
                 Route::get('/categories/{category}', [KnowledgeManagementPortalCategoryController::class, 'show'])
                     ->name('category.show');

--- a/app-modules/portal/src/Actions/GeneratePortalEmbedCode.php
+++ b/app-modules/portal/src/Actions/GeneratePortalEmbedCode.php
@@ -48,8 +48,14 @@ class GeneratePortalEmbedCode
             PortalType::KnowledgeManagement => (function () {
                 $scriptUrl = url('js/portals/knowledge-management/advising-app-knowledge-management-portal.js?');
                 $portalAccessUrl = route('portals.knowledge-management.show');
-                $portalDefinitionUrl = URL::signedRoute('portal.knowledge-management.define');
-                $portalSearchUrl = URL::signedRoute('portal.knowledge-management.search');
+                $portalDefinitionUrl = URL::signedRoute(
+                    name: 'portal.knowledge-management.define',
+                    absolute: false,
+                );
+                $portalSearchUrl = URL::signedRoute(
+                    name: 'portal.knowledge-management.search',
+                    absolute: false,
+                );
                 $appUrl = parse_url(config('app.url'))['host'];
                 $apiUrl = route('portal.knowledge-management.define');
 

--- a/app-modules/service-management/routes/api.php
+++ b/app-modules/service-management/routes/api.php
@@ -50,16 +50,16 @@ Route::prefix('api')
             ->name('service-request-forms.')
             ->group(function () {
                 Route::get('/{serviceRequestForm}', [ServiceRequestFormWidgetController::class, 'view'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('define');
                 Route::post('/{serviceRequestForm}/authenticate/request', [ServiceRequestFormWidgetController::class, 'requestAuthentication'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('request-authentication');
                 Route::post('/{serviceRequestForm}/authenticate/{authentication}', [ServiceRequestFormWidgetController::class, 'authenticate'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('authenticate');
                 Route::post('/{serviceRequestForm}/submit', [ServiceRequestFormWidgetController::class, 'store'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('submit');
             });
     });

--- a/app-modules/service-management/src/Http/Controllers/ServiceRequestFormWidgetController.php
+++ b/app-modules/service-management/src/Http/Controllers/ServiceRequestFormWidgetController.php
@@ -68,9 +68,17 @@ class ServiceRequestFormWidgetController extends Controller
                 'description' => $serviceRequestForm->description,
                 'is_authenticated' => $serviceRequestForm->is_authenticated,
                 ...($serviceRequestForm->is_authenticated ? [
-                    'authentication_url' => URL::signedRoute('service-request-forms.request-authentication', ['serviceRequestForm' => $serviceRequestForm]),
+                    'authentication_url' => URL::signedRoute(
+                        name: 'service-request-forms.request-authentication',
+                        parameters: ['serviceRequestForm' => $serviceRequestForm],
+                        absolute: false
+                    ),
                 ] : [
-                    'submission_url' => URL::signedRoute('service-request-forms.submit', ['serviceRequestForm' => $serviceRequestForm]),
+                    'submission_url' => URL::signedRoute(
+                        name: 'service-request-forms.submit',
+                        parameters: ['serviceRequestForm' => $serviceRequestForm],
+                        absolute: false
+                    ),
                 ]),
                 'recaptcha_enabled' => $serviceRequestForm->recaptcha_enabled,
                 ...($serviceRequestForm->recaptcha_enabled ? [
@@ -111,10 +119,14 @@ class ServiceRequestFormWidgetController extends Controller
 
         return response()->json([
             'message' => "We've sent an authentication code to {$data['email']}.",
-            'authentication_url' => URL::signedRoute('service-request-forms.authenticate', [
-                'serviceRequestForm' => $serviceRequestForm,
-                'authentication' => $authentication,
-            ]),
+            'authentication_url' => URL::signedRoute(
+                name: 'service-request-forms.authenticate',
+                parameters: [
+                    'serviceRequestForm' => $serviceRequestForm,
+                    'authentication' => $authentication,
+                ],
+                absolute: false
+            ),
         ]);
     }
 
@@ -137,10 +149,14 @@ class ServiceRequestFormWidgetController extends Controller
         ]);
 
         return response()->json([
-            'submission_url' => URL::signedRoute('service-request-forms.submit', [
-                'authentication' => $authentication,
-                'serviceRequestForm' => $authentication->submissible,
-            ]),
+            'submission_url' => URL::signedRoute(
+                name: 'service-request-forms.submit',
+                parameters: [
+                    'authentication' => $authentication,
+                    'serviceRequestForm' => $authentication->submissible,
+                ],
+                absolute: false
+            ),
         ]);
     }
 

--- a/app-modules/survey/routes/api.php
+++ b/app-modules/survey/routes/api.php
@@ -49,16 +49,16 @@ Route::prefix('api')
             ->name('surveys.')
             ->group(function () {
                 Route::get('/{survey}', [SurveyWidgetController::class, 'view'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('define');
                 Route::post('/{survey}/authenticate/request', [SurveyWidgetController::class, 'requestAuthentication'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('request-authentication');
                 Route::post('/{survey}/authenticate/{authentication}', [SurveyWidgetController::class, 'authenticate'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('authenticate');
                 Route::post('/{survey}/submit', [SurveyWidgetController::class, 'store'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:relative'])
                     ->name('submit');
             });
     });

--- a/app-modules/survey/src/Http/Controllers/SurveyWidgetController.php
+++ b/app-modules/survey/src/Http/Controllers/SurveyWidgetController.php
@@ -68,9 +68,17 @@ class SurveyWidgetController extends Controller
                 'description' => $survey->description,
                 'is_authenticated' => $survey->is_authenticated,
                 ...($survey->is_authenticated ? [
-                    'authentication_url' => URL::signedRoute('surveys.request-authentication', ['survey' => $survey]),
+                    'authentication_url' => URL::signedRoute(
+                        name: 'surveys.request-authentication',
+                        parameters: ['survey' => $survey],
+                        absolute: false,
+                    ),
                 ] : [
-                    'submission_url' => URL::signedRoute('surveys.submit', ['survey' => $survey]),
+                    'submission_url' => URL::signedRoute(
+                        name: 'surveys.submit',
+                        parameters: ['survey' => $survey],
+                        absolute: false
+                    ),
                 ]),
                 'recaptcha_enabled' => $survey->recaptcha_enabled,
                 ...($survey->recaptcha_enabled ? [
@@ -111,10 +119,14 @@ class SurveyWidgetController extends Controller
 
         return response()->json([
             'message' => "We've sent an authentication code to {$data['email']}.",
-            'authentication_url' => URL::signedRoute('surveys.authenticate', [
-                'survey' => $survey,
-                'authentication' => $authentication,
-            ]),
+            'authentication_url' => URL::signedRoute(
+                name: 'surveys.authenticate',
+                parameters: [
+                    'survey' => $survey,
+                    'authentication' => $authentication,
+                ],
+                absolute: false
+            ),
         ]);
     }
 
@@ -137,10 +149,14 @@ class SurveyWidgetController extends Controller
         ]);
 
         return response()->json([
-            'submission_url' => URL::signedRoute('surveys.submit', [
-                'authentication' => $authentication,
-                'survey' => $authentication->submissible,
-            ]),
+            'submission_url' => URL::signedRoute(
+                name: 'surveys.submit',
+                parameters: [
+                    'authentication' => $authentication,
+                    'survey' => $authentication->submissible,
+                ],
+                absolute: false
+            ),
         ]);
     }
 

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -46,7 +46,7 @@ class TrustProxies extends Middleware
      *
      * @var array<int, string>|string|null
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -46,7 +46,7 @@ class TrustProxies extends Middleware
      *
      * @var array<int, string>|string|null
      */
-    protected $proxies = '*';
+    protected $proxies;
 
     /**
      * The headers that should be used to detect proxies.


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-320

### Technical Description

Fixes issues with Production portal and widget loading. Switch to only do relative signed URLs. Which will give us the same parameters protection we wanted without dealing with the LB redirect issues.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Content or styling update (Changes which don't affect functionality)
- [ ] DevOps
- [ ] Documentation

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [ ] Yes, please specify
- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `main` branch.
