### PR TITLE
[ADVAPP-435]: Implement loader presentation when sending messages to the AI assistant.

### DIFF
--- a/app-modules/assistant/resources/views/filament/pages/personal-assistant.blade.php
+++ b/app-modules/assistant/resources/views/filament/pages/personal-assistant.blade.php
@@ -320,14 +320,12 @@ use Illuminate\Support\Facades\Vite;
                                                         <div
                                                             class="flex min-h-[20px] flex-col items-start gap-3 overflow-x-auto break-words">
                                                             <div
-                                                                class="hidden"
-                                                                id="hidden_current_response"
-                                                                wire:stream="currentResponse"
-                                                            >{{ $currentResponse }}</div>
-                                                            <div
-                                                                class="markdown light prose w-full break-words dark:prose-invert"
-                                                                id="current_response"
-                                                            ></div>
+                                                                class="flex items-center rounded-lg bg-primary-600 px-4 py-2 dark:bg-primary-500">
+                                                                <x-filament::loading-indicator class="h-5 w-5" />
+                                                                <span class="ml-2">
+                                                                    Processing...
+                                                                </span>
+                                                            </div>
                                                         </div>
                                                     </div>
                                                 </div>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-435

### Technical Description

> Add a loading indicator when the AI is generating a respinse.

### Screenshots (if appropriate)

<img width="878" alt="Screenshot 2024-04-08 at 6 06 23 PM" src="https://github.com/canyongbs/advisingapp/assets/10821263/ff0f47a9-8ab0-4263-bca5-8237e674214d">

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
