### PR TITLE
[ADVAPP-434]: Currently some subdomains present a 401 error when accessing & [ADVAPP-373]: Tenant connections not using DB for sessions

### DIFF
--- a/app/Multitenancy/Tasks/SwitchSessionDriver.php
+++ b/app/Multitenancy/Tasks/SwitchSessionDriver.php
@@ -74,5 +74,8 @@ class SwitchSessionDriver implements SwitchTenantTask
             'session.driver' => $driver,
             'session.connection' => $connection,
         ]);
+
+        app()->forgetInstance('session');
+        app()->forgetInstance('session.store');
     }
 }

--- a/app/Multitenancy/Tasks/SwitchSessionDriver.php
+++ b/app/Multitenancy/Tasks/SwitchSessionDriver.php
@@ -44,9 +44,11 @@ class SwitchSessionDriver implements SwitchTenantTask
     public function __construct(
         protected ?string $originalSessionDriver = null,
         protected ?string $originalSessionConnection = null,
+        protected ?string $originalSessionDomain = null,
     ) {
         $this->originalSessionDriver ??= config('session.driver');
         $this->originalSessionConnection ??= config('session.connection');
+        $this->originalSessionDomain ??= config('session.domain');
     }
 
     public function makeCurrent(Tenant $tenant): void
@@ -56,7 +58,11 @@ class SwitchSessionDriver implements SwitchTenantTask
             return;
         }
 
-        $this->setSessionConfig('database', 'tenant');
+        $this->setSessionConfig(
+            driver: 'database',
+            connection: 'tenant',
+            domain: $tenant->domain,
+        );
     }
 
     public function forgetCurrent(): void
@@ -65,14 +71,19 @@ class SwitchSessionDriver implements SwitchTenantTask
             return;
         }
 
-        $this->setSessionConfig($this->originalSessionDriver, $this->originalSessionConnection);
+        $this->setSessionConfig(
+            driver: $this->originalSessionDriver,
+            connection: $this->originalSessionConnection,
+            domain: $this->originalSessionDomain,
+        );
     }
 
-    protected function setSessionConfig(string $driver, string $connection): void
+    protected function setSessionConfig(string $driver, string $connection, string $domain): void
     {
         config([
             'session.driver' => $driver,
             'session.connection' => $connection,
+            'session.domain' => $domain,
         ]);
 
         app()->forgetInstance('session');


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-434
- https://canyongbs.atlassian.net/browse/ADVAPP-373

### Technical Description

Fixes the session tenancy switch task to ensure that the session singletons are flushes so that the app will use the session driver changes. It also sets the session domain to be the tenant domain so that sessions are not shared between tenant URLs.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
