### PR TITLE
[ADVAPP-334]: Embed issue with navigation bar

### DIFF
--- a/portals/knowledge-management/src/Components/DesktopSidebar.vue
+++ b/portals/knowledge-management/src/Components/DesktopSidebar.vue
@@ -44,7 +44,7 @@ defineProps({
 </script>
 
 <template>
-    <div class="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
+    <div class="hidden lg:fixed h-full lg:z-50 lg:flex lg:w-72 lg:flex-col">
         <div class="flex grow flex-col gap-y-5 overflow-y-auto bg-primary-700 px-6 pb-4">
             <SidebarContent :categories="categories"></SidebarContent>
         </div>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-334

### Technical Description

> This PR adjusts navbar styling so that it is appropriately rendered when embedded inside of another app

### Screenshots (if appropriate)

Before:

<img width="1313" alt="Screenshot 2024-02-19 at 3 56 56 PM" src="https://github.com/canyongbs/advisingapp/assets/10821263/2d2e1e04-4eff-48f6-955e-ea914460e6ac">


After:

<img width="1320" alt="Screenshot 2024-02-19 at 3 55 48 PM" src="https://github.com/canyongbs/advisingapp/assets/10821263/bfc9d345-3086-4a2a-b95b-ba7f74338e95">


### Any deployment steps required?

> No 

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
