### PR TITLE
[ADVAPP-601]: Enhance the AI assistant so that the LLM credentials are isolated per tenant

### DIFF
--- a/app-modules/ai/database/migrations/2024_06_04_144637_seed_ai_integration_settings_permission.php
+++ b/app-modules/ai/database/migrations/2024_06_04_144637_seed_ai_integration_settings_permission.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Database\Migrations\Concerns\CanModifyPermissions;
+
+return new class () extends Migration {
+    use CanModifyPermissions;
+
+    public function up(): void
+    {
+        $this->createPermissions(
+            [
+                'ai.view_cognitive_services_settings' => 'Integration: Cognitive Services',
+            ],
+            guardName: 'web'
+        );
+    }
+
+    public function down(): void
+    {
+        $this->deletePermissions(
+            [
+                'ai.view_cognitive_services_settings',
+            ],
+            guardName: 'web',
+        );
+    }
+};

--- a/app-modules/ai/database/migrations/2024_06_04_144637_seed_ai_integration_settings_permission.php
+++ b/app-modules/ai/database/migrations/2024_06_04_144637_seed_ai_integration_settings_permission.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Database\Migrations\Concerns\CanModifyPermissions;
 

--- a/app-modules/ai/database/migrations/2024_06_04_150112_create_ai_integrations_settings.php
+++ b/app-modules/ai/database/migrations/2024_06_04_150112_create_ai_integrations_settings.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
 return new class () extends SettingsMigration {

--- a/app-modules/ai/database/migrations/2024_06_04_150112_create_ai_integrations_settings.php
+++ b/app-modules/ai/database/migrations/2024_06_04_150112_create_ai_integrations_settings.php
@@ -1,0 +1,27 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        $this->migrator->add('ai.open_ai_gpt_35_base_uri', config('integration-open-ai.gpt_35_base_uri'), encrypted: true);
+        $this->migrator->add('ai.open_ai_gpt_35_api_key', config('integration-open-ai.gpt_35_api_key'), encrypted: true);
+        $this->migrator->add('ai.open_ai_gpt_35_model', config('integration-open-ai.gpt_35_model'), encrypted: true);
+
+        $this->migrator->add('ai.open_ai_gpt_4_base_uri', config('integration-open-ai.gpt_4_base_uri'), encrypted: true);
+        $this->migrator->add('ai.open_ai_gpt_4_api_key', config('integration-open-ai.gpt_4_api_key'), encrypted: true);
+        $this->migrator->add('ai.open_ai_gpt_4_model', config('integration-open-ai.gpt_4_model'), encrypted: true);
+    }
+
+    public function down(): void
+    {
+        $this->migrator->deleteIfExists('ai.open_ai_gpt_35_base_uri');
+        $this->migrator->deleteIfExists('ai.open_ai_gpt_35_api_key');
+        $this->migrator->deleteIfExists('ai.open_ai_gpt_35_model');
+
+        $this->migrator->deleteIfExists('ai.open_ai_gpt_4_base_uri');
+        $this->migrator->deleteIfExists('ai.open_ai_gpt_4_api_key');
+        $this->migrator->deleteIfExists('ai.open_ai_gpt_4_model');
+    }
+};

--- a/app-modules/ai/src/Actions/ResetAiServiceIds.php
+++ b/app-modules/ai/src/Actions/ResetAiServiceIds.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AdvisingApp\Ai\Actions;
+
+use AdvisingApp\Ai\Enums\AiModel;
+use AdvisingApp\Ai\Models\AiThread;
+use AdvisingApp\Ai\Models\AiAssistant;
+
+class ResetAiServiceIds
+{
+    public function __invoke(AiModel $model): void
+    {
+        AiAssistant::query()
+            ->where('model', $model)
+            ->update([
+                'assistant_id' => null,
+            ]);
+
+        AiThread::query()
+            ->whereRelation('assistant', 'model', $model)
+            ->update([
+                'thread_id' => null,
+            ]);
+    }
+}

--- a/app-modules/ai/src/Actions/ResetAiServiceIds.php
+++ b/app-modules/ai/src/Actions/ResetAiServiceIds.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Ai\Actions;
 
 use AdvisingApp\Ai\Enums\AiModel;

