### PR TITLE
[ADVAPP-383]: Delay loading of portal contents until after authentication

### DIFF
--- a/app-modules/portal/routes/api.php
+++ b/app-modules/portal/routes/api.php
@@ -87,6 +87,8 @@ Route::prefix('api')
                 Route::post('/search', [KnowledgeManagementPortalSearchController::class, 'get'])
                     ->middleware(['signed:relative'])
                     ->name('search');
+                Route::get('/categories', [KnowledgeManagementPortalCategoryController::class, 'index'])
+                    ->name('category.index');
                 Route::get('/categories/{category}', [KnowledgeManagementPortalCategoryController::class, 'show'])
                     ->name('category.show');
                 Route::get('/categories/{category}/articles/{article}', [KnowledgeManagementPortalArticleController::class, 'show'])

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagement/KnowledgeManagementPortalCategoryController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagement/KnowledgeManagementPortalCategoryController.php
@@ -44,6 +44,25 @@ use AdvisingApp\Portal\DataTransferObjects\KnowledgeBaseCategoryData;
 
 class KnowledgeManagementPortalCategoryController extends Controller
 {
+    public function index(): JsonResponse
+    {
+        return response()->json(
+            KnowledgeBaseCategoryData::collection(
+                KnowledgeBaseCategory::query()
+                    ->get()
+                    ->map(function (KnowledgeBaseCategory $category) {
+                        return [
+                            'id' => $category->getKey(),
+                            'name' => $category->name,
+                            'description' => $category->description,
+                            'icon' => $category->icon ? svg($category->icon, 'h-6 w-6')->toHtml() : null,
+                        ];
+                    })
+                    ->toArray()
+            )
+        );
+    }
+
     public function show(KnowledgeBaseCategory $category): JsonResponse
     {
         return response()->json([

--- a/app-modules/portal/src/Http/Controllers/KnowledgeManagement/KnowledgeManagementPortalController.php
+++ b/app-modules/portal/src/Http/Controllers/KnowledgeManagement/KnowledgeManagementPortalController.php
@@ -41,8 +41,6 @@ use Filament\Support\Colors\Color;
 use Illuminate\Support\Facades\URL;
 use App\Http\Controllers\Controller;
 use AdvisingApp\Portal\Settings\PortalSettings;
-use AdvisingApp\KnowledgeBase\Models\KnowledgeBaseCategory;
-use AdvisingApp\Portal\DataTransferObjects\KnowledgeBaseCategoryData;
 
 class KnowledgeManagementPortalController extends Controller
 {
@@ -59,19 +57,6 @@ class KnowledgeManagementPortalController extends Controller
                     name: 'api.portal.knowledge-management.request-authentication',
                     absolute: false,
                 )
-            ),
-            'categories' => KnowledgeBaseCategoryData::collection(
-                KnowledgeBaseCategory::query()
-                    ->get()
-                    ->map(function (KnowledgeBaseCategory $category) {
-                        return [
-                            'id' => $category->getKey(),
-                            'name' => $category->name,
-                            'description' => $category->description,
-                            'icon' => $category->icon ? svg($category->icon, 'h-6 w-6')->toHtml() : null,
-                        ];
-                    })
-                    ->toArray()
             ),
         ]);
     }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-383

### Technical Description

A new API endpoint has been introduced to return categories, and they have been removed from the existing one. If authentication is required and has not been performed, the request to fetch categories is delayed until it happens successfully.