### PR TITLE
[ADVAPP-630]: Setting division when creating a knowledge article produces an error

### DIFF
--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseArticleResource/Pages/CreateKnowledgeBaseArticle.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseArticleResource/Pages/CreateKnowledgeBaseArticle.php
@@ -94,6 +94,7 @@ class CreateKnowledgeBaseArticle extends CreateRecord
                             ->exists((new KnowledgeBaseCategory())->getTable(), (new KnowledgeBaseCategory())->getKeyName()),
                         Select::make('division')
                             ->label('Division')
+                            ->multiple()
                             ->relationship('division', 'name')
                             ->searchable(['name', 'code'])
                             ->preload()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseArticleResource/Pages/EditKnowledgeBaseArticleMetadata.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseArticleResource/Pages/EditKnowledgeBaseArticleMetadata.php
@@ -84,6 +84,7 @@ class EditKnowledgeBaseArticleMetadata
                         ->exists((new KnowledgeBaseCategory())->getTable(), (new KnowledgeBaseCategory())->getKeyName()),
                     Select::make('division')
                         ->label('Division')
+                        ->multiple()
                         ->relationship('division', 'name')
                         ->searchable(['name', 'code'])
                         ->preload()


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-630

### Technical Description

Resolves the bug triggered when you try and set a Division for a KnowledgeBaseArticle. The relationship is a `belongsToMany` and we were using a simple select, so it would throw errors when trying to save.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
