### PR TITLE
[ADVAPP-407] && [ADVAPP-408] && [ADVAPP-423]: Implement Rich Text Editing and Templates in Campaign Journey Step

### DIFF
--- a/app-modules/caseload-management/src/Filament/Resources/CaseloadResource/Pages/GetCaseloadQuery.php
+++ b/app-modules/caseload-management/src/Filament/Resources/CaseloadResource/Pages/GetCaseloadQuery.php
@@ -42,7 +42,7 @@ use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Builder;
 use Filament\Tables\Concerns\InteractsWithTable;
 use AdvisingApp\CaseloadManagement\Enums\CaseloadType;
-use AdvisingApp\CaseloadManagement\Filament\Resources\CaseloadResource;
+use AdvisingApp\CaseloadManagement\Filament\Resources\CaseloadResourceForProcesses;
 
 class GetCaseloadQuery extends EditRecord implements HasTable
 {
@@ -50,7 +50,7 @@ class GetCaseloadQuery extends EditRecord implements HasTable
         bootedInteractsWithTable as baseBootedInteractsWithTable;
     }
 
-    protected static string $resource = CaseloadResource::class;
+    protected static string $resource = CaseloadResourceForProcesses::class;
 
     public function mount(int | string $record): void
     {

--- a/app-modules/caseload-management/src/Filament/Resources/CaseloadResourceForProcesses.php
+++ b/app-modules/caseload-management/src/Filament/Resources/CaseloadResourceForProcesses.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\CaseloadManagement\Filament\Resources;
+
+use Filament\Resources\Resource;
+use AdvisingApp\CaseloadManagement\Models\Caseload;
+
+class CaseloadResourceForProcesses extends Resource
+{
+    protected static ?string $model = Caseload::class;
+
+    protected static bool $isGloballySearchable = false;
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    public static function canAccess(array $parameters = []): bool
+    {
+        return true;
+    }
+}

--- a/database/seeders/NewTenantSeeder.php
+++ b/database/seeders/NewTenantSeeder.php
@@ -56,7 +56,6 @@ use AdvisingApp\ServiceManagement\Database\Seeders\ServiceRequestTypeSeeder;
 use AdvisingApp\ServiceManagement\Database\Seeders\ChangeRequestStatusSeeder;
 use AdvisingApp\Application\Database\Seeders\ApplicationSubmissionStateSeeder;
 use AdvisingApp\ServiceManagement\Database\Seeders\ServiceRequestStatusSeeder;
-use AdvisingApp\InventoryManagement\Database\Seeders\MaintenanceProviderSeeder;
 
 class NewTenantSeeder extends Seeder
 {
@@ -91,8 +90,6 @@ class NewTenantSeeder extends Seeder
             ApplicationSubmissionStateSeeder::class,
             // InventoryManagement
             ...AssetSeeder::metadataSeeders(),
-            AssetSeeder::class,
-            MaintenanceProviderSeeder::class,
             AnalyticsResourceSourceSeeder::class,
             AnalyticsResourceCategorySeeder::class,
 

--- a/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
@@ -34,6 +34,7 @@
 @php
     use Carbon\Carbon;
     use AdvisingApp\Campaign\Settings\CampaignSettings;
+    use AdvisingApp\Engagement\Models\EngagementBatch;
 @endphp
 
 <x-filament::fieldset>
@@ -54,10 +55,12 @@
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Subject</dt>
             <dd class="text-sm font-semibold">{{ $action['subject'] }}</dd>
         </div>
-        <div class="flex flex-col pt-3">
-            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Body</dt>
-            <dd class="text-sm font-semibold">{{ $action['body'] }}</dd>
-        </div>
+        @if($action['body'])
+            <div class="flex flex-col pt-3">
+                <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Body</dt>
+                <dd class="text-sm font-semibold">{!! EngagementBatch::renderWithMergeTags(tiptap_converter()->asHTML($action['body'])) !!}</dd>
+            </div>
+        @endif
         <div class="flex flex-col pt-3">
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Execute At</dt>
             <dd class="text-sm font-semibold">{{ Carbon::parse($action['execute_at'])->format('M j, Y H:i:s') }}

--- a/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
@@ -55,7 +55,7 @@
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Subject</dt>
             <dd class="text-sm font-semibold">{{ $action['subject'] }}</dd>
         </div>
-        @if($action['body'])
+        @if ($action['body'])
             <div class="flex flex-col pt-3">
                 <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Body</dt>
                 <dd class="text-sm font-semibold">{!! EngagementBatch::renderWithMergeTags(tiptap_converter()->asHTML($action['body'])) !!}</dd>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-407
- https://canyongbs.atlassian.net/browse/ADVAPP-408
- https://canyongbs.atlassian.net/browse/ADVAPP-423

### Technical Description

> This PR adds the ability to utilize templates and the rich text editor within a campaign journey step for emails/texts. This also resolves an issue with campaign execution that stemmed from the implementation of proper permissions for resources.

### Screenshots (if appropriate)

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
