### PR TITLE
[ADVAPP-462]: Resolve embed snippet for forms

### DIFF
--- a/app-modules/application/src/Filament/Resources/ApplicationResource/Pages/EditApplication.php
+++ b/app-modules/application/src/Filament/Resources/ApplicationResource/Pages/EditApplication.php
@@ -36,8 +36,10 @@
 
 namespace AdvisingApp\Application\Filament\Resources\ApplicationResource\Pages;
 
+use Illuminate\Support\Str;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
+use Illuminate\Support\HtmlString;
 use Filament\Forms\Form as FilamentForm;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Infolists\Components\TextEntry;
@@ -76,13 +78,14 @@ class EditApplication extends EditRecord
                             ->state(function (Application $application) {
                                 $code = resolve(GenerateSubmissibleEmbedCode::class)->handle($application);
 
-                                return <<<EOD
+                                $state = <<<EOD
                                 ```
                                 {$code}
                                 ```
                                 EOD;
+
+                                return new HtmlString(Str::markdown($state));
                             })
-                            ->markdown()
                             ->copyable()
                             ->copyableState(fn (Application $application) => resolve(GenerateSubmissibleEmbedCode::class)->handle($application))
                             ->copyMessage('Copied!')

--- a/app-modules/application/src/Filament/Resources/ApplicationResource/Pages/EditApplication.php
+++ b/app-modules/application/src/Filament/Resources/ApplicationResource/Pages/EditApplication.php
@@ -36,10 +36,8 @@
 
 namespace AdvisingApp\Application\Filament\Resources\ApplicationResource\Pages;
 
-use Illuminate\Support\Str;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
-use Illuminate\Support\HtmlString;
 use Filament\Forms\Form as FilamentForm;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Infolists\Components\TextEntry;
@@ -84,7 +82,7 @@ class EditApplication extends EditRecord
                                 ```
                                 EOD;
 
-                                return new HtmlString(Str::markdown($state));
+                                return str($state)->markdown()->toHtmlString();
                             })
                             ->copyable()
                             ->copyableState(fn (Application $application) => resolve(GenerateSubmissibleEmbedCode::class)->handle($application))

--- a/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
+++ b/app-modules/form/src/Actions/GenerateSubmissibleEmbedCode.php
@@ -49,7 +49,6 @@ class GenerateSubmissibleEmbedCode
 {
     public function handle(Submissible $submissible): string
     {
-        // TODO Clean this up
         return match ($submissible::class) {
             Form::class => (function () use ($submissible) {
                 $scriptUrl = url('js/widgets/form/advising-app-form-widget.js?');

--- a/app-modules/form/src/Filament/Resources/FormResource/Pages/EditForm.php
+++ b/app-modules/form/src/Filament/Resources/FormResource/Pages/EditForm.php
@@ -36,11 +36,9 @@
 
 namespace AdvisingApp\Form\Filament\Resources\FormResource\Pages;
 
-use Illuminate\Support\Str;
 use Filament\Actions\Action;
 use AdvisingApp\Form\Models\Form;
 use Filament\Actions\DeleteAction;
-use Illuminate\Support\HtmlString;
 use Filament\Forms\Form as FilamentForm;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Infolists\Components\TextEntry;
@@ -84,7 +82,7 @@ class EditForm extends EditRecord
                                 ```
                                 EOD;
 
-                                return new HtmlString(Str::markdown($state));
+                                return str($state)->markdown()->toHtmlString();
                             })
                             ->copyable()
                             ->copyableState(fn (Form $form) => resolve(GenerateSubmissibleEmbedCode::class)->handle($form))

--- a/app-modules/form/src/Filament/Resources/FormResource/Pages/EditForm.php
+++ b/app-modules/form/src/Filament/Resources/FormResource/Pages/EditForm.php
@@ -36,9 +36,11 @@
 
 namespace AdvisingApp\Form\Filament\Resources\FormResource\Pages;
 
+use Illuminate\Support\Str;
 use Filament\Actions\Action;
 use AdvisingApp\Form\Models\Form;
 use Filament\Actions\DeleteAction;
+use Illuminate\Support\HtmlString;
 use Filament\Forms\Form as FilamentForm;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Infolists\Components\TextEntry;
@@ -76,13 +78,14 @@ class EditForm extends EditRecord
                             ->state(function (Form $form) {
                                 $code = resolve(GenerateSubmissibleEmbedCode::class)->handle($form);
 
-                                return <<<EOD
+                                $state = <<<EOD
                                 ```
                                 {$code}
                                 ```
                                 EOD;
+
+                                return new HtmlString(Str::markdown($state));
                             })
-                            ->markdown()
                             ->copyable()
                             ->copyableState(fn (Form $form) => resolve(GenerateSubmissibleEmbedCode::class)->handle($form))
                             ->copyMessage('Copied!')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestFormResource/Pages/EditServiceRequestForm.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestFormResource/Pages/EditServiceRequestForm.php
