### PR TITLE
[ADVAPP-633]: Engagement Timeline throw errors sometimes

### DIFF
--- a/app-modules/engagement/resources/views/components/engagement-timeline-item.blade.php
+++ b/app-modules/engagement/resources/views/components/engagement-timeline-item.blade.php
@@ -57,22 +57,9 @@
                             class="h-5 w-5 text-gray-400 dark:text-gray-100"
                             icon="heroicon-o-envelope"
                         />
-                        @php
-                            $emailStatusColor = match ($deliverable->delivery_status) {
-                                EngagementDeliveryStatus::Awaiting => 'text-yellow-500',
-                                EngagementDeliveryStatus::Successful => 'text-green-500',
-                                EngagementDeliveryStatus::Failed => 'text-red-500',
-                            };
-
-                            $emailStatusIcon = match ($deliverable->delivery_status) {
-                                EngagementDeliveryStatus::Awaiting => 'heroicon-s-clock',
-                                EngagementDeliveryStatus::Successful => 'heroicon-s-check-circle',
-                                EngagementDeliveryStatus::Failed => 'heroicon-s-exclamation-circle',
-                            };
-                        @endphp
                         <x-filament::icon
-                            class="{{ $emailStatusColor }} absolute bottom-0 right-0 h-2 w-2"
-                            icon="{{ $emailStatusIcon }}"
+                            class="{{ $deliverable->delivery_status->getTextColorClass() }} absolute bottom-0 right-0 h-2 w-2"
+                            icon="{{ $deliverable->delivery_status->getIconClass() }}"
                         />
                     </div>
                 @endif
@@ -82,22 +69,9 @@
                             class="h-5 w-5 text-gray-400 dark:text-gray-100"
                             icon="heroicon-o-chat-bubble-left"
                         />
-                        @php
-                            $smsStatusColor = match ($deliverable->delivery_status) {
-                                EngagementDeliveryStatus::Awaiting => 'text-yellow-500',
-                                EngagementDeliveryStatus::Successful => 'text-green-500',
-                                EngagementDeliveryStatus::Failed => 'text-red-500',
-                            };
-
-                            $smsStatusIcon = match ($deliverable->delivery_status) {
-                                EngagementDeliveryStatus::Awaiting => 'heroicon-s-clock',
-                                EngagementDeliveryStatus::Successful => 'heroicon-s-check-circle',
-                                EngagementDeliveryStatus::Failed => 'heroicon-s-exclamation-circle',
-                            };
-                        @endphp
                         <x-filament::icon
-                            class="{{ $smsStatusColor }} absolute bottom-0 right-0 h-2 w-2"
-                            icon="{{ $smsStatusIcon }}"
+                            class="{{ $deliverable->delivery_status->getTextColorClass() }} absolute bottom-0 right-0 h-2 w-2"
+                            icon="{{ $deliverable->delivery_status->getIconClass() }}"
                         />
                     </div>
                 @endif

--- a/app-modules/engagement/src/Enums/EngagementDeliveryStatus.php
+++ b/app-modules/engagement/src/Enums/EngagementDeliveryStatus.php
@@ -45,4 +45,56 @@ enum EngagementDeliveryStatus: string
 
     case Successful = 'successful';
     case Failed = 'failed';
