### PR TITLE
[ADVAPP-466]: API docs link produces an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "api-docs:generate": "export NODE_OPTIONS=--max_old_space_size=4096 && env-cmd spectaql spectaql.yml",
+        "api-docs:generate": "export NODE_OPTIONS=--max_old_space_size=4096 && spectaql spectaql.yml",
         "build": "npm run build:vite && npm run build:js-compile && npm run build:widgets && npm run build:portals",
         "build:application": "(cd widgets/application && vite build)",
         "build:event-registration": "(cd widgets/event-registration && vite build)",

--- a/spectaql.yml
+++ b/spectaql.yml
@@ -44,8 +44,8 @@ info:
 
 
 servers:
-  - url: ${APP_URL}/graphql
-    description: This server
+  - url: https://college.advising.app/graphql
+    description: This server. Replace with your own server URL.
     production: true
     headers:
       - name: Authorization


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-466

### Technical Description

This should fix the errors when generating the API docs in dev and production.

We don't have a `.env` in dev and production, so this removes the need for it and sets a dummy URL for the docs URL.

I'm leaving the package we used to install this for now, though. We will need to make some changes to generate API docs per client, it will be needed then.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
