### PR TITLE
[ADVAPP-550]: Remove seconds from start and end time picker fields for creation of events

### DIFF
--- a/app-modules/meeting-center/src/Filament/Resources/EventResource/Pages/Concerns/HasSharedEventFormConfiguration.php
+++ b/app-modules/meeting-center/src/Filament/Resources/EventResource/Pages/Concerns/HasSharedEventFormConfiguration.php
@@ -84,9 +84,11 @@ trait HasSharedEventFormConfiguration
                 ->minValue(1)
                 ->nullable(),
             DateTimePicker::make('starts_at')
+                ->seconds(false)
                 ->timezone($user->timezone)
                 ->required(),
             DateTimePicker::make('ends_at')
+                ->seconds(false)
                 ->timezone($user->timezone)
                 ->required(),
             Fieldset::make('Registration Form')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-550