### PR TITLE
[ADVAPP-530]: AI Assistant default Assistant is not created when Custom Assistant setting is turned off

### DIFF
--- a/app-modules/assistant/src/Filament/Pages/PersonalAssistant.php
+++ b/app-modules/assistant/src/Filament/Pages/PersonalAssistant.php
@@ -373,11 +373,9 @@ class PersonalAssistant extends Page
                 /** @var AssistantChat $assistantChat */
                 $assistantChat = $user->assistantChats()->create([
                     'name' => $data['name'],
-                    ...(Feature::active('custom-ai-assistants') ? [
+                    ...((Feature::active('custom-ai-assistants') && $this->aiAssistant) ? [
                         'ai_assistant_id' => $this->aiAssistant->getKey(),
-                    ] : [
-                        'assistant_id' => $this->chat->assistantId,
-                    ]),
+                    ] : []),
                     'thread_id' => $this->chat->threadId,
                 ]);
 

--- a/app-modules/assistant/src/Filament/Pages/PersonalAssistant.php
+++ b/app-modules/assistant/src/Filament/Pages/PersonalAssistant.php
@@ -182,14 +182,26 @@ class PersonalAssistant extends Page
 
         $this->aiAssistant = $chat->assistant;
 
-        if (! $this->aiAssistant) {
-            $this->aiAssistant = AiAssistant::query()
-                ->where('assistant_id', resolve(GetDefaultAiAssistantId::class)->get())
-                ->first();
+        if ($this->aiAssistant) {
+            $this->assistantId = $this->aiAssistant->assistant_id;
 
-            $chat->ai_assistant_id = $this->aiAssistant->getKey();
-            $chat->save();
+            return;
         }
+
+        $defaultId = resolve(GetDefaultAiAssistantId::class)->get();
+
+        $this->aiAssistant = AiAssistant::query()
+            ->where('assistant_id', $defaultId)
+            ->first();
+
+        if (! $this->aiAssistant) {
+            $this->assistantId = $defaultId;
+
+            return;
+        }
+
+        $chat->ai_assistant_id = $this->aiAssistant->getKey();
+        $chat->save();
 
         $this->assistantId = $this->aiAssistant->assistant_id;
     }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-530

### Technical Description

If saved chats exist, do not assume that AI assistant records also exist and fall back to the stored default assistant ID.
