### PR TITLE
[ADVAPP-295]: Prevent ALB Target Group tenant log pollution

### DIFF
--- a/app/Multitenancy/Http/Middleware/NeedsTenant.php
+++ b/app/Multitenancy/Http/Middleware/NeedsTenant.php
@@ -36,14 +36,10 @@
 
 namespace App\Multitenancy\Http\Middleware;
 
-use Spatie\Multitenancy\Exceptions\NoCurrentTenant;
-
 class NeedsTenant extends \Spatie\Multitenancy\Http\Middleware\NeedsTenant
 {
     public function handleInvalidRequest()
     {
-        report(NoCurrentTenant::make());
-
         return redirect(config('app.landlord_url'));
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-295

### Technical Description

Stops reporting the NoCurrentTenant Exception during the `NeedsTenant` check. Now, we just redirect to the landlord's main URL. There is no need or benefit to reporting this; it just pollutes the logs.

### Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Content or styling update (Changes which don't affect functionality)
- [ ] DevOps
- [ ] Documentation

### Screenshots (if appropriate)

### Any deployment steps required?

A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.

- [ ] Yes, please specify
- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `main` branch.
