### PR TITLE
[ADVAPP-579]: Form validation issue for certain input types

### DIFF
--- a/app-modules/form/src/Actions/GenerateSubmissibleValidator.php
+++ b/app-modules/form/src/Actions/GenerateSubmissibleValidator.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Form\Actions;
+
+use Illuminate\Http\Request;
+use Illuminate\Validation\Validator;
+use AdvisingApp\Form\Models\Submissible;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
+
+class GenerateSubmissibleValidator
+{
+    public function __construct(
+        protected Request $request,
+        protected GenerateSubmissibleValidation $generateValidationRules,
+    ) {}
+
+    public function __invoke(Submissible $submissible): Validator
+    {
+        $inputs = collect($this->request->all())
+            ->dot()
+            ->filter();
+
+        $attributes = $inputs
+            ->keys()
+            ->mapWithKeys(function (string $key) use ($submissible): array {
+                $key = str($key);
+                $id = $key->afterLast('.');
+
+                return [$key->toString() => $id->isUuid() ? $submissible->fields()->find($id->toString())?->label : $key->toString()];
+            })
+            ->all();
+
+        return ValidatorFacade::make(
+            $inputs->undot()->all(),
+            ($this->generateValidationRules)($submissible),
+            attributes: $attributes,
+        );
+    }
+}

--- a/app-modules/form/src/Actions/ProcessSubmissionField.php
+++ b/app-modules/form/src/Actions/ProcessSubmissionField.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Form\Actions;
+
+use Illuminate\Support\Str;
+use AdvisingApp\Form\Models\Submission;
+use AdvisingApp\Form\Filament\Blocks\EducatableEmailFormFieldBlock;
+
+class ProcessSubmissionField
+{
+    public function __construct(
+        protected ResolveSubmissionAuthorFromEmail $resolveSubmissionAuthorFromEmail
+    ) {}
+
+    public function __invoke(Submission $submission, string $fieldId, mixed $response, array $fields): void
+    {
+        $submission->fields()->attach($fieldId, [
+            'id' => Str::orderedUuid(),
+            'response' => $response,
+        ]);
+
+        if ($submission->author) {
+            return;
+        }
+
+        if ($fields[$fieldId] !== EducatableEmailFormFieldBlock::type()) {
+            return;
+        }
+
+        $author = ($this->resolveSubmissionAuthorFromEmail)($response);
+
+        if (! $author) {
+            return;
+        }
+
+        $submission->author()->associate($author);
+    }
+}

--- a/app-modules/form/src/Http/Controllers/FormWidgetController.php
+++ b/app-modules/form/src/Http/Controllers/FormWidgetController.php
@@ -37,59 +37,57 @@
 namespace AdvisingApp\Form\Http\Controllers;
 
 use Closure;
-use Illuminate\Support\Str;
+use Throwable;
 use Illuminate\Http\Request;
 use AdvisingApp\Form\Models\Form;
 use Illuminate\Http\JsonResponse;
 use Filament\Support\Colors\Color;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\URL;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Validator;
 use AdvisingApp\Form\Models\FormSubmission;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpFoundation\Response;
 use AdvisingApp\Form\Models\FormAuthentication;
 use AdvisingApp\Form\Actions\GenerateFormKitSchema;
-use AdvisingApp\Form\Actions\GenerateSubmissibleValidation;
+use AdvisingApp\Form\Actions\ProcessSubmissionField;
+use AdvisingApp\Form\Actions\GenerateSubmissibleValidator;
 use AdvisingApp\Form\Actions\ResolveSubmissionAuthorFromEmail;
 use AdvisingApp\Form\Notifications\AuthenticateFormNotification;
