### PR TITLE
[ADVAPP-301]: Align the experience for public profile features depending on assigned license

### DIFF
--- a/_ide_helper.macros.php
+++ b/_ide_helper.macros.php
@@ -40,7 +40,7 @@ namespace Filament\Forms\Components {
     class Checkbox
     {
         /**
-         * @source app/Providers/FilamentServiceProvider.php
+         * @see app/Providers/FilamentServiceProvider.php
          */
         public function lockedWithoutAnyLicenses(User $user, array $licenses): self
         {
@@ -51,7 +51,7 @@ namespace Filament\Forms\Components {
     class Toggle
     {
         /**
-         * @source app/Providers/FilamentServiceProvider.php
+         * @see app/Providers/FilamentServiceProvider.php
          */
         public function lockedWithoutAnyLicenses(User $user, array $licenses): self
         {

--- a/_ide_helper.macros.php
+++ b/_ide_helper.macros.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Filament\Forms\Components {
+    use App\Models\User;
+
+    class Checkbox
+    {
+        /**
+         * @source app/Providers/FilamentServiceProvider.php
+         */
+        public function lockedWithoutAnyLicenses(User $user, array $licenses): self
+        {
+            return $this;
+        }
+    }
+
+    class Toggle
+    {
+        /**
+         * @source app/Providers/FilamentServiceProvider.php
+         */
+        public function lockedWithoutAnyLicenses(User $user, array $licenses): self
+        {
+            return $this;
+        }
+    }
+}

--- a/_ide_helper.macros.php
+++ b/_ide_helper.macros.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace Filament\Forms\Components {
     use App\Models\User;
 

--- a/app/Filament/Pages/EditProfile.php
+++ b/app/Filament/Pages/EditProfile.php
@@ -63,6 +63,7 @@ use Illuminate\Validation\Rules\Password;
 use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\DateTimePicker;
 use Illuminate\Contracts\Auth\Authenticatable;
+use AdvisingApp\Authorization\Enums\LicenseType;
 use Filament\Pages\Concerns\InteractsWithFormActions;
 use AdvisingApp\MeetingCenter\Managers\CalendarManager;
 use Filament\Forms\Components\Actions\Action as FormAction;
@@ -148,7 +149,14 @@ class EditProfile extends Page
                     ->schema([
                         Toggle::make('has_enabled_public_profile')
                             ->label('Enable public profile')
-                            ->live(),
+                            ->live()
+                            ->afterStateHydrated(function ($component) {
+                                $component->lockedWithoutAnyLicenses(
+                                    component: $component,
+                                    user: auth()->user(),
+                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
+                                );
+                            }),
                         TextInput::make('public_profile_slug')
                             ->label('Url')
                             ->visible(fn (Get $get) => $get('has_enabled_public_profile'))
@@ -191,20 +199,41 @@ class EditProfile extends Page
                             ->hint(fn (Get $get): string => $get('is_bio_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile'),
                         Checkbox::make('is_bio_visible_on_profile')
                             ->label('Show Bio on profile')
-                            ->live(),
+                            ->live()
+                            ->afterStateHydrated(function ($component) {
+                                $component->lockedWithoutAnyLicenses(
+                                    component: $component,
+                                    user: auth()->user(),
+                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
+                                );
+                            }),
                         TextInput::make('phone_number')
                             ->label('Contact phone number')
                             ->integer()
                             ->hint(fn (Get $get): string => $get('is_phone_number_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile'),
                         Checkbox::make('is_phone_number_visible_on_profile')
                             ->label('Show phone number on profile')
-                            ->live(),
+                            ->live()
+                            ->afterStateHydrated(function ($component) {
+                                $component->lockedWithoutAnyLicenses(
+                                    component: $component,
+                                    user: auth()->user(),
+                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
+                                );
+                            }),
                         Select::make('pronouns_id')
                             ->relationship('pronouns', 'label')
                             ->hint(fn (Get $get): string => $get('are_pronouns_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile'),
                         Checkbox::make('are_pronouns_visible_on_profile')
                             ->label('Show Pronouns on profile')
-                            ->live(),
+                            ->live()
+                            ->afterStateHydrated(function ($component) {
+                                $component->lockedWithoutAnyLicenses(
+                                    component: $component,
+                                    user: auth()->user(),
+                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
+                                );
+                            }),
                         Placeholder::make('teams')
                             ->label(str('Team')->plural($user->teams->count()))
                             ->content($user->teams->pluck('name')->join(', ', ' and '))
@@ -233,7 +262,14 @@ class EditProfile extends Page
                             ->disabled($user->is_external),
                         Checkbox::make('is_email_visible_on_profile')
                             ->label('Show Email on profile')
-                            ->live(),
+                            ->live()
+                            ->afterStateHydrated(function ($component) {
+                                $component->lockedWithoutAnyLicenses(
+                                    component: $component,
+                                    user: auth()->user(),
+                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
+                                );
+                            }),
                         $this->getPasswordFormComponent()
                             ->hidden($user->is_external),
                         $this->getPasswordConfirmationFormComponent()
@@ -253,7 +289,14 @@ class EditProfile extends Page
                         Toggle::make('working_hours_are_enabled')
                             ->label('Set Working Hours')
                             ->live()
-                            ->hint(fn (Get $get): string => $get('are_working_hours_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile'),
+                            ->hint(fn (Get $get): string => $get('are_working_hours_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile')
+                            ->afterStateHydrated(function ($component) {
+                                $component->lockedWithoutAnyLicenses(
+                                    component: $component,
+                                    user: auth()->user(),
+                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
+                                );
+                            }),
                         Checkbox::make('are_working_hours_visible_on_profile')
                             ->label('Show Working Hours on profile')
                             ->visible(fn (Get $get) => $get('working_hours_are_enabled'))
@@ -267,7 +310,14 @@ class EditProfile extends Page
                     ->schema([
                         Toggle::make('office_hours_are_enabled')
                             ->label('Enable Office Hours')
-                            ->live(),
+                            ->live()
+                            ->afterStateHydrated(function ($component) {
+                                $component->lockedWithoutAnyLicenses(
+                                    component: $component,
+                                    user: auth()->user(),
+                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
+                                );
+                            }),
                         Checkbox::make('appointments_are_restricted_to_existing_students')
                             ->label('Restrict appointments to existing students')
                             ->visible(fn (Get $get) => $get('office_hours_are_enabled')),

--- a/app/Filament/Pages/EditProfile.php
+++ b/app/Filament/Pages/EditProfile.php
@@ -150,13 +150,7 @@ class EditProfile extends Page
                         Toggle::make('has_enabled_public_profile')
                             ->label('Enable public profile')
                             ->live()
-                            ->afterStateHydrated(function ($component) {
-                                $component->lockedWithoutAnyLicenses(
-                                    component: $component,
-                                    user: auth()->user(),
-                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
-                                );
-                            }),
+                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         TextInput::make('public_profile_slug')
                             ->label('Url')
                             ->visible(fn (Get $get) => $get('has_enabled_public_profile'))
@@ -200,13 +194,7 @@ class EditProfile extends Page
                         Checkbox::make('is_bio_visible_on_profile')
                             ->label('Show Bio on profile')
                             ->live()
-                            ->afterStateHydrated(function ($component) {
-                                $component->lockedWithoutAnyLicenses(
-                                    component: $component,
-                                    user: auth()->user(),
-                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
-                                );
-                            }),
+                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         TextInput::make('phone_number')
                             ->label('Contact phone number')
                             ->integer()
@@ -214,26 +202,14 @@ class EditProfile extends Page
                         Checkbox::make('is_phone_number_visible_on_profile')
                             ->label('Show phone number on profile')
                             ->live()
-                            ->afterStateHydrated(function ($component) {
-                                $component->lockedWithoutAnyLicenses(
-                                    component: $component,
-                                    user: auth()->user(),
-                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
-                                );
-                            }),
+                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         Select::make('pronouns_id')
                             ->relationship('pronouns', 'label')
                             ->hint(fn (Get $get): string => $get('are_pronouns_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile'),
                         Checkbox::make('are_pronouns_visible_on_profile')
                             ->label('Show Pronouns on profile')
                             ->live()
-                            ->afterStateHydrated(function ($component) {
-                                $component->lockedWithoutAnyLicenses(
-                                    component: $component,
-                                    user: auth()->user(),
-                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
-                                );
-                            }),
+                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         Placeholder::make('teams')
                             ->label(str('Team')->plural($user->teams->count()))
                             ->content($user->teams->pluck('name')->join(', ', ' and '))
@@ -263,13 +239,7 @@ class EditProfile extends Page
                         Checkbox::make('is_email_visible_on_profile')
                             ->label('Show Email on profile')
                             ->live()
-                            ->afterStateHydrated(function ($component) {
-                                $component->lockedWithoutAnyLicenses(
-                                    component: $component,
-                                    user: auth()->user(),
-                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
-                                );
-                            }),
+                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         $this->getPasswordFormComponent()
                             ->hidden($user->is_external),
                         $this->getPasswordConfirmationFormComponent()
@@ -290,13 +260,7 @@ class EditProfile extends Page
                             ->label('Set Working Hours')
                             ->live()
                             ->hint(fn (Get $get): string => $get('are_working_hours_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile')
-                            ->afterStateHydrated(function ($component) {
-                                $component->lockedWithoutAnyLicenses(
-                                    component: $component,
-                                    user: auth()->user(),
-                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
-                                );
-                            }),
+                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         Checkbox::make('are_working_hours_visible_on_profile')
                             ->label('Show Working Hours on profile')
                             ->visible(fn (Get $get) => $get('working_hours_are_enabled'))
@@ -311,13 +275,7 @@ class EditProfile extends Page
                         Toggle::make('office_hours_are_enabled')
                             ->label('Enable Office Hours')
                             ->live()
-                            ->afterStateHydrated(function ($component) {
-                                $component->lockedWithoutAnyLicenses(
-                                    component: $component,
-                                    user: auth()->user(),
-                                    licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]
-                                );
-                            }),
+                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         Checkbox::make('appointments_are_restricted_to_existing_students')
                             ->label('Restrict appointments to existing students')
                             ->visible(fn (Get $get) => $get('office_hours_are_enabled')),

--- a/app/Providers/FilamentServiceProvider.php
+++ b/app/Providers/FilamentServiceProvider.php
@@ -45,7 +45,6 @@ use Filament\Support\Colors\Color;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Checkbox;
 use Illuminate\Support\ServiceProvider;
-use Filament\Forms\Components\Component;
 use Filament\Support\Facades\FilamentView;
 use Filament\Support\Facades\FilamentColor;
 use Filament\Actions\Exports\Models\Export as BaseExport;
@@ -182,15 +181,17 @@ class FilamentServiceProvider extends ServiceProvider
             fn (): View => view('filament.footer'),
         );
 
-        Toggle::macro('lockedWithoutAnyLicenses', function (Component $component, User $user, array $licenses) {
-            $component->disabled(! $user->hasAnyLicense($licenses))
-                ->hintIcon(fn ($component) => $component->isDisabled() ? 'heroicon-m-lock-closed' : null)
+        Toggle::macro('lockedWithoutAnyLicenses', function (User $user, array $licenses) {
+            /** @var Toggle $this */
+            return $this->disabled(! $user->hasAnyLicense($licenses))
+                ->hintIcon(fn (Toggle $component) => $component->isDisabled() ? 'heroicon-m-lock-closed' : null)
                 ->hintIconTooltip('A CRM license is required for our public profile features.');
         });
 
-        Checkbox::macro('lockedWithoutAnyLicenses', function (Component $component, User $user, array $licenses) {
-            $component->disabled(! $user->hasAnyLicense($licenses))
-                ->hintIcon(fn ($component) => $component->isDisabled() ? 'heroicon-m-lock-closed' : null)
+        Checkbox::macro('lockedWithoutAnyLicenses', function (User $user, array $licenses) {
+            /** @var Checkbox $this */
+            return $this->disabled(! $user->hasAnyLicense($licenses))
+                ->hintIcon(fn (Checkbox $component) => $component->isDisabled() ? 'heroicon-m-lock-closed' : null)
                 ->hintIconTooltip('A CRM license is required for our public profile features.');
         });
     }

--- a/app/Providers/FilamentServiceProvider.php
+++ b/app/Providers/FilamentServiceProvider.php
@@ -36,12 +36,16 @@
 
 namespace App\Providers;
 
+use App\Models\User;
 use App\Models\Export;
 use App\Models\Import;
 use Illuminate\View\View;
 use App\Models\FailedImportRow;
 use Filament\Support\Colors\Color;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Components\Checkbox;
 use Illuminate\Support\ServiceProvider;
+use Filament\Forms\Components\Component;
 use Filament\Support\Facades\FilamentView;
 use Filament\Support\Facades\FilamentColor;
 use Filament\Actions\Exports\Models\Export as BaseExport;
@@ -177,5 +181,17 @@ class FilamentServiceProvider extends ServiceProvider
             'panels::footer',
             fn (): View => view('filament.footer'),
         );
+
+        Toggle::macro('lockedWithoutAnyLicenses', function (Component $component, User $user, array $licenses) {
+            $component->disabled(! $user->hasAnyLicense($licenses))
+                ->hintIcon(fn ($component) => $component->isDisabled() ? 'heroicon-m-lock-closed' : null)
+                ->hintIconTooltip('A CRM license is required for our public profile features.');
+        });
+
+        Checkbox::macro('lockedWithoutAnyLicenses', function (Component $component, User $user, array $licenses) {
+            $component->disabled(! $user->hasAnyLicense($licenses))
+                ->hintIcon(fn ($component) => $component->isDisabled() ? 'heroicon-m-lock-closed' : null)
+                ->hintIconTooltip('A CRM license is required for our public profile features.');
+        });
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-301

### Technical Description

This PR adds license checks for the authenticated user into public profile based settings.

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Screenshots (if appropriate)

### Any deployment steps required?

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `main` branch.