--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Ai\Filament\Pages;
+
+use App\Models\User;
+use Filament\Forms\Form;
+use Filament\Actions\Action;
+use Livewire\Attributes\Locked;
+use Filament\Pages\SettingsPage;
+use AdvisingApp\Ai\Enums\AiModel;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Bus;
+use Filament\Support\Enums\MaxWidth;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\TextInput;
+use App\Filament\Clusters\GlobalSettings;
+use AdvisingApp\Ai\Actions\ResetAiServiceIds;
+use AdvisingApp\Ai\Jobs\ReInitializeAiService;
+use AdvisingApp\Ai\Settings\AiIntegrationsSettings;
+
+class ManageAiIntegrationsSettings extends SettingsPage
+{
+    protected static ?string $navigationIcon = 'heroicon-o-cog-6-tooth';
+
+    protected static string $settings = AiIntegrationsSettings::class;
+
+    protected static ?string $title = 'Cognitive Services Settings';
+
+    protected static ?string $navigationLabel = 'Cognitive Services';
+
+    protected static ?int $navigationSort = 100;
+
+    protected static ?string $navigationGroup = 'Product Integrations';
+
+    protected static ?string $cluster = GlobalSettings::class;
+
+    #[Locked]
+    public ?array $originalData = null;
+
+    public static function canAccess(): bool
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        return $user->can('ai.view_cognitive_services_settings');
+    }
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->columns(1)
+            ->schema([
+                Section::make('Azure OpenAI')
+                    ->collapsible()
+                    ->schema([
+                        Section::make('GPT 3.5')
+                            ->collapsible()
+                            ->schema([
+                                TextInput::make('open_ai_gpt_35_base_uri')
+                                    ->label('Base URI')
+                                    ->placeholder('https://example.openai.azure.com/openai')
+                                    ->url(),
+                                TextInput::make('open_ai_gpt_35_api_key')
+                                    ->label('API Key')
+                                    ->password()
+                                    ->autocomplete(false),
+                                TextInput::make('open_ai_gpt_35_model')
+                                    ->label('Model'),
+                            ]),
+                        Section::make('GPT 4')
+                            ->collapsible()
+                            ->schema([
+                                TextInput::make('open_ai_gpt_4_base_uri')
+                                    ->label('Base URI')
+                                    ->placeholder('https://example.openai.azure.com/openai')
+                                    ->url(),
+                                TextInput::make('open_ai_gpt_4_api_key')
+                                    ->label('API Key')
+                                    ->password()
+                                    ->autocomplete(false),
+                                TextInput::make('open_ai_gpt_4_model')
+                                    ->label('Model'),
+                            ]),
+                    ]),
+            ]);
+    }
+
+    public function getSaveFormAction(): Action
+    {
+        return parent::getSaveFormAction()
+            ->submit(null)
+            ->requiresConfirmation()
+            ->modalHeading('Sync all chats to this new service?')
+            ->modalDescription('If you are moving to a new account, you will need to sync all the data to the new service to minimize disruption. Advising App can do this for you, but if you just want to save the settings and do it yourself, you can choose to do so.')
+            ->modalWidth(MaxWidth::TwoExtraLarge)
+            ->modalSubmitActionLabel('Save and sync all chats')
+            ->extraModalFooterActions([
+                Action::make('justSave')
+                    ->label('Just save the settings')
+                    ->color('gray')
+                    ->action(fn () => $this->save())
+                    ->cancelParentActions(),
+            ])
+            ->action(function (ResetAiServiceIds $resetAiServiceIds) {
+                $openAiGpt35HasChanged = $this->originalData['open_ai_gpt_35_base_uri'] !== $this->data['open_ai_gpt_35_base_uri'];
+                $openAiGpt4HasChanged = $this->originalData['open_ai_gpt_4_base_uri'] !== $this->data['open_ai_gpt_4_base_uri'];
+
+                DB::transaction(function () use ($openAiGpt35HasChanged, $openAiGpt4HasChanged, $resetAiServiceIds) {
+                    if ($openAiGpt35HasChanged) {
+                        $resetAiServiceIds(AiModel::OpenAiGpt35);
+                    }
+
+                    if ($openAiGpt4HasChanged) {
+                        $resetAiServiceIds(AiModel::OpenAiGpt4);
+                    }
+                });
+
+                $this->save();
+
+                if ($openAiGpt35HasChanged) {
+                    Bus::batch([
+                        app(ReInitializeAiService::class, ['model' => AiModel::OpenAiGpt35->value]),
+                    ])->dispatch();
+                }
+
+                if ($openAiGpt4HasChanged) {
+                    Bus::batch([
+                        app(ReInitializeAiService::class, ['model' => AiModel::OpenAiGpt4->value]),
+                    ])->dispatch();
+                }
+            });
+    }
+
+    protected function rememberData(): void
+    {
+        parent::rememberData();
+
+        $this->originalData = $this->data;
+    }
+}

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -64,7 +64,7 @@ class AiAssistantForm
                     ->options(AiModel::class)
                     ->required()
                     ->visible(app()->hasDebugModeEnabled())
