### PR TITLE
[ADVAPP-477]: Online Admissions settings should not present under Product Administration when feature is disabled, [ADVAPP-479]: Make Schedule & Appointments Feature Configurable Per Tenant

### DIFF
--- a/app/DataTransferObjects/LicenseManagement/LicenseAddonsData.php
+++ b/app/DataTransferObjects/LicenseManagement/LicenseAddonsData.php
@@ -53,5 +53,6 @@ class LicenseAddonsData extends Data
         public bool $realtimeChat,
         public bool $mobileApps,
         public bool $experimentalReporting = false,
+        public bool $scheduleAndAppointments = false,
     ) {}
 }

--- a/app/Enums/Feature.php
+++ b/app/Enums/Feature.php
@@ -59,6 +59,8 @@ enum Feature: string
 
     case ExperimentalReporting = 'experimental-reporting';
 
+    case ScheduleAndAppointments = 'schedule-and-appointments';
+
     public function generateGate(): void
     {
         // If features are added that are not based on a License Addon we will need to update this

--- a/app/Filament/Pages/ManageLicenseSettings.php
+++ b/app/Filament/Pages/ManageLicenseSettings.php
@@ -153,6 +153,8 @@ class ManageLicenseSettings extends SettingsPage
                                 ->disabled(fn (LicenseSettings $settings): bool => $settings->data->limits->conversationalAiSeats < 1)
                                 ->live()
                                 ->afterStateUpdated(fn (Toggle $component, $state) => $state ? $component->state(false) && $this->mountAction('enableExperimentalReporting') : null),
+                            Toggle::make('data.addons.scheduleAndAppointments')
+                                ->label('Schedule & Appointments'),
                         ]
                     ),
             ]);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-477
- https://canyongbs.atlassian.net/browse/ADVAPP-479

### Technical Description

> Describe your changes in detail. This should include technical/architectural decisions and reasoning, if applicable.
>
> Please ensure that at least one correct change type label is added to the PR. For example, if you are adding a new feature, please add the `Change Type | New Feature` label.

Enforce Online Admissions addon feature flag. Add and enforce Schedule & Appointments addon feature flag.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
