### PR TITLE
[ADVAPP-501]: Failed Import doesn't stop processing

### DIFF
--- a/app/Jobs/ImportCsv.php
+++ b/app/Jobs/ImportCsv.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Jobs;
+
+use Carbon\CarbonInterface;
+use Filament\Actions\Imports\Jobs\ImportCsv as BaseImportCsv;
+
+class ImportCsv extends BaseImportCsv
+{
+    public int $tries = 2;
+
+    public function retryUntil(): ?CarbonInterface
+    {
+        return null;
+    }
+}

--- a/app/Overrides/Filament/Actions/Imports/Jobs/ImportCsvOverride.php
+++ b/app/Overrides/Filament/Actions/Imports/Jobs/ImportCsvOverride.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Overrides\Filament\Actions\Imports\Jobs;
 
 use Carbon\CarbonInterface;

--- a/app/Overrides/Filament/Actions/Imports/Jobs/ImportCsvOverride.php
+++ b/app/Overrides/Filament/Actions/Imports/Jobs/ImportCsvOverride.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\Jobs;
+namespace App\Overrides\Filament\Actions\Imports\Jobs;
 
 use Carbon\CarbonInterface;
-use Filament\Actions\Imports\Jobs\ImportCsv as BaseImportCsv;
+use Filament\Actions\Imports\Jobs\ImportCsv;
 
-class ImportCsv extends BaseImportCsv
+class ImportCsvOverride extends ImportCsv
 {
     public int $tries = 2;
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -42,8 +42,10 @@ use Laravel\Pennant\Feature;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Octane\Commands\ReloadCommand;
+use Filament\Actions\Imports\Jobs\ImportCsv;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use OpenSearch\Migrations\Filesystem\MigrationStorage;
+use App\Overrides\Filament\Actions\Imports\Jobs\ImportCsvOverride;
 use LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition as GraphQLSearchByTypesCondition;
 use LastDragon_ru\LaraASP\GraphQL\SearchBy\Definitions\SearchByDirective as GraphQLSearchByDirectiveAlias;
 use App\Overrides\LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition as GraphQLSearchByTypesConditionOverride;
@@ -60,6 +62,7 @@ class AppServiceProvider extends ServiceProvider
 
         $this->app->bind(GraphQLSearchByTypesCondition::class, GraphQLSearchByTypesConditionOverride::class);
         $this->app->bind(GraphQLSearchByDirectiveAlias::class, GraphQLSearchByDirectiveOverride::class);
+        $this->app->bind(ImportCsv::class, ImportCsvOverride::class);
 
         // Laravel Octane does not register the `ReloadCommand` when the application is not running in the console.
         // We need to call this command from the `UpdateBrandSettingsController` during an HTTP request.


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-501

### Technical Description

This removes the default `retryUntil()` behaviour from the job, and replaces it with a maximum of 2 tries for import jobs.
