### PR TITLE
[ADVAPP-49]: Display whether or not a User is currently active in chat

### DIFF
--- a/app-modules/in-app-communication/resources/js/userToUserChat.js
+++ b/app-modules/in-app-communication/resources/js/userToUserChat.js
@@ -50,7 +50,7 @@ document.addEventListener('alpine:init', () => {
 
     let conversationsClient = null;
 
-    Alpine.data('userToUserChat', ({ selectedConversation, users }) => ({
+    Alpine.data('userToUserChat', ({ selectedConversation, users, activeUsers }) => ({
         loading: true,
         loadingMessage: 'Loading chat…',
         error: false,
@@ -61,6 +61,7 @@ document.addEventListener('alpine:init', () => {
         messages: [],
         message: '',
         usersTyping: [],
+        activeUsers,
         submit: function () {
             if (this.conversation === null) return;
 
@@ -187,6 +188,7 @@ document.addEventListener('alpine:init', () => {
                     this.messages.push({
                         avatar: await this.getAvatarUrl(message.author),
                         author: await this.getAuthorName(message.author),
+                        authorId: message.author,
                         date: message.dateCreated,
                         message: message,
                     });
@@ -205,6 +207,7 @@ document.addEventListener('alpine:init', () => {
                         this.messages[index] = {
                             avatar: await this.getAvatarUrl(data.message.author),
                             author: await this.getAuthorName(data.message.author),
+                            authorId: data.message.author,
                             data: data.message.dateCreated,
                             message: data.message,
                         };
@@ -264,6 +267,7 @@ document.addEventListener('alpine:init', () => {
                         this.messages.push({
                             avatar: await this.getAvatarUrl(message.author),
                             author: await this.getAuthorName(message.author),
+                            authorId: message.author,
                             date: message.dateCreated,
                             message: message,
                         });
@@ -291,6 +295,7 @@ document.addEventListener('alpine:init', () => {
                             this.messages.unshift({
                                 avatar: await this.getAvatarUrl(message.author),
                                 author: await this.getAuthorName(message.author),
+                                authorId: message.author,
                                 date: message.dateCreated,
                                 message: message,
                             });

--- a/app-modules/in-app-communication/resources/views/filament/pages/user-chat.blade.php
+++ b/app-modules/in-app-communication/resources/views/filament/pages/user-chat.blade.php
@@ -164,8 +164,13 @@
             @if ($conversation)
                 <div
                     class="col-span-1 flex h-full flex-col gap-2 overflow-hidden md:col-span-3"
-                    x-data="userToUserChat({ selectedConversation: @js($conversation->getKey()), users: @js($users) })"
+                    x-data="userToUserChat({
+                        selectedConversation: @js($conversation->getKey()),
+                        users: @js($users),
+                        activeUsers: $wire.$entangle('conversationActiveUsers'),
+                    })"
                     wire:key="conversation-{{ $conversation->getKey() }}"
+                    wire:poll.60s="loadConversationActiveUsers"
                 >
                     <div
                         class="flex flex-col items-center self-center"
@@ -213,12 +218,22 @@
                                             <div
                                                 class="mx-auto flex flex-1 gap-6 text-base md:max-w-2xl lg:max-w-[38rem] xl:max-w-3xl">
                                                 <div class="relative mt-1 flex flex-shrink-0 flex-col items-end">
-                                                    <x-filament::avatar
-                                                        class="rounded-full"
-                                                        alt="User Avatar"
-                                                        x-bind:src="message.avatar"
-                                                        size="lg"
-                                                    />
+                                                    <div class="relative">
+                                                        <x-filament::avatar
+                                                            class="rounded-full"
+                                                            alt="User Avatar"
+                                                            x-bind:src="message.avatar"
+                                                            size="lg"
+                                                        />
+
+                                                        <div
+                                                            x-bind:class="{
+                                                                'bg-success-500': activeUsers.includes(message.authorId),
+                                                                'bg-gray-500': !activeUsers.includes(message.authorId),
+                                                            }"
+                                                            class="absolute h-3 w-3 rounded-full bottom-0 end-0"
+                                                        ></div>
+                                                    </div>
                                                 </div>
                                                 <div
                                                     class="relative flex w-[calc(100%-50px)] flex-col lg:w-[calc(100%-115px)]">

--- a/app-modules/in-app-communication/resources/views/filament/pages/user-chat.blade.php
+++ b/app-modules/in-app-communication/resources/views/filament/pages/user-chat.blade.php
@@ -227,11 +227,12 @@
                                                         />
 
                                                         <div
+                                                            class="absolute bottom-0 end-0 h-3 w-3 rounded-full"
                                                             x-bind:class="{
-                                                                'bg-success-500': activeUsers.includes(message.authorId),
+                                                                'bg-success-500': activeUsers.includes(message
+                                                                    .authorId),
                                                                 'bg-gray-500': !activeUsers.includes(message.authorId),
                                                             }"
-                                                            class="absolute h-3 w-3 rounded-full bottom-0 end-0"
                                                         ></div>
                                                     </div>
                                                 </div>

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -138,6 +138,7 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
         'working_hours_are_enabled' => 'boolean',
         'are_working_hours_visible_on_profile' => 'boolean',
         'working_hours' => 'array',
+        'last_chat_ping_at' => 'immutable_datetime',
     ];
 
     protected $fillable = [
@@ -171,6 +172,7 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
         'are_working_hours_visible_on_profile',
         'working_hours',
         'job_title',
+        'last_chat_ping_at',
     ];
 
     public $orderable = [

--- a/database/migrations/2024_03_04_165304_add_last_chat_ping_at_column_to_users_table.php
+++ b/database/migrations/2024_03_04_165304_add_last_chat_ping_at_column_to_users_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2024_03_04_165304_add_last_chat_ping_at_column_to_users_table.php
+++ b/database/migrations/2024_03_04_165304_add_last_chat_ping_at_column_to_users_table.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dateTime('last_chat_ping_at')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-49

### Technical Description

Every 60 seconds, the chat will send an HTTP request. This request will inform the server that the user is currently viewing *a* chat. The server will respond by informing the client which users in the current chat are also active. The chat app frontend can use that list of active users to display the status dots. When a new conversation is loaded, the same process happens.