### PR TITLE
[ADVAPP-499]: Enrollment details will always just show the first enrollment for the student

### DIFF
--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EnrollmentsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EnrollmentsRelationManager.php
@@ -41,7 +41,7 @@ use Laravel\Pennant\Feature;
 use Filament\Infolists\Infolist;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
-use App\Filament\Tables\Columns\IdColumn;
+use Illuminate\Database\Eloquent\Model;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\RelationManagers\RelationManager;
 
@@ -111,7 +111,6 @@ class EnrollmentsRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('division')
             ->columns([
-                IdColumn::make(),
                 TextColumn::make('division')
                     ->label('College'),
                 TextColumn::make('class_nbr')
@@ -128,5 +127,17 @@ class EnrollmentsRelationManager extends RelationManager
                 ViewAction::make(),
             ])
             ->bulkActions([]);
+    }
+
+    public function getTableRecordKey(Model $record): string
+    {
+        return base64_encode(json_encode($record->attributesToArray()));
+    }
+
+    protected function resolveTableRecord(?string $key): ?Model
+    {
+        return $this->getTable()->getQuery()
+            ->where(json_decode(base64_decode($key), associative: true))
+            ->first();
     }
 }

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/PerformanceRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/PerformanceRelationManager.php
@@ -41,7 +41,7 @@ use Filament\Infolists\Infolist;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
-use App\Filament\Tables\Columns\IdColumn;
+use Illuminate\Database\Eloquent\Model;
 use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -85,7 +85,6 @@ class PerformanceRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('acad_career')
             ->columns([
-                IdColumn::make(),
                 TextColumn::make('acad_career')
                     ->label('Academic Career'),
                 TextColumn::make('division')
@@ -107,5 +106,17 @@ class PerformanceRelationManager extends RelationManager
                 ViewAction::make(),
             ])
             ->bulkActions([]);
+    }
+
+    public function getTableRecordKey(Model $record): string
+    {
+        return base64_encode(json_encode($record->attributesToArray()));
+    }
+
+    protected function resolveTableRecord(?string $key): ?Model
+    {
+        return $this->getTable()->getQuery()
+            ->where(json_decode(base64_decode($key), associative: true))
+            ->first();
     }
 }

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/ProgramsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/ProgramsRelationManager.php
@@ -40,7 +40,7 @@ use Filament\Tables\Table;
 use Filament\Infolists\Infolist;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
-use App\Filament\Tables\Columns\IdColumn;
+use Illuminate\Database\Eloquent\Model;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\RelationManagers\RelationManager;
 
@@ -76,7 +76,6 @@ class ProgramsRelationManager extends RelationManager
         return $table
             ->recordTitleAttribute('descr')
             ->columns([
-                IdColumn::make(),
                 TextColumn::make('otherid')
                     ->label('STUID'),
                 TextColumn::make('division')
@@ -95,5 +94,17 @@ class ProgramsRelationManager extends RelationManager
                 ViewAction::make(),
             ])
             ->bulkActions([]);
+    }
+
+    public function getTableRecordKey(Model $record): string
+    {
+        return base64_encode(json_encode($record->attributesToArray()));
+    }
+
+    protected function resolveTableRecord(?string $key): ?Model
+    {
+        return $this->getTable()->getQuery()
+            ->where(json_decode(base64_decode($key), associative: true))
+            ->first();
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-499

### Technical Description

By default, Filament uses the primary key of the model to identify it and tell the modal which record to open. When it's not unique, it does not work properly because Filament matches the first model with that key, which is why the first modal opens all the time.

The solution is to encode the data from the row, encode it, and use that as a temporary primary key. It's not stored anywhere, just used by Filament to identify the rows. It's not perfect if there are 2 identical records, but it doesn't matter since this is a read-only view anyway.