-                    ->hiddenOn('edit'),
+                    ->disabledOn('edit'),
                 Textarea::make('description')
                     ->columnSpanFull()
                     ->required(),

--- a/app-modules/ai/src/Jobs/ReInitializeAiThread.php
+++ b/app-modules/ai/src/Jobs/ReInitializeAiThread.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Ai\Jobs;
 
+use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Models\AiMessage;
@@ -44,10 +45,12 @@ use Illuminate\Queue\InteractsWithQueue;
 use Spatie\Multitenancy\Jobs\TenantAware;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 use AdvisingApp\IntegrationOpenAi\Services\BaseOpenAiService;
 
 class ReInitializeAiThread implements ShouldQueue, TenantAware
 {
+    use Batchable;
     use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
@@ -61,33 +64,21 @@ class ReInitializeAiThread implements ShouldQueue, TenantAware
     ) {}
 
     /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [(new WithoutOverlapping("reinitialise-{$this->thread->assistant->model->value}"))->releaseAfter(10)];
+    }
+
+    /**
      * Execute the job.
      */
     public function handle(): void
     {
         $this->thread->assistant->model->getService()->createThread($this->thread);
         $this->thread->save();
-
-        auth()->setUser($this->thread->user);
-
-        AiMessage::withoutEvents(function () {
-            $service = $this->thread->assistant->model->getService();
-
-            if (! ($service instanceof BaseOpenAiService)) {
-                return;
-            }
-
-            $client = $service->getClient();
-
-            $client->threads()->messages()->create($this->thread->thread_id, [
-                'role' => 'user',
-                'content' => 'This is a test message, please ignore this and never mention it again.',
-            ]);
-
-            $client->threads()->runs()->create($this->thread->thread_id, [
-                'assistant_id' => $this->thread->assistant->assistant_id,
-                'instructions' => invade($service)->generateAssistantInstructions($this->thread->assistant, withDynamicContext: true),
-            ]);
-        });
     }
 }