+
+    public function getTextColorClass(): string
+    {
+        return match ($this) {
+            EngagementDeliveryStatus::Awaiting,
+            EngagementDeliveryStatus::Dispatched => 'text-yellow-500',
+
+            EngagementDeliveryStatus::Successful => 'text-green-500',
+
+            EngagementDeliveryStatus::Failed,
+            EngagementDeliveryStatus::RateLimited,
+            EngagementDeliveryStatus::DispatchFailed => 'text-red-500',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            EngagementDeliveryStatus::Awaiting,
+            EngagementDeliveryStatus::Dispatched => 'info',
+
+            EngagementDeliveryStatus::Successful => 'success',
+
+            EngagementDeliveryStatus::Failed,
+            EngagementDeliveryStatus::RateLimited,
+            EngagementDeliveryStatus::DispatchFailed => 'danger',
+        };
+    }
+
+    public function getIconClass(): string
+    {
+        return match ($this) {
+            EngagementDeliveryStatus::Awaiting,
+            EngagementDeliveryStatus::Dispatched => 'heroicon-s-clock',
+
+            EngagementDeliveryStatus::Successful => 'heroicon-s-check-circle',
+
+            EngagementDeliveryStatus::Failed,
+            EngagementDeliveryStatus::RateLimited,
+            EngagementDeliveryStatus::DispatchFailed => 'heroicon-s-exclamation-circle',
+        };
+    }
+
+    public function getMessage(): string
+    {
+        return match ($this) {
+            EngagementDeliveryStatus::Successful => 'Successfully delivered',
+            EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'Awaiting delivery',
+            EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed => 'Failed to send',
+            EngagementDeliveryStatus::RateLimited => 'Failed to send due to rate limits',
+        };
+    }
 }

--- a/app-modules/engagement/src/Filament/Concerns/EngagementInfolist.php
+++ b/app-modules/engagement/src/Filament/Concerns/EngagementInfolist.php
@@ -67,16 +67,8 @@ trait EngagementInfolist
                     TextEntry::make('deliverable.channel')
                         ->label('Channel'),
                     IconEntry::make('deliverable.delivery_status')
-                        ->icon(fn (EngagementDeliveryStatus $state): string => match ($state) {
-                            EngagementDeliveryStatus::Successful => 'heroicon-o-check-circle',
-                            EngagementDeliveryStatus::Awaiting => 'heroicon-o-clock',
-                            EngagementDeliveryStatus::Failed => 'heroicon-o-x-circle',
-                        })
-                        ->color(fn (EngagementDeliveryStatus $state): string => match ($state) {
-                            EngagementDeliveryStatus::Successful => 'success',
-                            EngagementDeliveryStatus::Awaiting => 'warning',
-                            EngagementDeliveryStatus::Failed => 'danger',
-                        })
+                        ->icon(fn (EngagementDeliveryStatus $state): string => $state->getIconClass())
+                        ->color(fn (EngagementDeliveryStatus $state): string => $state->getColor())
                         ->label('Status'),
                     TextEntry::make('deliverable.delivered_at')
                         ->label('Delivered At')

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/RelationManagers/EngagementDeliverablesRelationManager.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/RelationManagers/EngagementDeliverablesRelationManager.php
@@ -78,16 +78,8 @@ class EngagementDeliverablesRelationManager extends RelationManager
                 IdColumn::make(),
                 TextColumn::make('channel'),
                 IconColumn::make('delivery_status')
