### PR TITLE
[Hotfix]: Adjust how users are searched and selected in Team User manager

### DIFF
--- a/app-modules/team/src/Filament/Resources/TeamResource/RelationManagers/UsersRelationManager.php
+++ b/app-modules/team/src/Filament/Resources/TeamResource/RelationManagers/UsersRelationManager.php
@@ -51,7 +51,7 @@ class UsersRelationManager extends RelationManager
 {
     protected static string $relationship = 'users';
 
-    protected static ?string $recordTitleAttribute = 'email';
+    protected static ?string $recordTitleAttribute = 'name';
 
     public function form(Form $form): Form
     {
@@ -74,6 +74,7 @@ class UsersRelationManager extends RelationManager
             ->headerActions([
                 AttachAction::make()
                     ->label('Add user to this team')
+                    ->recordSelectSearchColumns(['name', 'email'])
                     //TODO: remove this if we support multiple teams
                     ->form(fn (AttachAction $action): array => [
                         $action->getRecordSelect()


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Adjusts the Team User relation manager to be able to search via name and email and to display via name.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
