### PR TITLE
[Hotfix] Reduce default queue workers started

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY docker/s6-overlay/s6-rc.d/ /etc/s6-overlay/s6-rc.d/
 COPY ./docker/s6-overlay/user/ /etc/s6-overlay/s6-rc.d/user/contents.d/
 COPY ./docker/s6-overlay/templates/ /tmp/s6-overlay-templates
 
-ARG TOTAL_QUEUE_WORKERS=10
+ARG TOTAL_QUEUE_WORKERS=3
 
 COPY ./docker/generate-queues.sh /generate-queues.sh
 RUN chmod +x /generate-queues.sh


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Hotfix to reduce the default amount of workers started.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
