### PR TITLE
[ADVAPP-506]: Enhance emailed chats by including formatting

### DIFF
--- a/app-modules/assistant/src/Notifications/SendAssistantTranscriptNotification.php
+++ b/app-modules/assistant/src/Notifications/SendAssistantTranscriptNotification.php
@@ -73,15 +73,27 @@ class SendAssistantTranscriptNotification extends BaseNotification implements Em
         $this->chat
             ->messages
             ->each(function ($chatMessage) use ($senderIsNotifiable, $message) {
-                if ($chatMessage->from === AIChatMessageFrom::User) {
-                    if ($senderIsNotifiable) {
-                        $message->line("You: {$chatMessage->message}");
-                    } else {
-                        $message->line("{$this->sender->name}: {$chatMessage->message}");
-                    }
-                } else {
-                    $message->line("Canyon: {$chatMessage->message}");
+                if ($chatMessage->from !== AIChatMessageFrom::User) {
+                    return $message->line(str(nl2br($chatMessage->message))
+                        ->prepend('**Canyon:** ')
+                        ->markdown()
+                        ->sanitizeHtml()
+                        ->toHtmlString());
                 }
+
+                if ($senderIsNotifiable) {
+                    return $message->line(str(nl2br($chatMessage->message))
+                        ->prepend('**You:** ')
+                        ->markdown()
+                        ->sanitizeHtml()
+                        ->toHtmlString());
+                }
+
+                return $message->line(str(nl2br($chatMessage->message))
+                    ->prepend("**{$this->sender->name}:** ")
+                    ->markdown()
+                    ->sanitizeHtml()
+                    ->toHtmlString());
             });
 
         return $message;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-506

### Technical Description

`->line()` only allows plain text out of the box, not Markdown or HTML. You can pass an Htmlable object to allow HTML. We can convert the message from Markdown to HTML and put it in an HtmlString for preservation. It needs to be sanitised for XSS safety. We convert new lines to `<br>` so that a singular line takes effect and a new paragraph is not required.
