### PR TITLE
[Bugfix]: Increase the timeout of the build command and display output

### DIFF
--- a/app/Console/Commands/BuildAssets.php
+++ b/app/Console/Commands/BuildAssets.php
@@ -72,13 +72,18 @@ class BuildAssets extends Command
         $script = $this->argument('script');
         $script = filled($script) ? "build:{$script}" : 'build';
 
-        $process = Process::run(
-            <<<BASH
-                #!/bin/bash
-                [ -s "/usr/local/nvm/nvm.sh" ] && \. "/usr/local/nvm/nvm.sh"
-                npm run {$script}
-            BASH
-        )->throw();
+        $process = Process::timeout(3600)
+            ->run(
+                command: <<<BASH
+                    #!/bin/bash
+                    [ -s "/usr/local/nvm/nvm.sh" ] && \. "/usr/local/nvm/nvm.sh"
+                    npm run {$script}
+                BASH,
+                output: function (string $type, string $output) {
+                    $this->line($output);
+                }
+            )
+            ->throw();
 
         $this->line($process->output());
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Fixes issues with the `app:build-assets` by increasing the timeout. Also displays the output so that you can see the command actually is processing.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