@@ -37,8 +37,10 @@
 namespace AdvisingApp\ServiceManagement\Filament\Resources\ServiceRequestFormResource\Pages;
 
 use Filament\Forms\Form;
+use Illuminate\Support\Str;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
+use Illuminate\Support\HtmlString;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Infolists\Components\TextEntry;
 use AdvisingApp\Form\Actions\GenerateSubmissibleEmbedCode;
@@ -74,13 +76,14 @@ class EditServiceRequestForm extends EditRecord
                             ->state(function (ServiceRequestForm $serviceRequestForm) {
                                 $code = resolve(GenerateSubmissibleEmbedCode::class)->handle($serviceRequestForm);
 
-                                return <<<EOD
+                                $state = <<<EOD
                                 ```
                                 {$code}
                                 ```
                                 EOD;
+
+                                return new HtmlString(Str::markdown($state));
                             })
-                            ->markdown()
                             ->copyable()
                             ->copyableState(fn (ServiceRequestForm $serviceRequestForm) => resolve(GenerateSubmissibleEmbedCode::class)->handle($serviceRequestForm))
                             ->copyMessage('Copied!')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestFormResource/Pages/EditServiceRequestForm.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestFormResource/Pages/EditServiceRequestForm.php
@@ -82,7 +82,7 @@ class EditServiceRequestForm extends EditRecord
                                 ```
                                 EOD;
 
-                                return new HtmlString(Str::markdown($state));
+                                return str($state)->markdown()->toHtmlString();
                             })
                             ->copyable()
                             ->copyableState(fn (ServiceRequestForm $serviceRequestForm) => resolve(GenerateSubmissibleEmbedCode::class)->handle($serviceRequestForm))

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestFormResource/Pages/EditServiceRequestForm.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestFormResource/Pages/EditServiceRequestForm.php
@@ -37,10 +37,8 @@
 namespace AdvisingApp\ServiceManagement\Filament\Resources\ServiceRequestFormResource\Pages;
 
 use Filament\Forms\Form;
-use Illuminate\Support\Str;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
-use Illuminate\Support\HtmlString;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Infolists\Components\TextEntry;
 use AdvisingApp\Form\Actions\GenerateSubmissibleEmbedCode;

--- a/app-modules/survey/src/Filament/Resources/SurveyResource/Pages/EditSurvey.php
+++ b/app-modules/survey/src/Filament/Resources/SurveyResource/Pages/EditSurvey.php
@@ -37,10 +37,8 @@
 namespace AdvisingApp\Survey\Filament\Resources\SurveyResource\Pages;
 
 use Filament\Forms\Form;
-use Illuminate\Support\Str;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
-use Illuminate\Support\HtmlString;
 use AdvisingApp\Survey\Models\Survey;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Infolists\Components\TextEntry;

--- a/app-modules/survey/src/Filament/Resources/SurveyResource/Pages/EditSurvey.php
+++ b/app-modules/survey/src/Filament/Resources/SurveyResource/Pages/EditSurvey.php
@@ -37,8 +37,10 @@
 namespace AdvisingApp\Survey\Filament\Resources\SurveyResource\Pages;
 
 use Filament\Forms\Form;
+use Illuminate\Support\Str;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
+use Illuminate\Support\HtmlString;
 use AdvisingApp\Survey\Models\Survey;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Infolists\Components\TextEntry;
@@ -76,13 +78,14 @@ class EditSurvey extends EditRecord
                             ->state(function (Survey $survey) {
                                 $code = resolve(GenerateSubmissibleEmbedCode::class)->handle($survey);
 
-                                return <<<EOD
+                                $state = <<<EOD
                                 ```
                                 {$code}
                                 ```
                                 EOD;
+
+                                return new HtmlString(Str::markdown($state));
                             })
-                            ->markdown()
                             ->copyable()
                             ->copyableState(fn (Survey $survey) => resolve(GenerateSubmissibleEmbedCode::class)->handle($survey))
                             ->copyMessage('Copied!')

--- a/app-modules/survey/src/Filament/Resources/SurveyResource/Pages/EditSurvey.php
+++ b/app-modules/survey/src/Filament/Resources/SurveyResource/Pages/EditSurvey.php
@@ -84,7 +84,7 @@ class EditSurvey extends EditRecord
                                 ```
                                 EOD;
 
-                                return new HtmlString(Str::markdown($state));
+                                return str($state)->markdown()->toHtmlString();
                             })
                             ->copyable()
                             ->copyableState(fn (Survey $survey) => resolve(GenerateSubmissibleEmbedCode::class)->handle($survey))


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-462

### Technical Description

Fixes the issue with the embed snippet display in the UI. It seems there was some change in the Filament that now results in the HTML being sanitized. So, I removed marking it as `markdown` and formatted it manually.

@danharrin, can you confirm this is the best approach or at least a good enough one?

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
