### PR TITLE
[ADVAPP-594]: Prevent super admin email and text messaging from counting towards customer limits

### DIFF
--- a/app-modules/notification/src/Notifications/BaseNotification.php
+++ b/app-modules/notification/src/Notifications/BaseNotification.php
@@ -120,6 +120,11 @@ abstract class BaseNotification extends Notification implements ShouldQueue
         $this->afterSendHook($notifiable, $deliverable);
     }
 
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+
     protected function beforeSendHook(object $notifiable, OutboundDeliverable $deliverable, string $channel): void {}
 
     protected function afterSendHook(object $notifiable, OutboundDeliverable $deliverable): void {}

--- a/app-modules/notification/src/Notifications/Channels/EmailChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/EmailChannel.php
@@ -127,7 +127,7 @@ class EmailChannel extends MailChannel
     public static function determineQuotaUsage(array $recipients): int
     {
         return collect($recipients)->filter(function ($recipient) {
-            $user = User::where('email', $recipient->getAddress())->first();
+            $user = User::with('roles')->where('email', $recipient->getAddress())->first();
 
             return ! $user || ! $user->hasRole('authorization.super_admin');
         })->count();

--- a/app-modules/notification/src/Notifications/Channels/SmsChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/SmsChannel.php
@@ -141,7 +141,7 @@ class SmsChannel
 
     public static function determineQuotaUsage(SmsChannelResultData $result): int
     {
-        if ($user = User::where('phone_number', $result->message->to)->first()) {
+        if ($user = User::with('roles')->where('phone_number', $result->message->to)->first()) {
             if ($user->hasRole('authorization.super_admin')) {
                 return 0;
             }

--- a/app-modules/notification/tests/Features/NotificationSendingTest.php
+++ b/app-modules/notification/tests/Features/NotificationSendingTest.php
@@ -68,7 +68,7 @@ it('will create an outbound deliverable for each of the channels that the notifi
     expect(OutboundDeliverable::where('channel', NotificationChannel::Database)->count())->toBe(1);
 });
 
-it('will not count email or sms sent to Super Admins against quota usage', function () {
+it('will not count emails sent to Super Admin Users against quota usage', function () {
     // Given that we have a super admin user
     $user = User::factory()->create();
     $nonSuperAdminUser = User::factory()->create();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -81,6 +81,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use AdvisingApp\ServiceManagement\Models\ChangeRequestType;
 use AdvisingApp\InAppCommunication\Models\TwilioConversation;
 use AdvisingApp\Engagement\Models\Concerns\HasManyEngagements;
+use AdvisingApp\Notification\Models\Concerns\NotifiableViaSms;
 use AdvisingApp\Timeline\Models\Contracts\HasFilamentResource;
 use AdvisingApp\ServiceManagement\Models\ChangeRequestResponse;
 use AdvisingApp\InAppCommunication\Models\TwilioConversationUser;
@@ -107,6 +108,7 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
     use CanConsent;
     use Impersonate;
     use InteractsWithMedia;
+    use NotifiableViaSms;
 
     protected $hidden = [
         'remember_token',
@@ -495,6 +497,11 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
         }
 
         return "{$context}. When you respond please use this information about me to tailor your response. You should refer to me by my name and remember what my name and job title are, using it in your responses when appropriate.";
+    }
+
+    public function routeNotificationForSms(): string
+    {
+        return $this->phone_number;
     }
 
     protected function serializeDate(DateTimeInterface $date): string

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -53,13 +53,14 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-            'remember_token' => Str::random(10),
-            'is_external' => false,
             'default_assistant_chat_folders_created' => false,
+            'email_verified_at' => now(),
+            'email' => fake()->unique()->safeEmail(),
+            'is_external' => false,
+            'name' => fake()->name(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'phone_number' => fake()->phoneNumber(),
+            'remember_token' => Str::random(10),
         ];
     }
 

--- a/tests/Unit/LicenseSettingsEmailQuotaTracking.php
+++ b/tests/Unit/LicenseSettingsEmailQuotaTracking.php
@@ -37,6 +37,7 @@
 use App\Models\User;
 use App\Settings\LicenseSettings;
 use Illuminate\Support\Facades\Event;
+use Tests\Unit\TestEmailNotification;
 use Illuminate\Mail\Events\MessageSent;
 
 use function Pest\Laravel\assertDatabaseCount;
@@ -56,7 +57,7 @@ it('An email is allowed to be sent if there is available quota and its quota usa
 
     $notifiable = User::factory()->create();
 
-    $notification = new Tests\Unit\TestEmailNotification();
+    $notification = new TestEmailNotification();
 
     $notifiable->notify($notification);
 
@@ -89,7 +90,7 @@ it('An email is prevented from being sent if there is no available quota', funct
 
     $notifiable = User::factory()->create();
 
-    $notification = new Tests\Unit\TestEmailNotification();
+    $notification = new TestEmailNotification();
 
     expect(fn () => $notifiable->notify($notification))->toThrow(NotificationQuotaExceeded::class);
 
@@ -116,7 +117,7 @@ it('An email is sent to a super admin user even if there is no available quota',
 
     $notifiable->assignRole('authorization.super_admin');
 
-    $notification = new Tests\Unit\TestEmailNotification();
+    $notification = new TestEmailNotification();
 
     $notifiable->notify($notification);
 

--- a/tests/Unit/LicenseSettingsSmsQuotaTracking.php
+++ b/tests/Unit/LicenseSettingsSmsQuotaTracking.php
@@ -34,6 +34,7 @@
 </COPYRIGHT>
 */
 
+use App\Models\User;
 use Twilio\Rest\Client;
 use Tests\Unit\ClientMock;
 use Twilio\Rest\Api\V2010;
@@ -50,7 +51,7 @@ use AdvisingApp\IntegrationTwilio\Settings\TwilioSettings;
 use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
 use AdvisingApp\Notification\Exceptions\NotificationQuotaExceeded;
 
-it('An sms is allowed to be sent if there is available quota and it\'s quota usage is tracked', function () {
+it('An sms is allowed to be sent if there is available quota and its quota usage is tracked', function () {
     $notifiable = Prospect::factory()->create();
 
     $notification = new Tests\Unit\TestSmsNotification();
@@ -145,4 +146,54 @@ it('An sms is prevented from being sent if there is no available quota', functio
         ->toThrow(NotificationQuotaExceeded::class);
 
     assertDatabaseCount(OutboundDeliverable::class, 0);
+});
+
+it('An sms is sent to a super admin user even if there is no available quota', function () {
+    $notifiable = User::factory()->create();
+
+    $notifiable->assignRole('authorization.super_admin');
+
+    $notification = new Tests\Unit\TestSmsNotification();
+
+    $settings = app()->make(TwilioSettings::class);
+
+    $settings->account_sid = 'abc123';
+    $settings->auth_token = 'abc123';
+    $settings->from_number = '+11231231234';
+
+    $settings->save();
+
+    $licenseSettings = app(LicenseSettings::class);
+
+    $licenseSettings->data->limits->sms = 0;
+    $licenseSettings->save();
+
+    $mockMessageList = mock(MessageList::class);
+
+    $numSegments = rand(1, 5);
+
+    $mockMessageList->shouldReceive('create')->andReturn(
+        new MessageInstance(
+            new V2010(new MessagingBase(new Client())),
+            [
+                'sid' => 'abc123',
+                'status' => 'queued',
+                'from' => '+11231231234',
+                'to' => $notifiable->phone_number,
+                'body' => 'test',
+                'num_segments' => $numSegments,
+            ],
+            'abc123'
+        )
+    );
+
+    app()->bind(Client::class, fn () => new ClientMock(
+        messageList: $mockMessageList,
+        username: $settings->account_sid,
+        password: $settings->auth_token,
+    ));
+
+    $notifiable->notify($notification);
+
+    assertDatabaseCount(OutboundDeliverable::class, 1);
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-594

### Technical Description

> This PR adds handling to ensure we don't count emails/sms sent to Users with the `authorization.super_admin` against organizational quota usage.

### Screenshots (if appropriate)

### Any deployment steps required?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
