### PR TITLE
[ADVAPP-307]: Restrict the display of available public profile features depending on whether the user has access to a CRM product

### DIFF
--- a/app/Filament/Pages/EditProfile.php
+++ b/app/Filament/Pages/EditProfile.php
@@ -94,7 +94,10 @@ class EditProfile extends Page
     {
         /** @var User $user */
         $user = auth()->user();
-
+        $retentionLicense = $user->hasLicense(LicenseType::RetentionCrm);
+        $recruitmentLicense = $user->hasLicense(LicenseType::RecruitmentCrm);
+        $crmSetting = ($retentionLicense || $recruitmentLicense) ? true : false;
+        
         $connectedAccounts = collect([
             Grid::make()
                 ->schema([
@@ -149,7 +152,8 @@ class EditProfile extends Page
         return $form
             ->schema([
                 Section::make('Public Profile')
-                    ->aside()
+                    ->aside()                    
+                    ->visible($crmSetting)
                     ->schema([
                         Toggle::make('has_enabled_public_profile')
                             ->label('Enable public profile')
@@ -197,6 +201,7 @@ class EditProfile extends Page
                             ->hint(fn (Get $get): string => $get('is_bio_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile'),
                         Checkbox::make('is_bio_visible_on_profile')
                             ->label('Show Bio on profile')
+                            ->visible($crmSetting)
                             ->live()
                             ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         TextInput::make('phone_number')
@@ -206,6 +211,7 @@ class EditProfile extends Page
                         Checkbox::make('is_phone_number_visible_on_profile')
                             ->label('Show phone number on profile')
                             ->live()
+                            ->visible($crmSetting)
                             ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         Select::make('pronouns_id')
                             ->relationship('pronouns', 'label')
@@ -213,6 +219,7 @@ class EditProfile extends Page
                         Checkbox::make('are_pronouns_visible_on_profile')
                             ->label('Show Pronouns on profile')
                             ->live()
+                            ->visible($crmSetting)
                             ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         Placeholder::make('teams')
                             ->label(str('Team')->plural($user->teams->count()))
@@ -243,6 +250,7 @@ class EditProfile extends Page
                         Checkbox::make('is_email_visible_on_profile')
                             ->label('Show Email on profile')
                             ->live()
+                            ->visible($crmSetting)
                             ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         $this->getPasswordFormComponent()
                             ->hidden($user->is_external),
@@ -271,6 +279,7 @@ class EditProfile extends Page
                     ->visible($connectedAccounts->count()),
                 Section::make('Working Hours')
                     ->aside()
+                    ->visible($crmSetting)
                     ->schema([
                         Toggle::make('working_hours_are_enabled')
                             ->label('Set Working Hours')
@@ -287,6 +296,7 @@ class EditProfile extends Page
                     ]),
                 Section::make('Office Hours')
                     ->aside()
+                    ->visible($crmSetting)
                     ->schema([
                         Toggle::make('office_hours_are_enabled')
                             ->label('Enable Office Hours')

--- a/app/Filament/Pages/EditProfile.php
+++ b/app/Filament/Pages/EditProfile.php
@@ -97,7 +97,7 @@ class EditProfile extends Page
         $retentionLicense = $user->hasLicense(LicenseType::RetentionCrm);
         $recruitmentLicense = $user->hasLicense(LicenseType::RecruitmentCrm);
         $crmSetting = ($retentionLicense || $recruitmentLicense) ? true : false;
-        
+
         $connectedAccounts = collect([
             Grid::make()
                 ->schema([
@@ -152,7 +152,7 @@ class EditProfile extends Page
         return $form
             ->schema([
                 Section::make('Public Profile')
-                    ->aside()                    
+                    ->aside()
                     ->visible($crmSetting)
                     ->schema([
                         Toggle::make('has_enabled_public_profile')

--- a/app/Filament/Pages/EditProfile.php
+++ b/app/Filament/Pages/EditProfile.php
@@ -94,9 +94,9 @@ class EditProfile extends Page
     {
         /** @var User $user */
         $user = auth()->user();
-        $retentionLicense = $user->hasLicense(LicenseType::RetentionCrm);
-        $recruitmentLicense = $user->hasLicense(LicenseType::RecruitmentCrm);
-        $crmSetting = ($retentionLicense || $recruitmentLicense) ? true : false;
+        $retentionLicense = $user->hasAnyLicense(LicenseType::RetentionCrm);
+        $recruitmentLicense = $user->hasAnyLicense(LicenseType::RecruitmentCrm);
+        $hasCrmLicense = ($retentionLicense || $recruitmentLicense) ? true : false;
 
         $connectedAccounts = collect([
             Grid::make()
@@ -153,7 +153,7 @@ class EditProfile extends Page
             ->schema([
                 Section::make('Public Profile')
                     ->aside()
-                    ->visible($crmSetting)
+                    ->visible($hasCrmLicense)
                     ->schema([
                         Toggle::make('has_enabled_public_profile')
                             ->label('Enable public profile')
@@ -201,7 +201,7 @@ class EditProfile extends Page
                             ->hint(fn (Get $get): string => $get('is_bio_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile'),
                         Checkbox::make('is_bio_visible_on_profile')
                             ->label('Show Bio on profile')
-                            ->visible($crmSetting)
+                            ->visible($hasCrmLicense)
                             ->live()
                             ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         TextInput::make('phone_number')
@@ -211,7 +211,7 @@ class EditProfile extends Page
                         Checkbox::make('is_phone_number_visible_on_profile')
                             ->label('Show phone number on profile')
                             ->live()
-                            ->visible($crmSetting)
+                            ->visible($hasCrmLicense)
                             ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         Select::make('pronouns_id')
                             ->relationship('pronouns', 'label')
@@ -219,7 +219,7 @@ class EditProfile extends Page
                         Checkbox::make('are_pronouns_visible_on_profile')
                             ->label('Show Pronouns on profile')
                             ->live()
-                            ->visible($crmSetting)
+                            ->visible($hasCrmLicense)
                             ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         Placeholder::make('teams')
                             ->label(str('Team')->plural($user->teams->count()))
@@ -250,7 +250,7 @@ class EditProfile extends Page
                         Checkbox::make('is_email_visible_on_profile')
                             ->label('Show Email on profile')
                             ->live()
-                            ->visible($crmSetting)
+                            ->visible($hasCrmLicense)
                             ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
                         $this->getPasswordFormComponent()
                             ->hidden($user->is_external),
@@ -279,7 +279,7 @@ class EditProfile extends Page
                     ->visible($connectedAccounts->count()),
                 Section::make('Working Hours')
                     ->aside()
-                    ->visible($crmSetting)
+                    ->visible($hasCrmLicense)
                     ->schema([
                         Toggle::make('working_hours_are_enabled')
                             ->label('Set Working Hours')
@@ -296,7 +296,7 @@ class EditProfile extends Page
                     ]),
                 Section::make('Office Hours')
                     ->aside()
-                    ->visible($crmSetting)
+                    ->visible($hasCrmLicense)
                     ->schema([
                         Toggle::make('office_hours_are_enabled')
                             ->label('Enable Office Hours')

--- a/app/Filament/Pages/EditProfile.php
+++ b/app/Filament/Pages/EditProfile.php
@@ -94,9 +94,7 @@ class EditProfile extends Page
     {
         /** @var User $user */
         $user = auth()->user();
-        $retentionLicense = $user->hasAnyLicense(LicenseType::RetentionCrm);
-        $recruitmentLicense = $user->hasAnyLicense(LicenseType::RecruitmentCrm);
-        $hasCrmLicense = ($retentionLicense || $recruitmentLicense) ? true : false;
+        $hasCrmLicense = $user->hasAnyLicense([LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]);
 
         $connectedAccounts = collect([
             Grid::make()
@@ -157,8 +155,7 @@ class EditProfile extends Page
                     ->schema([
                         Toggle::make('has_enabled_public_profile')
                             ->label('Enable public profile')
-                            ->live()
-                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
+                            ->live(),
                         TextInput::make('public_profile_slug')
                             ->label('Url')
                             ->visible(fn (Get $get) => $get('has_enabled_public_profile'))
@@ -202,8 +199,7 @@ class EditProfile extends Page
                         Checkbox::make('is_bio_visible_on_profile')
                             ->label('Show Bio on profile')
                             ->visible($hasCrmLicense)
-                            ->live()
-                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
+                            ->live(),
                         TextInput::make('phone_number')
                             ->label('Contact phone number')
                             ->integer()
@@ -211,16 +207,14 @@ class EditProfile extends Page
                         Checkbox::make('is_phone_number_visible_on_profile')
                             ->label('Show phone number on profile')
                             ->live()
-                            ->visible($hasCrmLicense)
-                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
+                            ->visible($hasCrmLicense),
                         Select::make('pronouns_id')
                             ->relationship('pronouns', 'label')
                             ->hint(fn (Get $get): string => $get('are_pronouns_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile'),
                         Checkbox::make('are_pronouns_visible_on_profile')
                             ->label('Show Pronouns on profile')
                             ->live()
-                            ->visible($hasCrmLicense)
-                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
+                            ->visible($hasCrmLicense),
                         Placeholder::make('teams')
                             ->label(str('Team')->plural($user->teams->count()))
                             ->content($user->teams->pluck('name')->join(', ', ' and '))
@@ -250,8 +244,7 @@ class EditProfile extends Page
                         Checkbox::make('is_email_visible_on_profile')
                             ->label('Show Email on profile')
                             ->live()
-                            ->visible($hasCrmLicense)
-                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
+                            ->visible($hasCrmLicense),
                         $this->getPasswordFormComponent()
                             ->hidden($user->is_external),
                         $this->getPasswordConfirmationFormComponent()
@@ -284,8 +277,7 @@ class EditProfile extends Page
                         Toggle::make('working_hours_are_enabled')
                             ->label('Set Working Hours')
                             ->live()
-                            ->hint(fn (Get $get): string => $get('are_working_hours_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile')
-                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
+                            ->hint(fn (Get $get): string => $get('are_working_hours_visible_on_profile') ? 'Visible on profile' : 'Not visible on profile'),
                         Checkbox::make('are_working_hours_visible_on_profile')
                             ->label('Show Working Hours on profile')
                             ->visible(fn (Get $get) => $get('working_hours_are_enabled'))
@@ -300,8 +292,7 @@ class EditProfile extends Page
                     ->schema([
                         Toggle::make('office_hours_are_enabled')
                             ->label('Enable Office Hours')
-                            ->live()
-                            ->lockedWithoutAnyLicenses(user: auth()->user(), licenses: [LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]),
+                            ->live(),
                         Checkbox::make('appointments_are_restricted_to_existing_students')
                             ->label('Restrict appointments to existing students')
                             ->visible(fn (Get $get) => $get('office_hours_are_enabled')),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-307

### Technical Description

> Based on CRM settings set for a user, he/she will have access to some of the profile  settings features.