### PR TITLE
[ADVAPP-453]: Engagement sending failures retry indefinitely

### DIFF
--- a/app-modules/notification/src/Notifications/BaseNotification.php
+++ b/app-modules/notification/src/Notifications/BaseNotification.php
@@ -58,6 +58,8 @@ abstract class BaseNotification extends Notification implements ShouldQueue
 
     protected array $metadata = [];
 
+    public $tries = 3;
+
     public function via(object $notifiable): array
     {
         $traits = collect(class_uses_recursive(static::class));

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementsRelationManager.php
@@ -42,10 +42,10 @@ use Filament\Infolists\Infolist;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Illuminate\Database\Eloquent\Model;
+use Filament\Support\Enums\IconPosition;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Infolists\Components\Fieldset;
-use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use AdvisingApp\Engagement\Models\Engagement;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -88,18 +88,25 @@ class EngagementsRelationManager extends RelationManager
                     ->schema([
                         TextEntry::make('deliverable.channel')
                             ->label('Channel'),
-                        IconEntry::make('deliverable.delivery_status')
+                        TextEntry::make('deliverable.delivery_status')
+                            ->iconPosition(IconPosition::After)
                             ->icon(fn (EngagementDeliveryStatus $state): string => match ($state) {
                                 EngagementDeliveryStatus::Successful => 'heroicon-o-check-circle',
                                 EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'heroicon-o-clock',
                                 EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed, EngagementDeliveryStatus::RateLimited => 'heroicon-o-x-circle',
                             })
-                            ->color(fn (EngagementDeliveryStatus $state): string => match ($state) {
+                            ->iconColor(fn (EngagementDeliveryStatus $state): string => match ($state) {
                                 EngagementDeliveryStatus::Successful => 'success',
                                 EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'info',
                                 EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed, EngagementDeliveryStatus::RateLimited => 'danger',
                             })
-                            ->label('Status'),
+                            ->label('Status')
+                            ->formatStateUsing(fn (Engagement $engagement): string => match ($engagement->deliverable->delivery_status) {
+                                EngagementDeliveryStatus::Successful => 'Successfully delivered',
+                                EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'Awaiting delivery',
+                                EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed => 'Failed to send',
+                                EngagementDeliveryStatus::RateLimited => 'Failed to send due to rate limits',
+                            }),
                         TextEntry::make('deliverable.delivered_at')
                             ->label('Delivered At')
                             ->hidden(fn (Engagement $engagement): bool => is_null($engagement->deliverable->delivered_at)),

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -42,10 +42,10 @@ use Filament\Infolists\Infolist;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Illuminate\Database\Eloquent\Model;
+use Filament\Support\Enums\IconPosition;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Infolists\Components\Fieldset;
-use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use AdvisingApp\Engagement\Models\Engagement;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -88,18 +88,25 @@ class EngagementsRelationManager extends RelationManager
                     ->schema([
                         TextEntry::make('deliverable.channel')
                             ->label('Channel'),
-                        IconEntry::make('deliverable.delivery_status')
+                        TextEntry::make('deliverable.delivery_status')
+                            ->iconPosition(IconPosition::After)
                             ->icon(fn (EngagementDeliveryStatus $state): string => match ($state) {
                                 EngagementDeliveryStatus::Successful => 'heroicon-o-check-circle',
                                 EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'heroicon-o-clock',
                                 EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed, EngagementDeliveryStatus::RateLimited => 'heroicon-o-x-circle',
                             })
-                            ->color(fn (EngagementDeliveryStatus $state): string => match ($state) {
+                            ->iconColor(fn (EngagementDeliveryStatus $state): string => match ($state) {
                                 EngagementDeliveryStatus::Successful => 'success',
                                 EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'info',
                                 EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed, EngagementDeliveryStatus::RateLimited => 'danger',
                             })
-                            ->label('Status'),
+                            ->label('Status')
+                            ->formatStateUsing(fn (Engagement $engagement): string => match ($engagement->deliverable->delivery_status) {
+                                EngagementDeliveryStatus::Successful => 'Successfully delivered',
+                                EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'Awaiting delivery',
+                                EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed => 'Failed to send',
+                                EngagementDeliveryStatus::RateLimited => 'Failed to send due to rate limits',
+                            }),
                         TextEntry::make('deliverable.delivered_at')
                             ->label('Delivered At')
                             ->hidden(fn (Engagement $engagement): bool => is_null($engagement->deliverable->delivered_at)),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-453

### Technical Description

> Ensures we only retry failed notification jobs 3 times, and alerts the engagement sender when their engagement failed to send.

### Screenshots (if appropriate)

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