-use AdvisingApp\Form\Filament\Blocks\EducatableEmailFormFieldBlock;
 use AdvisingApp\IntegrationGoogleRecaptcha\Settings\GoogleRecaptchaSettings;
 
 class FormWidgetController extends Controller
 {
     public function view(GenerateFormKitSchema $generateSchema, Form $form): JsonResponse
     {
-        return response()->json(
-            [
-                'name' => $form->name,
-                'description' => $form->description,
-                'is_authenticated' => $form->is_authenticated,
-                ...($form->is_authenticated ? [
-                    'authentication_url' => URL::signedRoute(
-                        name: 'forms.request-authentication',
-                        parameters: ['form' => $form],
-                        absolute: false,
-                    ),
-                ] : [
-                    'submission_url' => URL::signedRoute(
-                        name: 'forms.submit',
-                        parameters: ['form' => $form],
-                        absolute: false,
-                    ),
-                ]),
-                'recaptcha_enabled' => $form->recaptcha_enabled,
-                ...($form->recaptcha_enabled ? [
-                    'recaptcha_site_key' => app(GoogleRecaptchaSettings::class)->site_key,
-                ] : []),
-                'schema' => $generateSchema($form),
-                'primary_color' => Color::all()[$form->primary_color ?? 'blue'],
-                'rounding' => $form->rounding,
-                'on_screen_response' => $form->on_screen_response,
-            ],
-        );
+        return response()->json([
+            'name' => $form->name,
+            'description' => $form->description,
+            'is_authenticated' => $form->is_authenticated,
+            ...($form->is_authenticated ? [
+                'authentication_url' => URL::signedRoute(
+                    name: 'forms.request-authentication',
+                    parameters: ['form' => $form],
+                    absolute: false,
+                ),
+            ] : [
+                'submission_url' => URL::signedRoute(
+                    name: 'forms.submit',
+                    parameters: ['form' => $form],
+                    absolute: false,
+                ),
+            ]),
+            'recaptcha_enabled' => $form->recaptcha_enabled,
+            ...($form->recaptcha_enabled ? [
+                'recaptcha_site_key' => app(GoogleRecaptchaSettings::class)->site_key,
+            ] : []),
+            'schema' => $generateSchema($form),
+            'primary_color' => Color::all()[$form->primary_color ?? 'blue'],
+            'rounding' => $form->rounding,
+            'on_screen_response' => $form->on_screen_response,
+        ]);
     }
 
     public function requestAuthentication(Request $request, ResolveSubmissionAuthorFromEmail $resolveSubmissionAuthorFromEmail, Form $form): JsonResponse
@@ -163,8 +161,8 @@ class FormWidgetController extends Controller
 
     public function store(
         Request $request,
-        GenerateSubmissibleValidation $generateValidation,
-        ResolveSubmissionAuthorFromEmail $resolveSubmissionAuthorFromEmail,
+        GenerateSubmissibleValidator $generateSubmissibleValidator,
+        ProcessSubmissionField $processSubmissionField,
         Form $form,
     ): JsonResponse {
         $authentication = $request->query('authentication');
@@ -180,102 +178,80 @@ class FormWidgetController extends Controller
             abort(Response::HTTP_UNAUTHORIZED);
         }
 
-        $validator = Validator::make(
-            $request->all(),
-            $generateValidation($form)
-        );
+        $validator = $generateSubmissibleValidator($form);
 
         if ($validator->fails()) {
-            return response()->json(
-                [
-                    'errors' => (object) $validator->errors(),
-                ],
-                Response::HTTP_UNPROCESSABLE_ENTITY
-            );
+            return response()->json([
+                'errors' => $validator->errors(),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
         }
-
-        /** @var ?FormSubmission $submission */
-        $submission = $authentication ? $form->submissions()
-            ->requested()
-            ->whereMorphedTo('author', $authentication->author)
-            ->first() : null;
-
-        $submission ??= $form->submissions()->make();
-
-        if ($authentication) {
-            $submission->author()->associate($authentication->author);
-
-            $authentication->delete();
-        }
-
-        $submission->submitted_at = now();
-
-        $submission->save();
 
         $data = $validator->validated();
 
-        unset($data['recaptcha-token']);
+        DB::beginTransaction();
 
-        if ($form->is_wizard) {
-            foreach ($form->steps as $step) {
-                $stepFields = $step->fields()->pluck('type', 'id')->all();
+        try {
+            /** @var ?FormSubmission $submission */
+            $submission = $authentication ? $form->submissions()
+                ->requested()
+                ->whereMorphedTo('author', $authentication->author)
+                ->first() : null;
 
-                foreach ($data[$step->label] as $fieldId => $response) {
-                    $submission->fields()->attach(
+            $submission ??= $form->submissions()->make();
+
+            if ($authentication) {
+                $submission->author()->associate($authentication->author);
+
+                $authentication->delete();
+            }
+
+            $submission->submitted_at = now();
+
+            $submission->save();
+
+            unset($data['recaptcha-token']);
+
+            if ($form->is_wizard) {
+                foreach ($form->steps as $step) {
+                    $stepFields = $step->fields()->pluck('type', 'id')->all();
+
+                    foreach ($data[$step->label] as $fieldId => $response) {
+                        $processSubmissionField(
+                            $submission,
+                            $fieldId,
+                            $response,
+                            $stepFields,
+                        );
+                    }
+                }
+            } else {
+                $formFields = $form->fields()->pluck('type', 'id')->all();
+
+                foreach ($data as $fieldId => $response) {
+                    $processSubmissionField(
+                        $submission,
                         $fieldId,
-                        ['id' => Str::orderedUuid(), 'response' => $response],
+                        $response,
+                        $formFields,
                     );
-
-                    if ($submission->author) {
-                        continue;
-                    }
-
-                    if ($stepFields[$fieldId] !== EducatableEmailFormFieldBlock::type()) {
-                        continue;
-                    }
-
-                    $author = $resolveSubmissionAuthorFromEmail($response);
-
-                    if (! $author) {
-                        continue;
-                    }
-
-                    $submission->author()->associate($author);
                 }
             }
-        } else {
-            $formFields = $form->fields()->pluck('type', 'id')->all();
 
-            foreach ($data as $fieldId => $response) {
-                $submission->fields()->attach(
-                    $fieldId,
-                    ['id' => Str::orderedUuid(), 'response' => $response],
-                );
+            $submission->save();
 
-                if ($submission->author) {
-                    continue;
-                }
+            DB::commit();
+        } catch (Throwable $e) {
+            DB::rollBack();
 
-                if ($formFields[$fieldId] !== EducatableEmailFormFieldBlock::type()) {
-                    continue;
-                }
+            report($e);
 
-                $author = $resolveSubmissionAuthorFromEmail($response);
-
-                if (! $author) {
-                    continue;
-                }
-
-                $submission->author()->associate($author);
-            }
+            return response()->json([
+                'errors' => ['An error occurred while submitting this form.'],
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
         }
 
-        $submission->save();
-
-        return response()->json(
-            [
-                'message' => 'Form submitted successfully.',
-            ]
-        );
+        return response()->json([
+            'message' => 'Form submitted successfully.',
+        ]);
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-589

### Technical Description

So this one was a bit weird. It turns out that in a FormKit form, if you never enter a value for an input that input isn't included in the form and never submitted. But, if you enter a value and remove it the key is left in the form with an empty string as it's value. 

Then the Laravel `ConvertEmptyStringsToNull` middleware makes it null. Then the validator fails because it expects the `text_input` to be a string. Originally I was adding the `nullable` validation rule to the input, but that doesn't matter because the `form_field_submission` doesn't allow null values. So instead I just filter out the inputs that are null. 

It also turns out that the only validation error message displayed on the frontend that comes from FormKit is the `required` validation. All others are actually the Laravel native validation messages, which explains why the uuids were being returned instead of the labels. I've added the input labels as attributes in the validator which allows Laravel to swap the uuids in the message with the string.
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
