### PR TITLE
[ADVAPP-333]: Error Loading Portal using embed code on wordpress site

### DIFF
--- a/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
+++ b/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
@@ -53,10 +53,12 @@ class GenerateSubmissibleEmbedCode
         return match ($submissible::class) {
             Form::class => (function () use ($submissible) {
                 $scriptUrl = url('js/widgets/form/advising-app-form-widget.js?');
-                $formDefinitionUrl = URL::signedRoute(
-                    name: 'forms.define',
-                    parameters: ['form' => $submissible],
-                    absolute: false,
+                $formDefinitionUrl = URL::to(
+                    URL::signedRoute(
+                        name: 'forms.define',
+                        parameters: ['form' => $submissible],
+                        absolute: false,
+                    )
                 );
 
                 return <<<EOD
@@ -66,10 +68,12 @@ class GenerateSubmissibleEmbedCode
             })(),
             Application::class => (function () use ($submissible) {
                 $scriptUrl = url('js/widgets/application/advising-app-application-widget.js?');
-                $applicationDefinitionUrl = URL::signedRoute(
-                    name: 'applications.define',
-                    parameters: ['application' => $submissible],
-                    absolute: false,
+                $applicationDefinitionUrl = URL::to(
+                    URL::signedRoute(
+                        name: 'applications.define',
+                        parameters: ['application' => $submissible],
+                        absolute: false,
+                    )
                 );
 
                 return <<<EOD
@@ -79,10 +83,12 @@ class GenerateSubmissibleEmbedCode
             })(),
             Survey::class => (function () use ($submissible) {
                 $scriptUrl = url('js/widgets/survey/advising-app-survey-widget.js?');
-                $surveyDefinitionUrl = URL::signedRoute(
-                    name: 'surveys.define',
-                    parameters: ['survey' => $submissible],
-                    absolute: false,
+                $surveyDefinitionUrl = URL::to(
+                    URL::signedRoute(
+                        name: 'surveys.define',
+                        parameters: ['survey' => $submissible],
+                        absolute: false,
+                    )
                 );
 
                 return <<<EOD
@@ -93,10 +99,12 @@ class GenerateSubmissibleEmbedCode
             EventRegistrationForm::class => (function () use ($submissible) {
                 /** @var EventRegistrationForm $submissible */
                 $scriptUrl = url('js/widgets/events/advising-app-event-registration-form-widget.js?');
-                $formDefinitionUrl = URL::signedRoute(
-                    name: 'event-registration.define',
-                    parameters: ['event' => $submissible->event],
-                    absolute: false,
+                $formDefinitionUrl = URL::to(
+                    URL::signedRoute(
+                        name: 'event-registration.define',
+                        parameters: ['event' => $submissible->event],
+                        absolute: false,
+                    )
                 );
 
                 return <<<EOD
@@ -107,10 +115,12 @@ class GenerateSubmissibleEmbedCode
             ServiceRequestForm::class => (function () use ($submissible) {
                 /** @var ServiceRequestForm $submissible */
                 $scriptUrl = url('js/widgets/service-request-form/advising-app-service-request-form-widget.js?');
-                $formDefinitionUrl = URL::signedRoute(
-                    name: 'service-request-forms.define',
-                    parameters: ['serviceRequestForm' => $submissible],
-                    absolute: false,
+                $formDefinitionUrl = URL::to(
+                    URL::signedRoute(
+                        name: 'service-request-forms.define',
+                        parameters: ['serviceRequestForm' => $submissible],
+                        absolute: false,
+                    )
                 );
 
                 return <<<EOD

--- a/app-modules/portal/src/Actions/GeneratePortalEmbedCode.php
+++ b/app-modules/portal/src/Actions/GeneratePortalEmbedCode.php
@@ -47,16 +47,25 @@ class GeneratePortalEmbedCode
         return match ($portal) {
             PortalType::KnowledgeManagement => (function () {
                 $scriptUrl = url('js/portals/knowledge-management/advising-app-knowledge-management-portal.js?');
+
                 $portalAccessUrl = route('portals.knowledge-management.show');
-                $portalDefinitionUrl = URL::signedRoute(
-                    name: 'portal.knowledge-management.define',
-                    absolute: false,
+
+                $portalDefinitionUrl = URL::to(
+                    URL::signedRoute(
+                        name: 'portal.knowledge-management.define',
+                        absolute: false,
+                    )
                 );
-                $portalSearchUrl = URL::signedRoute(
-                    name: 'portal.knowledge-management.search',
-                    absolute: false,
+
+                $portalSearchUrl = URL::to(
+                    URL::signedRoute(
+                        name: 'portal.knowledge-management.search',
+                        absolute: false,
+                    )
                 );
+
                 $appUrl = parse_url(config('app.url'))['host'];
+
                 $apiUrl = route('portal.knowledge-management.define');
 
                 return <<<EOD


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-333

### Technical Description

This fixes an issue stemming from widget/portal related signed URLs being relative, and therefore inaccessible when trying to embed.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots (if appropriate)

### Any deployment steps required?

- [x] No

_______________________________________________

## Before contributing and submitting this PR, make sure you have:
* [x] Read the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
* [x] Title the PR with the ticket/issue number and a short description of the changes made. Or if no ticket/issue exists, title the PR with a short description of the changes made
* [x] Linked a relevant ticket or issue or describe the issue/feature which this PR resolves/implements.
* [x] Resolved all conflicts, if any.
* [x] Rebased your branch PR on top of the latest upstream `main` branch.
