### PR TITLE
[ADVAPP-427]: Update email copyright template

### DIFF
--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -55,7 +55,7 @@
     {{-- Footer --}}
     <x-slot:footer>
         <x-mail::footer>
-            © {{ date('Y') }} {{ config('app.name') }}. @lang('All rights reserved.')
+            This email was sent using Advising App™. <br /> <br /> © 2016-{{ date('Y') }} Canyon GBS LLC. All Rights Reserved. Canyon GBS™ and Advising App™ are trademarks of Canyon GBS LLC.
         </x-mail::footer>
     </x-slot:footer>
 </x-mail::layout>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-427

### Technical Description

`<br />` had to be used instead of line breaks otherwise Markdown treated the indentation as a code block.

### Screenshots (if appropriate)

<img width="724" alt="Screenshot 2024-03-26 at 14 16 56" src="https://github.com/canyongbs/advisingapp/assets/41773797/e2bf674d-55de-43a2-be07-17193f6ef14b">
