### PR TITLE
[Bugfix] Increase AI Max Length to 25000

### DIFF
--- a/app-modules/ai/resources/views/components/assistant.blade.php
+++ b/app-modules/ai/resources/views/components/assistant.blade.php
@@ -415,6 +415,7 @@
                                 x-bind:disabled="isSendingMessage"
                                 placeholder="Type here..."
                                 required
+                                maxlength="25000"
                             ></textarea>
                         </div>
                         <div class="flex items-center justify-between border-t px-3 py-2 dark:border-gray-600">

--- a/app-modules/ai/src/Http/Requests/SendMessageRequest.php
+++ b/app-modules/ai/src/Http/Requests/SendMessageRequest.php
@@ -56,7 +56,7 @@ class SendMessageRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'content' => ['required', 'string', 'max:1000'],
+            'content' => ['required', 'string', 'max:25000'],
         ];
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Changes the AI max length to 25000, also prevents a User from adding more than 25000 chars to the textarea.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
