### PR TITLE
[ADVAPP-532] Add ability to hide source, status and created fields in the prospect list.

### DIFF
--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
@@ -102,6 +102,7 @@ class ListProspects extends ListRecords implements HasBulkEngagementAction
                     ->badge()
                     ->translateLabel()
                     ->color(fn (Prospect $record) => $record->status->color->value)
+                    ->toggleable()
                     ->sortable(['sort']),
                 TextColumn::make('source.name')
                     ->label('Source')

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
@@ -106,10 +106,12 @@ class ListProspects extends ListRecords implements HasBulkEngagementAction
                 TextColumn::make('source.name')
                     ->label('Source')
                     ->translateLabel()
+                    ->toggleable()
                     ->sortable(),
                 TextColumn::make('created_at')
                     ->label('Created')
                     ->dateTime('g:ia - M j, Y')
+                    ->toggleable()
                     ->sortable(),
             ])
             ->filters([


### PR DESCRIPTION
… the prospect list.

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-532

### Technical Description

> Describe your changes in detail. This should include technical/architectural decisions and reasoning, if applicable.
> Source and Created column in Prospects list now default will checked and can be togglable.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