-                    ->icon(fn (EngagementDeliveryStatus $state): string => match ($state) {
-                        EngagementDeliveryStatus::Successful => 'heroicon-o-check-circle',
-                        EngagementDeliveryStatus::Awaiting => 'heroicon-o-clock',
-                        EngagementDeliveryStatus::Failed => 'heroicon-o-x-circle',
-                    })
-                    ->color(fn (EngagementDeliveryStatus $state): string => match ($state) {
-                        EngagementDeliveryStatus::Successful => 'success',
-                        EngagementDeliveryStatus::Awaiting => 'info',
-                        EngagementDeliveryStatus::Failed => 'danger',
-                    }),
+                    ->icon(fn (EngagementDeliveryStatus $state): string => $state->getIconClass())
+                    ->color(fn (EngagementDeliveryStatus $state): string => $state->getColor()),
             ])
             ->headerActions([
                 CreateAction::make(),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementsRelationManager.php
@@ -90,23 +90,10 @@ class EngagementsRelationManager extends RelationManager
                             ->label('Channel'),
                         TextEntry::make('deliverable.delivery_status')
                             ->iconPosition(IconPosition::After)
-                            ->icon(fn (EngagementDeliveryStatus $state): string => match ($state) {
-                                EngagementDeliveryStatus::Successful => 'heroicon-o-check-circle',
-                                EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'heroicon-o-clock',
-                                EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed, EngagementDeliveryStatus::RateLimited => 'heroicon-o-x-circle',
-                            })
-                            ->iconColor(fn (EngagementDeliveryStatus $state): string => match ($state) {
-                                EngagementDeliveryStatus::Successful => 'success',
-                                EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'info',
-                                EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed, EngagementDeliveryStatus::RateLimited => 'danger',
-                            })
+                            ->icon(fn (EngagementDeliveryStatus $state): string => $state->getIconClass())
+                            ->iconColor(fn (EngagementDeliveryStatus $state): string => $state->getColor())
                             ->label('Status')
-                            ->formatStateUsing(fn (Engagement $engagement): string => match ($engagement->deliverable->delivery_status) {
-                                EngagementDeliveryStatus::Successful => 'Successfully delivered',
-                                EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'Awaiting delivery',
-                                EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed => 'Failed to send',
-                                EngagementDeliveryStatus::RateLimited => 'Failed to send due to rate limits',
-                            }),
+                            ->formatStateUsing(fn (Engagement $engagement): string => $engagement->deliverable->delivery_status->getMessage()),
                         TextEntry::make('deliverable.delivered_at')
                             ->label('Delivered At')
                             ->hidden(fn (Engagement $engagement): bool => is_null($engagement->deliverable->delivered_at)),

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -90,23 +90,10 @@ class EngagementsRelationManager extends RelationManager
                             ->label('Channel'),
                         TextEntry::make('deliverable.delivery_status')
                             ->iconPosition(IconPosition::After)
-                            ->icon(fn (EngagementDeliveryStatus $state): string => match ($state) {
-                                EngagementDeliveryStatus::Successful => 'heroicon-o-check-circle',
-                                EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'heroicon-o-clock',
-                                EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed, EngagementDeliveryStatus::RateLimited => 'heroicon-o-x-circle',
-                            })
-                            ->iconColor(fn (EngagementDeliveryStatus $state): string => match ($state) {
-                                EngagementDeliveryStatus::Successful => 'success',
-                                EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'info',
-                                EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed, EngagementDeliveryStatus::RateLimited => 'danger',
-                            })
+                            ->icon(fn (EngagementDeliveryStatus $state): string => $state->getIconClass())
+                            ->iconColor(fn (EngagementDeliveryStatus $state): string => $state->getColor())
                             ->label('Status')
-                            ->formatStateUsing(fn (Engagement $engagement): string => match ($engagement->deliverable->delivery_status) {
-                                EngagementDeliveryStatus::Successful => 'Successfully delivered',
-                                EngagementDeliveryStatus::Awaiting, EngagementDeliveryStatus::Dispatched => 'Awaiting delivery',
-                                EngagementDeliveryStatus::Failed, EngagementDeliveryStatus::DispatchFailed => 'Failed to send',
-                                EngagementDeliveryStatus::RateLimited => 'Failed to send due to rate limits',
-                            }),
+                            ->formatStateUsing(fn (Engagement $engagement): string => $engagement->deliverable->delivery_status->getMessage()),
                         TextEntry::make('deliverable.delivered_at')
                             ->label('Delivered At')
                             ->hidden(fn (Engagement $engagement): bool => is_null($engagement->deliverable->delivered_at)),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-633

### Technical Description

Fixes errors caused by missing values in match statements for EngagementStatus. Unified all references into the ENUM itself and made sure all were filled out.

https://canyongbs.sentry.io/issues/5361466202/?project=4507045956943872&query=is:unresolved+issue.priority:%5Bhigh,+medium%5D+EngagementDeliveryStatus&statsPeriod=14d&stream_index=0
https://canyongbs.sentry.io/issues/5360445655/?project=4507045956943872&query=is:unresolved+issue.priority:%5Bhigh,+medium%5D+EngagementDeliveryStatus&statsPeriod=14d&stream_index=1
https://canyongbs.sentry.io/issues/5396331121/?project=4507045956943872&query=is:unresolved+issue.priority:%5Bhigh,+medium%5D+EngagementDeliveryStatus&statsPeriod=14d&stream_index=2

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
