### PR TITLE
[ADVAPP-464]: Add support for transactional email via API call

### DIFF
--- a/app-modules/engagement/graphql/engagement.graphql
+++ b/app-modules/engagement/graphql/engagement.graphql
@@ -91,8 +91,39 @@ input CreateEngagementSMSInput {
         @rules(apply: ["required", "in:student,prospect"])
 }
 
+input CreateEngagementEmailInput {
+    subject: String! @rules(apply: ["required", "string", "max:255"])
+
+    body: String! @rules(apply: ["required", "string", "max:65535"])
+
+    scheduled: Boolean
+
+    deliver_at: DateTime @rules(apply: ["required_if:scheduled,true"])
+
+    recipient_id: EducatableId!
+        @rules(
+            apply: [
+                "required"
+                "AdvisingApp\\Engagement\\GraphQL\\Rules\\RecipientIdExists"
+            ]
+        )
+
+    recipient_type: EducatableType!
+        @rules(apply: ["required", "in:student,prospect"])
+}
+
 input UpdateEngagementSMSInput {
-    body: String @rules(apply: ["required", "string", "max:320"])
+    body: String @rules(apply: ["string", "max:320"])
+
+    scheduled: Boolean
+
+    deliver_at: DateTime @rules(apply: ["required_if:scheduled,true"])
+}
+
+input UpdateEngagementEmailInput {
+    subject: String @rules(apply: ["string", "max:255"])
+
+    body: String @rules(apply: ["string", "max:65535"])
 
     scheduled: Boolean
 
@@ -113,6 +144,23 @@ type EngagementMutations {
         @canFind(ability: "update", find: "id")
         @field(
             resolver: "AdvisingApp\\Engagement\\GraphQL\\Mutations\\UpdateSMS"
+        )
+
+    sendEmail(input: CreateEngagementEmailInput! @spread): Engagement!
+        @canResolved(ability: "create")
+        @field(
+            resolver: "AdvisingApp\\Engagement\\GraphQL\\Mutations\\SendEmail"
+        )
+
+    updateEmail(
+        id: UUID!
+            @whereKey
+            @rules(apply: ["required", "uuid", "exists:engagements"])
+        input: UpdateEngagementEmailInput! @spread
+    ): Engagement
+        @canFind(ability: "update", find: "id")
+        @field(
+            resolver: "AdvisingApp\\Engagement\\GraphQL\\Mutations\\UpdateEmail"
         )
 
     delete(

--- a/app-modules/engagement/src/Actions/GenerateTipTapBodyJson.php
+++ b/app-modules/engagement/src/Actions/GenerateTipTapBodyJson.php
@@ -51,7 +51,7 @@ class GenerateTipTapBodyJson
                 $content = collect();
 
                 foreach ($node->content as $item) {
-                    preg_match_all('/{{2}[\s\S]*?}{2}|[{(<\[]|[})>\]]|\s*\S+\s*/', $item->text, $tokens);
+                    preg_match_all('/{{2}[\s\S]*?}{2}|[{(<\[]|\s*\S+\s*/', $item->text, $tokens);
 
                     if (empty($tokens)) {
                         continue;

--- a/app-modules/engagement/src/Actions/GenerateTipTapBodyJson.php
+++ b/app-modules/engagement/src/Actions/GenerateTipTapBodyJson.php
@@ -51,7 +51,7 @@ class GenerateTipTapBodyJson
                 $content = collect();
 
                 foreach ($node->content as $item) {
-                    preg_match_all('/{{2}[\s\S]*?}{2}|[{(<\[]|\s*\S+\s*/', $item->text, $tokens);
+                    preg_match_all('/{{2}[\s\S]*?}{2}|\s*\S+\s*/', $item->text, $tokens);
 
                     if (empty($tokens)) {
                         continue;

--- a/app-modules/engagement/src/Actions/HandleEngagementEmailNotificationSent.php
+++ b/app-modules/engagement/src/Actions/HandleEngagementEmailNotificationSent.php
@@ -61,7 +61,7 @@ class HandleEngagementEmailNotificationSent implements ShouldQueue
         $deliverable->markDeliverySuccessful();
 
         if (is_null($deliverable->engagement->engagement_batch_id)) {
-            $deliverable->engagement->user->notify(new EngagementEmailSentNotification($deliverable->engagement));
+            $deliverable->engagement->user?->notify(new EngagementEmailSentNotification($deliverable->engagement));
         }
     }
 }

--- a/app-modules/engagement/src/Models/Engagement.php
+++ b/app-modules/engagement/src/Models/Engagement.php
@@ -211,6 +211,20 @@ class Engagement extends BaseModel implements Auditable, CanTriggerAutoSubscript
         ];
     }
 
+    /**
+     * @param class-string $type
+     */
+    public static function getMergeTags(string $type): array
+    {
+        return match ($type) {
+            Student::class => [
+                'student full name',
+                'student email',
+            ],
+            default => [],
+        };
+    }
+
     protected static function booted(): void
     {
         static::addGlobalScope('licensed', function (Builder $builder) {

--- a/app-modules/engagement/src/Notifications/EngagementEmailNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementEmailNotification.php
@@ -60,11 +60,13 @@ class EngagementEmailNotification extends BaseNotification implements EmailNotif
 
     public function toEmail(object $notifiable): MailMessage
     {
+        $name = $this->deliverable->engagement->user->name ?? config('app.name');
+
         return MailMessage::make()
             ->subject($this->deliverable->engagement->subject)
             ->greeting('Hello ' . $this->deliverable->engagement->recipient->display_name . '!')
             ->content($this->deliverable->engagement->getBody())
-            ->salutation("Regards, {$this->deliverable->engagement->user->name}");
+            ->salutation("Regards, {$name}");
     }
 
     protected function beforeSendHook(object $notifiable, OutboundDeliverable $deliverable, string $channel): void


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-464

### Technical Description

> Describe your changes in detail. This should include technical/architectural decisions and reasoning, if applicable.
>
> Please ensure that at least one correct change type label is added to the PR. For example, if you are adding a new feature, please add the `Change Type | New Feature` label.

Allows the sending of email engagements from the GraphQL api.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
