### PR TITLE
[ADVAPP-636]: Clicking on a prospect from global search takes you to edit route

### DIFF
--- a/app-modules/prospect/src/Filament/Resources/ProspectResource.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource.php
@@ -104,6 +104,11 @@ class ProspectResource extends Resource
         ], fn (mixed $value): bool => filled($value));
     }
 
+    public static function getGlobalSearchResultUrl(Model $record): string
+    {
+        return ProspectResource::getUrl('view', ['record' => $record]);
+    }
+
     public static function getPages(): array
     {
         return [


### PR DESCRIPTION
…edit route

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-636

### Technical Description

> When you click on a prospect name from global search it takes you to the view route.