### PR TITLE
[ADVAPP-543]: Enhance journey steps so Email or Text are discrete options

### DIFF
--- a/app-modules/campaign/src/Enums/CampaignActionType.php
+++ b/app-modules/campaign/src/Enums/CampaignActionType.php
@@ -51,11 +51,14 @@ use AdvisingApp\Campaign\Filament\Blocks\InteractionBlock;
 use AdvisingApp\Campaign\Filament\Blocks\SubscriptionBlock;
 use AdvisingApp\Campaign\Filament\Blocks\ProactiveAlertBlock;
 use AdvisingApp\Campaign\Filament\Blocks\ServiceRequestBlock;
-use AdvisingApp\Campaign\Filament\Blocks\EngagementBatchBlock;
+use AdvisingApp\Campaign\Filament\Blocks\EngagementBatchSmsBlock;
+use AdvisingApp\Campaign\Filament\Blocks\EngagementBatchEmailBlock;
 
 enum CampaignActionType: string implements HasLabel
 {
-    case BulkEngagement = 'bulk_engagement';
+    case BulkEngagementEmail = 'bulk_engagement_email';
+
+    case BulkEngagementSms = 'bulk_engagement_sms';
 
     case ServiceRequest = 'service_request';
 
@@ -72,7 +75,8 @@ enum CampaignActionType: string implements HasLabel
     public static function blocks(): array
     {
         return [
-            EngagementBatchBlock::make(),
+            EngagementBatchEmailBlock::make(),
+            EngagementBatchSmsBlock::make(),
             ServiceRequestBlock::make(),
             ProactiveAlertBlock::make(),
             InteractionBlock::make(),
@@ -85,7 +89,8 @@ enum CampaignActionType: string implements HasLabel
     public function getLabel(): ?string
     {
         return match ($this) {
-            CampaignActionType::BulkEngagement => 'Email or Text',
+            CampaignActionType::BulkEngagementEmail => 'Email',
+            CampaignActionType::BulkEngagementSms => 'Text',
             CampaignActionType::ServiceRequest => 'Service Request',
             CampaignActionType::ProactiveAlert => 'Proactive Alert',
             CampaignActionType::CareTeam => 'Care Team',
@@ -96,7 +101,8 @@ enum CampaignActionType: string implements HasLabel
     public function getModel(): string
     {
         return match ($this) {
-            CampaignActionType::BulkEngagement => EngagementBatch::class,
+            CampaignActionType::BulkEngagementEmail => EngagementBatch::class,
+            CampaignActionType::BulkEngagementSms => EngagementBatch::class,
             CampaignActionType::ServiceRequest => ServiceRequest::class,
             CampaignActionType::ProactiveAlert => Alert::class,
             CampaignActionType::Interaction => Interaction::class,
@@ -109,7 +115,8 @@ enum CampaignActionType: string implements HasLabel
     public function getEditFields(): array
     {
         $block = match ($this) {
-            CampaignActionType::BulkEngagement => EngagementBatchBlock::make(),
+            CampaignActionType::BulkEngagementEmail => EngagementBatchEmailBlock::make(),
+            CampaignActionType::BulkEngagementSms => EngagementBatchSmsBlock::make(),
             CampaignActionType::ServiceRequest => ServiceRequestBlock::make(),
             CampaignActionType::ProactiveAlert => ProactiveAlertBlock::make(),
             CampaignActionType::Interaction => InteractionBlock::make(),
@@ -124,7 +131,8 @@ enum CampaignActionType: string implements HasLabel
     public function getStepSummaryView(): string
     {
         return match ($this) {
-            CampaignActionType::BulkEngagement => 'filament.forms.components.campaigns.actions.bulk-engagement',
+            CampaignActionType::BulkEngagementEmail => 'filament.forms.components.campaigns.actions.bulk-engagement',
+            CampaignActionType::BulkEngagementSms => 'filament.forms.components.campaigns.actions.bulk-engagement',
             CampaignActionType::ServiceRequest => 'filament.forms.components.campaigns.actions.service-request',
             CampaignActionType::ProactiveAlert => 'filament.forms.components.campaigns.actions.proactive-alert',
             CampaignActionType::Interaction => 'filament.forms.components.campaigns.actions.interaction',
@@ -137,7 +145,8 @@ enum CampaignActionType: string implements HasLabel
     public function executeAction(CampaignAction $action): bool|string
     {
         return match ($this) {
-            CampaignActionType::BulkEngagement => EngagementBatch::executeFromCampaignAction($action),
+            CampaignActionType::BulkEngagementEmail => EngagementBatch::executeFromCampaignAction($action),
+            CampaignActionType::BulkEngagementSms => EngagementBatch::executeFromCampaignAction($action),
             CampaignActionType::ServiceRequest => ServiceRequest::executeFromCampaignAction($action),
             CampaignActionType::ProactiveAlert => Alert::executeFromCampaignAction($action),
             CampaignActionType::Interaction => Interaction::executeFromCampaignAction($action),

--- a/app-modules/campaign/src/Filament/Blocks/EngagementBatchEmailBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/EngagementBatchEmailBlock.php
@@ -51,15 +51,14 @@ use Filament\Forms\Components\DateTimePicker;
 use AdvisingApp\Engagement\Models\EmailTemplate;
 use AdvisingApp\Campaign\Settings\CampaignSettings;
 use AdvisingApp\Engagement\Enums\EngagementDeliveryMethod;
-use AdvisingApp\Engagement\Filament\Resources\EngagementResource\Fields\EngagementSmsBodyField;
 
-class EngagementBatchBlock extends CampaignActionBlock
+class EngagementBatchEmailBlock extends CampaignActionBlock
 {
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->label('Email or Text');
+        $this->label('Email');
 
         $this->schema($this->createFields());
     }
@@ -67,21 +66,14 @@ class EngagementBatchBlock extends CampaignActionBlock
     public function generateFields(string $fieldPrefix = ''): array
     {
         return [
-            Select::make($fieldPrefix . 'delivery_method')
-                ->columnSpanFull()
-                ->live()
-                ->label('How would you like to send this engagement?')
-                ->options(EngagementDeliveryMethod::getOptions())
+            TextInput::make($fieldPrefix . 'delivery_method')
                 ->default(EngagementDeliveryMethod::Email->value)
-                ->disableOptionWhen(fn (string $value): bool => EngagementDeliveryMethod::tryFrom($value)?->getCaseDisabled())
-                ->selectablePlaceholder(false)
-                ->validationAttribute('Delivery Method')
-                ->required(),
+                ->hidden()
+                ->disabled(),
             TextInput::make($fieldPrefix . 'subject')
                 ->columnSpanFull()
                 ->placeholder(__('Subject'))
-                ->required()
-                ->hidden(fn (callable $get) => collect($get($fieldPrefix . 'delivery_method'))->doesntContain(EngagementDeliveryMethod::Email->value)),
+                ->required(),
             TiptapEditor::make($fieldPrefix . 'body')
                 ->disk('s3-public')
                 ->visibility('public')
@@ -143,11 +135,8 @@ class EngagementBatchBlock extends CampaignActionBlock
 
                         $component->state($template->content);
                     }))
-                ->hidden(fn (Get $get): bool => $get($fieldPrefix . 'delivery_method') === EngagementDeliveryMethod::Sms->value)
                 ->helperText('You can insert student information by typing {{ and choosing a merge value to insert.')
                 ->columnSpanFull(),
-            EngagementSmsBodyField::make(context: 'create')
-                ->hidden(fn (Get $get): bool => $get($fieldPrefix . 'delivery_method') === EngagementDeliveryMethod::Email->value),
             DateTimePicker::make('execute_at')
                 ->label('When should the journey step be executed?')
                 ->columnSpanFull()
@@ -162,6 +151,6 @@ class EngagementBatchBlock extends CampaignActionBlock
 
     public static function type(): string
     {
-        return 'bulk_engagement';
+        return 'bulk_engagement_email';
     }
 }

--- a/app-modules/campaign/src/Filament/Blocks/EngagementBatchSmsBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/EngagementBatchSmsBlock.php
@@ -34,53 +34,48 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Campaign\Database\Factories;
+namespace AdvisingApp\Campaign\Filament\Blocks;
 
-use Carbon\Carbon;
-use AdvisingApp\Campaign\Models\Campaign;
-use AdvisingApp\Campaign\Enums\CampaignActionType;
-use Illuminate\Database\Eloquent\Factories\Factory;
+use Carbon\CarbonImmutable;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\DateTimePicker;
+use AdvisingApp\Campaign\Settings\CampaignSettings;
+use AdvisingApp\Engagement\Enums\EngagementDeliveryMethod;
+use AdvisingApp\Engagement\Filament\Resources\EngagementResource\Fields\EngagementSmsBodyField;
 
-/**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\AdvisingApp\Campaign\Models\CampaignAction>
- */
-class CampaignActionFactory extends Factory
+class EngagementBatchSmsBlock extends CampaignActionBlock
 {
-    public function definition(): array
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Text');
+
+        $this->schema($this->createFields());
+    }
+
+    public function generateFields(string $fieldPrefix = ''): array
     {
         return [
-            'campaign_id' => Campaign::factory(),
-            'type' => fake()->randomElement([
-                CampaignActionType::BulkEngagementEmail,
-                CampaignActionType::BulkEngagementSms,
-            ]),
-            'data' => [],
-            'execute_at' => fake()->dateTimeBetween('+1 week', '+1 year'),
+            TextInput::make($fieldPrefix . 'delivery_method')
+                ->default(EngagementDeliveryMethod::Sms->value)
+                ->hidden()
+                ->disabled(),
+            EngagementSmsBodyField::make(context: 'create'),
+            DateTimePicker::make('execute_at')
+                ->label('When should the journey step be executed?')
+                ->columnSpanFull()
+                ->timezone(app(CampaignSettings::class)->getActionExecutionTimezone())
+                ->helperText(app(CampaignSettings::class)->getActionExecutionTimezoneLabel())
+                ->lazy()
+                ->hint(fn ($state): ?string => filled($state) ? $this->generateUserTimezoneHint(CarbonImmutable::parse($state)) : null)
+                ->required()
+                ->minDate(now()),
         ];
     }
 
-    public function successfulExecution(?Carbon $at = null): self
+    public static function type(): string
     {
-        return $this->state([
-            'execute_at' => $at ?? now(),
-            'last_execution_attempt_at' => $at ?? now(),
-            'successfully_executed_at' => $at ?? now(),
-        ]);
-    }
-
-    public function failedExecution(?Carbon $at = null): self
-    {
-        return $this->state([
-            'execute_at' => $at ?? now(),
-            'last_execution_attempt_at' => $at ?? now(),
-            'last_execution_attempt_error' => fake()->sentence(),
-        ]);
-    }
-
-    public function campaignDisabled(): self
-    {
-        return $this->state([
-            'campaign_id' => Campaign::factory()->disabled(),
-        ]);
+        return 'bulk_engagement_sms';
     }
 }

--- a/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
@@ -32,14 +32,19 @@
 </COPYRIGHT>
 --}}
 @php
-    use Carbon\Carbon;
     use AdvisingApp\Campaign\Settings\CampaignSettings;
+    use AdvisingApp\Engagement\Enums\EngagementDeliveryMethod;
     use AdvisingApp\Engagement\Models\EngagementBatch;
+    use Carbon\Carbon;
 @endphp
 
 <x-filament::fieldset>
     <x-slot name="label">
-        Email or Text
+        @if ($action['delivery_method'] === EngagementDeliveryMethod::Email->value)
+            Email
+        @else
+            Text
+        @endif
     </x-slot>
 
     <dl class="max-w-md divide-y divide-gray-200 text-gray-900 dark:divide-gray-700 dark:text-white">
@@ -51,10 +56,12 @@
                 </x-filament::badge>
             </dd>
         </div>
-        <div class="flex flex-col pt-3">
-            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Subject</dt>
-            <dd class="text-sm font-semibold">{{ $action['subject'] }}</dd>
-        </div>
+        @if (isset($action['subject']))
+            <div class="flex flex-col pt-3">
+                <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Subject</dt>
+                <dd class="text-sm font-semibold">{{ $action['subject'] }}</dd>
+            </div>
+        @endif
         @if ($action['body'])
             <div class="flex flex-col pt-3">
                 <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Body</dt>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-543

### Technical Description

> Adds new campaign action types so that email and sms are handled independently. 

### Screenshots (if appropriate)

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
