### PR TITLE
[ADVAPP-482]: Introduce ability to import a list of users

### DIFF
--- a/app/Filament/Imports/UserImporter.php
+++ b/app/Filament/Imports/UserImporter.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Filament\Imports;
 
 use App\Models\User;

--- a/app/Filament/Imports/UserImporter.php
+++ b/app/Filament/Imports/UserImporter.php
@@ -60,8 +60,6 @@ class UserImporter extends Importer
 
     protected function afterCreate(): void
     {
-        ray('UserImporter.afterCreate()');
-
         /** @var User $user */
         $user = $this->getRecord();
 

--- a/app/Filament/Imports/UserImporter.php
+++ b/app/Filament/Imports/UserImporter.php
@@ -60,7 +60,7 @@ class UserImporter extends Importer
             ImportColumn::make('job_title')
                 ->rules(['required'])
                 ->requiredMapping()
-                ->example('12345'),
+                ->example('Advisor'),
             ImportColumn::make('emplid')
                 ->rules(['string'])
                 ->example('12345'),

--- a/app/Filament/Imports/UserImporter.php
+++ b/app/Filament/Imports/UserImporter.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Filament\Imports;
+
+use App\Models\User;
+use Filament\Actions\Imports\Importer;
+use Filament\Actions\Imports\ImportColumn;
+use Filament\Actions\Imports\Models\Import;
+use App\Notifications\SetPasswordNotification;
+
+class UserImporter extends Importer
+{
+    protected static ?string $model = User::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            ImportColumn::make('name')
+                ->rules(['required'])
+                ->requiredMapping()
+                ->example('Jonathan Smith'),
+            ImportColumn::make('email')
+                ->rules(['required', 'email'])
+                ->requiredMapping()
+                ->example('johnsmith@gmail.com'),
+            ImportColumn::make('job_title')
+                ->rules(['required'])
+                ->requiredMapping()
+                ->example('12345'),
+            ImportColumn::make('emplid')
+                ->rules(['string'])
+                ->example('12345'),
+            ImportColumn::make('is_external')
+                ->label('External User')
+                ->boolean()
+                ->rules(['boolean'])
+                ->example('yes'),
+        ];
+    }
+
+    public function resolveRecord(): ?User
+    {
+        $user = User::where('email', $this->data['email'])->first();
+
+        return $user ?? new User([
+            'email' => $this->data['email'],
+        ]);
+    }
+
+    public static function getCompletedNotificationBody(Import $import): string
+    {
+        $body = 'Your user import has completed and ' . number_format($import->successful_rows) . ' ' . str('row')->plural($import->successful_rows) . ' imported.';
+
+        if ($failedRowsCount = $import->getFailedRowsCount()) {
+            $body .= ' ' . number_format($failedRowsCount) . ' ' . str('row')->plural($failedRowsCount) . ' failed to import.';
+        }
+
+        return $body;
+    }
+
+    protected function afterCreate(): void
+    {
+        ray('UserImporter.afterCreate()');
+
+        /** @var User $user */
+        $user = $this->getRecord();
+
+        if ($user->is_external) {
+            return;
+        }
+
+        $user->notify(new SetPasswordNotification());
+    }
+}

--- a/app/Filament/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Resources/UserResource/Pages/ListUsers.php
@@ -36,7 +36,10 @@
 
 namespace App\Filament\Resources\UserResource\Pages;
 
+use App\Models\User;
 use Filament\Actions\CreateAction;
+use Filament\Actions\ImportAction;
+use App\Filament\Imports\UserImporter;
 use App\Filament\Resources\UserResource;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Contracts\Support\Htmlable;
@@ -62,6 +65,9 @@ class ListUsers extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            ImportAction::make()
+                ->importer(UserImporter::class)
+                ->authorize('import', User::class),
             CreateAction::make(),
         ];
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -193,6 +193,11 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
         'locale',
     ];
 
+    public function getWebPermissions(): Collection
+    {
+        return collect(['import', ...$this->webPermissions()]);
+    }
+
     public function defaultAssistantChatFoldersHaveBeenCreated(): bool
     {
         return $this->default_assistant_chat_folders_created;

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -74,6 +74,14 @@ class UserPolicy
         );
     }
 
+    public function import(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'user.import',
+            denyResponse: 'You do not have permission to import users.',
+        );
+    }
+
     public function update(Authenticatable $authenticatable, User $model): Response
     {
         return $authenticatable->canOrElse(


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-482

### Technical Description

> This PR introduces the ability to import a list of users via Filament import functionality.

### Screenshots (if appropriate)

### Any deployment steps required?

> Yes - we will need to ensure that we run the Roles and Permissions sync process so that the `user.import` permission is added and available. 

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
