### PR TITLE
[ADVAPP-556]: HandleSettingsSaved causes error when settings are saved by landlord call

### DIFF
--- a/app/Listeners/Contracts/HandleSettingsSaved.php
+++ b/app/Listeners/Contracts/HandleSettingsSaved.php
@@ -34,14 +34,11 @@
 </COPYRIGHT>
 */
 
-namespace App\Listeners;
+namespace App\Listeners\Contracts;
 
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Spatie\Multitenancy\Jobs\NotTenantAware;
 use Spatie\LaravelSettings\Events\SettingsSaved;
-use App\Listeners\Contracts\HandleSettingsSaved as HandleSettingsSavedContract;
 
-class HandleSettingsSaved implements HandleSettingsSavedContract, ShouldQueue, NotTenantAware
+interface HandleSettingsSaved
 {
-    public function handle(SettingsSaved $event): void {}
+    public function handle(SettingsSaved $event);
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -37,8 +37,8 @@
 namespace App\Providers;
 
 use OwenIt\Auditing\Events\Auditing;
-use App\Listeners\HandleSettingsSaved;
 use Illuminate\Auth\Events\Registered;
+use App\Listeners\Contracts\HandleSettingsSaved;
 use Spatie\LaravelSettings\Events\SettingsSaved;
 use AdvisingApp\Audit\Listeners\AuditingListener;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-556

### Technical Description

> Resolves the issue of an error being thrown when the `HandleSettingsSaved` listener is queued because there is no current tenant. This creates two class instances, and binds the correct concrete class based on the existence of a tenant.

### Screenshots (if appropriate)

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
