### PR TITLE
[Hotfix] Ensure we run filament:assets on startup

### DIFF
--- a/docker/s6-overlay/scripts/build-assets
+++ b/docker/s6-overlay/scripts/build-assets
@@ -17,5 +17,7 @@ if [ "${BUILD_ASSETS:="false"}" == "true" ]; then
 
     USERNAME=$(id -nu "$PUID")
 
+    s6-setuidgid "$USERNAME" php -d variables_order=EGPCS "$WEBUSER_HOME"/artisan filament:assets
+
     s6-setuidgid "$USERNAME" php -d variables_order=EGPCS "$WEBUSER_HOME"/artisan app:build-assets vite
 fi


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Ensures Filament assets are published on container startup.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
