### PR TITLE
[ADVAPP-565]: Email templates content breaks when you save them on the edit page 

### DIFF
--- a/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/EditEmailTemplate.php
+++ b/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/EditEmailTemplate.php
@@ -41,7 +41,6 @@ use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
-use FilamentTiptapEditor\Enums\TiptapOutput;
 use App\Filament\Forms\Components\TiptapEditor;
 use AdvisingApp\Engagement\Filament\Resources\EmailTemplateResource;
 
@@ -70,7 +69,6 @@ class EditEmailTemplate extends EditRecord
                         'student email',
                     ])
                     ->profile('email')
-                    ->output(TiptapOutput::Json)
                     ->columnSpanFull()
                     ->extraInputAttributes(['style' => 'min-height: 12rem;'])
                     ->required(),

--- a/app-modules/engagement/src/Filament/Resources/SmsTemplateResource/Pages/EditSmsTemplate.php
+++ b/app-modules/engagement/src/Filament/Resources/SmsTemplateResource/Pages/EditSmsTemplate.php
@@ -41,7 +41,6 @@ use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
-use FilamentTiptapEditor\Enums\TiptapOutput;
 use App\Filament\Forms\Components\TiptapEditor;
 use AdvisingApp\Engagement\Filament\Resources\SmsTemplateResource;
 
@@ -68,7 +67,6 @@ class EditSmsTemplate extends EditRecord
                         'student email',
                     ])
                     ->profile('sms')
-                    ->output(TiptapOutput::Json)
                     ->columnSpanFull()
                     ->extraInputAttributes(['style' => 'min-height: 12rem;'])
                     ->required(),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-565

### Technical Description

> Fixes a double encoding issue on editing email/sms templates

### Screenshots (if appropriate)

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
