### PR TITLE
[ADVAPP-426]: Emailed chats include broken link to logo

### DIFF
--- a/resources/views/vendor/mail/html/header.blade.php
+++ b/resources/views/vendor/mail/html/header.blade.php
@@ -53,7 +53,7 @@
                      style="height: 75px; max-height: 75px; max-width: 100vw;"
                      alt="{{ config('app.name') }}">
             @else
-                <img src="{{ config('app.url') . Vite::asset('resources/images/default-logo-light.png') }}"
+                <img src="{{ url(Vite::asset('resources/images/default-logo-light.png')) }}"
                      style="height: 75px; max-height: 75px; max-width: 100vw;"
                      alt="{{ config('app.name') }}">
             @endif

--- a/resources/views/vendor/mail/html/header.blade.php
+++ b/resources/views/vendor/mail/html/header.blade.php
@@ -53,7 +53,7 @@
                      style="height: 75px; max-height: 75px; max-width: 100vw;"
                      alt="{{ config('app.name') }}">
             @else
-                <img src="{{ Vite::asset('resources/images/default-logo-light.png') }}"
+                <img src="{{ config('app.url') . Vite::asset('resources/images/default-logo-light.png') }}"
                      style="height: 75px; max-height: 75px; max-width: 100vw;"
                      alt="{{ config('app.name') }}">
             @endif


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-426

### Technical Description

> Prepend the app url to the asset so the file can be referenced in the email header.

### Screenshots (if appropriate)

![Screenshot 2024-03-18 at 12 41 26 PM](https://github.com/canyongbs/advisingapp/assets/10821263/59e4888d-aaa0-4406-8483-61d805fe42ae)


### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