--- a/app-modules/ai/src/Jobs/ReInitializeAiThread.php
+++ b/app-modules/ai/src/Jobs/ReInitializeAiThread.php
@@ -39,14 +39,12 @@ namespace AdvisingApp\Ai\Jobs;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use AdvisingApp\Ai\Models\AiThread;
-use AdvisingApp\Ai\Models\AiMessage;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Spatie\Multitenancy\Jobs\TenantAware;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Middleware\WithoutOverlapping;
-use AdvisingApp\IntegrationOpenAi\Services\BaseOpenAiService;
 
 class ReInitializeAiThread implements ShouldQueue, TenantAware
 {

--- a/app-modules/ai/src/Settings/AiIntegrationsSettings.php
+++ b/app-modules/ai/src/Settings/AiIntegrationsSettings.php
@@ -34,27 +34,38 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\IntegrationOpenAi\Services;
+namespace AdvisingApp\Ai\Settings;
 
-use OpenAI;
-use AdvisingApp\Ai\Settings\AiIntegrationsSettings;
+use Spatie\LaravelSettings\Settings;
 
-class OpenAiGpt35Service extends BaseOpenAiService
+class AiIntegrationsSettings extends Settings
 {
-    public function __construct(
-        protected AiIntegrationsSettings $settings,
-    ) {
-        $this->client = OpenAI::factory()
-            ->withBaseUri($this->settings->open_ai_gpt_35_base_uri ?? config('integration-open-ai.gpt_35_base_uri'))
-            ->withHttpHeader('api-key', $this->settings->open_ai_gpt_35_api_key ?? config('integration-open-ai.gpt_35_api_key'))
-            ->withQueryParam('api-version', config('integration-open-ai.gpt_35_api_version'))
-            ->withHttpHeader('OpenAI-Beta', 'assistants=v1')
-            ->withHttpHeader('Accept', '*/*')
-            ->make();
+    public ?string $open_ai_gpt_35_base_uri = null;
+
+    public ?string $open_ai_gpt_35_api_key = null;
+
+    public ?string $open_ai_gpt_35_model = null;
+
+    public ?string $open_ai_gpt_4_base_uri = null;
+
+    public ?string $open_ai_gpt_4_api_key = null;
+
+    public ?string $open_ai_gpt_4_model = null;
+
+    public static function group(): string
+    {
+        return 'ai';
     }
 
-    public function getModel(): string
+    public static function encrypted(): array
     {
-        return $this->settings->open_ai_gpt_35_model ?? config('integration-open-ai.gpt_35_model');
+        return [
+            'open_ai_gpt_35_base_uri',
+            'open_ai_gpt_35_api_key',
+            'open_ai_gpt_35_model',
+            'open_ai_gpt_4_base_uri',
+            'open_ai_gpt_4_api_key',
+            'open_ai_gpt_4_model',
+        ];
     }
 }

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt4Service.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt4Service.php
@@ -37,14 +37,16 @@
 namespace AdvisingApp\IntegrationOpenAi\Services;
 
 use OpenAI;
+use AdvisingApp\Ai\Settings\AiIntegrationsSettings;
 
 class OpenAiGpt4Service extends BaseOpenAiService
 {
-    public function __construct()
-    {
+    public function __construct(
+        protected AiIntegrationsSettings $settings,
+    ) {
         $this->client = OpenAI::factory()
-            ->withBaseUri(config('integration-open-ai.gpt_4_base_uri'))
-            ->withHttpHeader('api-key', config('integration-open-ai.gpt_4_api_key'))
+            ->withBaseUri($this->settings->open_ai_gpt_4_base_uri ?? config('integration-open-ai.gpt_4_base_uri'))
+            ->withHttpHeader('api-key', $this->settings->open_ai_gpt_4_api_key ?? config('integration-open-ai.gpt_4_api_key'))
             ->withQueryParam('api-version', config('integration-open-ai.gpt_4_api_version'))
             ->withHttpHeader('OpenAI-Beta', 'assistants=v1')
             ->withHttpHeader('Accept', '*/*')
@@ -53,6 +55,6 @@ class OpenAiGpt4Service extends BaseOpenAiService
 
     public function getModel(): string
     {
-        return config('integration-open-ai.gpt_4_model');
+        return $this->settings->open_ai_gpt_4_model ?? config('integration-open-ai.gpt_4_model');
     }
 }

--- a/database/migrations/Concerns/CanModifyPermissions.php
+++ b/database/migrations/Concerns/CanModifyPermissions.php
@@ -86,4 +86,15 @@ trait CanModifyPermissions
                 ];
             }, array_keys($names), array_values($names)));
     }
+
+    /**
+     * @param array<string> $names
+     */
+    public function deletePermissions(array $names, string $guardName): void
+    {
+        DB::table('permissions')
+            ->where('guard_name', $guardName)
+            ->whereIn('name', $names)
+            ->delete();
+    }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-601

### Technical Description

On deployment, the default credentials are copied into the settings tables of all tenants. This also happens during the tenant creation process since migrations are run.

The Open AI clients will respect the settings table.

A warning message is displayed when updating integration settings. The user has the option to either just save the settings, or to also sync all the threads and assistants to the new account as well as saving.

If the user chooses to sync the threads and assistants, all IDs are removed from affected records before the settings are saved. After the settings are saved, a job batch is kicked off to repopulate the IDs from the new service.

If the assistants or threads are interacted with before their IDs have been reissued, they handle the situation gracefully and initialise themselves before proceeding.