### PR TITLE
[Hotfix] Continue migration after rolling back

### DIFF
--- a/tests/Helpers/RollbackMigrations.php
+++ b/tests/Helpers/RollbackMigrations.php
@@ -61,4 +61,7 @@ function rollbackToBefore(string $migrationToRollbackTo)
     if ($rollbackSteps > 0) {
         Artisan::call('migrate:rollback', ['--step' => $rollbackSteps]);
     }
+
+    /** @phpstan-ignore-next-line */
+    $this->beforeApplicationDestroyed(fn () => Artisan::call('migrate'));
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

n/a

### Technical Description

> This PR adjusts the rollback to migration helper in order to continue the rest of the subsequent rolled back migrations.

### Screenshots (if appropriate)

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
