### PR TITLE
[ADVAPP-523]: Illuminate\View\ViewException

### DIFF
--- a/app/Multitenancy/Http/Middleware/NeedsTenant.php
+++ b/app/Multitenancy/Http/Middleware/NeedsTenant.php
@@ -40,6 +40,6 @@ class NeedsTenant extends \Spatie\Multitenancy\Http\Middleware\NeedsTenant
 {
     public function handleInvalidRequest()
     {
-        return redirect(config('app.landlord_url'));
+        abort(404);
     }
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -37,6 +37,7 @@
 namespace App\Providers\Filament;
 
 use Filament\Panel;
+use App\Models\Tenant;
 use Filament\PanelProvider;
 use App\Settings\BrandSettings;
 use App\Models\SettingsProperty;
@@ -98,6 +99,10 @@ class AdminPanelProvider extends PanelProvider
             ->login(Login::class)
             ->viteTheme('resources/css/filament/admin/theme.css')
             ->favicon(function () {
+                if (! Tenant::checkCurrent()) {
+                    return asset('/images/default-favicon.png');
+                }
+
                 $themeSettings = app(ThemeSettings::class);
                 $settingsProperty = SettingsProperty::getInstance('theme.is_favicon_active');
                 $favicon = $settingsProperty->getFirstMedia('favicon');

--- a/app/Providers/Filament/LandlordPanelProvider.php
+++ b/app/Providers/Filament/LandlordPanelProvider.php
@@ -61,6 +61,9 @@ class LandlordPanelProvider extends PanelProvider
                 DisableBladeIconComponents::class,
             ])
             ->routes(function () {
+                Route::get('/ping', fn () => response()->json(['message' => 'pong']))
+                    ->name('ping');
+
                 Route::get('/{path?}', fn () => view('landlord'))
                     ->where('path', '.*');
             });

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -61,6 +61,9 @@ class RouteServiceProvider extends ServiceProvider
         $this->configureRateLimiting();
 
         $this->routes(function () {
+            Route::get('/ping', fn () => response()->json(['message' => 'pong']))
+                ->name('ping');
+
             Route::prefix('landlord/api')
                 ->middleware('landlord-api')
                 ->namespace($this->namespace)

--- a/docker/s6-overlay/s6-rc.d/nginx/data/check
+++ b/docker/s6-overlay/s6-rc.d/nginx/data/check
@@ -1,5 +1,5 @@
 #!/command/with-contenv bash
-response=$(curl -s -o /dev/null -w "%{http_code}" -L --insecure http://localhost)
+response=$(curl -s -o /dev/null -w "%{http_code}" -L --insecure http://localhost/ping)
 
 if [[ $response == "200" ]]; then
 	exit 0

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -48,12 +48,12 @@
                 <p class="mb-5 font-bold tracking-tight text-gray-900 dark:text-gray-400 md:text-xl">
                     Oops! Looks like you followed a bad link. If you think this is a problem with us, please tell us.
                 </p>
-                @if(\App\Models\Tenant::checkCurrent())
+                @if (\App\Models\Tenant::checkCurrent())
                     <x-filament::button
-                            class="inline-flex rounded-lg bg-primary-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-primary-800 focus:outline-none focus:ring-4 focus:ring-primary-300 dark:focus:ring-primary-900"
-                            href="{{ Filament::getUrl() }}"
-                            icon="heroicon-o-chevron-left"
-                            tag="a"
+                        class="inline-flex rounded-lg bg-primary-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-primary-800 focus:outline-none focus:ring-4 focus:ring-primary-300 dark:focus:ring-primary-900"
+                        href="{{ Filament::getUrl() }}"
+                        icon="heroicon-o-chevron-left"
+                        tag="a"
                     >
                         Go back home
                     </x-filament::button>

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -48,14 +48,16 @@
                 <p class="mb-5 font-bold tracking-tight text-gray-900 dark:text-gray-400 md:text-xl">
                     Oops! Looks like you followed a bad link. If you think this is a problem with us, please tell us.
                 </p>
-                <x-filament::button
-                    class="inline-flex rounded-lg bg-primary-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-primary-800 focus:outline-none focus:ring-4 focus:ring-primary-300 dark:focus:ring-primary-900"
-                    href="{{ Filament::getUrl() }}"
-                    icon="heroicon-o-chevron-left"
-                    tag="a"
-                >
-                    Go back home
-                </x-filament::button>
+                @if(\App\Models\Tenant::checkCurrent())
+                    <x-filament::button
+                            class="inline-flex rounded-lg bg-primary-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-primary-800 focus:outline-none focus:ring-4 focus:ring-primary-300 dark:focus:ring-primary-900"
+                            href="{{ Filament::getUrl() }}"
+                            icon="heroicon-o-chevron-left"
+                            tag="a"
+                    >
+                        Go back home
+                    </x-filament::button>
+                @endif
             </div>
         </div>
     </section>

--- a/tests/Feature/Multitenancy/Http/Middleware/NeedsTenantTest.php
+++ b/tests/Feature/Multitenancy/Http/Middleware/NeedsTenantTest.php
@@ -48,15 +48,17 @@ beforeEach(function () {
     Route::get('/needs-tenant-test-route')->middleware(NeedsTenant::class);
 });
 
-it('redirects without a tenant', function () {
+it('returns a 404 without a tenant', function () {
+    /** @var Response $response */
     $response = (new NeedsTenant())->handle(Request::create('/needs-tenant-test-route'), fn () => new Response());
 
-    assertTrue($response->isRedirect(config('app.landlord_url')));
+    assertTrue($response->isNotFound());
 });
 
 it('continues with a tenant', function () {
     Tenant::first()->makeCurrent();
 
+    /** @var Response $response */
     $response = (new NeedsTenant())->handle(Request::create('/needs-tenant-test-route'), fn () => new Response());
 
     assertTrue($response->isOk());

--- a/tests/Feature/Multitenancy/Http/Middleware/NeedsTenantTest.php
+++ b/tests/Feature/Multitenancy/Http/Middleware/NeedsTenantTest.php
@@ -49,11 +49,8 @@ beforeEach(function () {
 });
 
 it('returns a 404 without a tenant', function () {
-    /** @var Response $response */
-    $response = (new NeedsTenant())->handle(Request::create('/needs-tenant-test-route'), fn () => new Response());
-
-    assertTrue($response->isNotFound());
-});
+    (new NeedsTenant())->handle(Request::create('/needs-tenant-test-route'), fn () => new Response());
+})->expectException(Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
 
 it('continues with a tenant', function () {
     Tenant::first()->makeCurrent();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-523

### Technical Description

This should fix the exception we are seeing in Sentry and also better handle our routing. Added a new `ping` route accessible from all tenants and the landlord to work better for healthchecks.

### Screenshots (if appropriate)

### Any deployment steps required?

Healthchecks will need to be updated in the ALB to check the /ping route for a `200`

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
