### PR TITLE
[ADVAPP-398]: Ensure that portal login only uses student and prospect guards

### DIFF
--- a/app-modules/portal/routes/api.php
+++ b/app-modules/portal/routes/api.php
@@ -57,7 +57,11 @@ Route::prefix('api')
     ->group(function () {
         Route::middleware(['auth:sanctum'])->group(function () {
             Route::get('/user', function (Request $request) {
-                return $request->user();
+                $user = auth('student')->user() ?? auth('prospect')->user() ?? $request->user();
+
+                if (! auth('web')->check()) {
+                    return $user;
+                }
             })->name('user.auth-check');
         });
 

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagement/KnowledgeManagementPortalLogoutController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagement/KnowledgeManagementPortalLogoutController.php
@@ -46,13 +46,11 @@ class KnowledgeManagementPortalLogoutController extends Controller
     public function __invoke(Request $request)
     {
         /** @var Student|Prospect $user */
-        $user = auth('prospect')->user() ?? auth('student')->user();
+        $user = auth('student')->user() ?? auth('prospect')->user();
 
         $user->tokens()->where('name', 'knowledge-management-portal-access-token')->delete();
 
-        if ($request->hasSession()) {
-            $request->session()->invalidate();
-        }
+        auth('student')->logout() ?? auth('prospect')->logout();
 
         return response()->json([
             'success' => true,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-398

### Technical Description

> This PR ensures that an application user must be properly authenticated through the student or prospect guards in order to use the Knowledge Management portal, regardless of session authentication via the web guard.

### Screenshots (if appropriate)

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
