### PR TITLE
[ADVAPP-635]: Update AI chat cloning to resolve message limitation

### DIFF
--- a/app-modules/ai/database/migrations/2024_06_05_192746_add_locked_at_column_to_ai_threads_table.php
+++ b/app-modules/ai/database/migrations/2024_06_05_192746_add_locked_at_column_to_ai_threads_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;

--- a/app-modules/ai/database/migrations/2024_06_05_192746_add_locked_at_column_to_ai_threads_table.php
+++ b/app-modules/ai/database/migrations/2024_06_05_192746_add_locked_at_column_to_ai_threads_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('ai_threads', function (Blueprint $table) {
+            $table->dateTime('locked_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('ai_threads', function (Blueprint $table) {
+            $table->dropColumn('locked_at');
+        });
+    }
+};

--- a/app-modules/ai/resources/js/chat.js
+++ b/app-modules/ai/resources/js/chat.js
@@ -65,7 +65,7 @@ document.addEventListener('alpine:init', () => {
                     // Wait for 10 seconds before checking if the thread is retryable again.
                     await new Promise((resolve) => setTimeout(resolve, 10000));
 
-                    this.isRetryable = !(await this.$wire.isThreadRetryable());
+                    this.isRetryable = !(await this.$wire.isThreadLocked());
                 }
             });
         },

--- a/app-modules/ai/resources/js/chat.js
+++ b/app-modules/ai/resources/js/chat.js
@@ -33,9 +33,10 @@
 */
 document.addEventListener('alpine:init', () => {
     Alpine.data('chat', ({ csrfToken, retryMessageUrl, sendMessageUrl, showThreadUrl, userId }) => ({
-        isError: false,
+        error: null,
         isLoading: true,
         isSendingMessage: false,
+        isRetryable: true,
         latestMessage: '',
         message: '',
         messages: [],
@@ -58,6 +59,15 @@ document.addEventListener('alpine:init', () => {
             this.users = thread.users;
 
             this.isLoading = false;
+
+            this.$watch('isRetryable', async (value) => {
+                while (!this.isRetryable) {
+                    // Wait for 10 seconds before checking if the thread is retryable again.
+                    await new Promise((resolve) => setTimeout(resolve, 10000));
+
+                    this.isRetryable = !(await this.$wire.isThreadRetryable());
+                }
+            });
         },
 
         sendMessage: async function () {
@@ -68,7 +78,7 @@ document.addEventListener('alpine:init', () => {
             }
 
             this.isSendingMessage = true;
-            this.isError = false;
+            this.error = null;
 
             this.latestMessage = this.message;
 
@@ -95,7 +105,8 @@ document.addEventListener('alpine:init', () => {
                 const response = await sendMessageResponse.json();
 
                 if (!sendMessageResponse.ok) {
-                    this.isError = true;
+                    this.error = response.message;
+                    this.isRetryable = !response.isThreadLocked;
                     this.isSendingMessage = false;
 
                     return;
@@ -111,7 +122,7 @@ document.addEventListener('alpine:init', () => {
 
         retryMessage: async function () {
             this.isSendingMessage = true;
-            this.isError = false;
+            this.error = null;
 
             this.$nextTick(async () => {
                 const retryMessageResponse = await fetch(retryMessageUrl, {
@@ -127,7 +138,8 @@ document.addEventListener('alpine:init', () => {
                 const response = await retryMessageResponse.json();
 
                 if (!retryMessageResponse.ok) {
-                    this.isError = true;
+                    this.error = response.message;
+                    this.isRetryable = !response.isThreadLocked;
                     this.isSendingMessage = false;
 
                     return;

--- a/app-modules/ai/resources/views/components/assistant.blade.php
+++ b/app-modules/ai/resources/views/components/assistant.blade.php
@@ -310,14 +310,18 @@
                     <div
                         class="bg-danger-100 px-4 py-2 dark:bg-danger-900"
                         x-cloak
-                        x-show="isError"
+                        x-show="error"
                     >
-                        An error happened when sending your message,
+                        <span x-text="error"></span>
+
+                        <span x-show="! isRetryable">We will inform you once you can retry sending your message.</span>
+
                         <x-filament::link
                             x-on:click="retryMessage"
+                            x-show="isRetryable"
                             tag="button"
                             color="gray"
-                        >click here to retry.
+                        >Click here to retry.
                         </x-filament::link>
                     </div>
 

--- a/app-modules/ai/src/Actions/RetryMessage.php
+++ b/app-modules/ai/src/Actions/RetryMessage.php
@@ -39,11 +39,16 @@ namespace AdvisingApp\Ai\Actions;
 use Illuminate\Support\Arr;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Models\AiMessage;
+use AdvisingApp\Ai\Exceptions\AiThreadLockedException;
 
 class RetryMessage
 {
     public function __invoke(AiThread $thread, string $content): string
     {
+        if ($thread->locked_at) {
+            throw new AiThreadLockedException();
+        }
+
         $message = $thread->messages()->whereBelongsTo(auth()->user())->latest()->first();
 
         if ($message?->content !== $content) {

--- a/app-modules/ai/src/Actions/SendMessage.php
+++ b/app-modules/ai/src/Actions/SendMessage.php
@@ -39,11 +39,16 @@ namespace AdvisingApp\Ai\Actions;
 use Illuminate\Support\Arr;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Models\AiMessage;
+use AdvisingApp\Ai\Exceptions\AiThreadLockedException;
 
 class SendMessage
 {
     public function __invoke(AiThread $thread, string $content): string
     {
+        if ($thread->locked_at) {
+            throw new AiThreadLockedException();
+        }
+
         $message = new AiMessage();
         $message->content = $content;
         $message->request = [

--- a/app-modules/ai/src/Exceptions/AiThreadLockedException.php
+++ b/app-modules/ai/src/Exceptions/AiThreadLockedException.php
@@ -38,4 +38,10 @@ namespace AdvisingApp\Ai\Exceptions;
 
 use Exception;
 
-class AiThreadLockedException extends Exception {}
+class AiThreadLockedException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('The assistant is currently undergoing maintenance.');
+    }
+}

--- a/app-modules/ai/src/Exceptions/AiThreadLockedException.php
+++ b/app-modules/ai/src/Exceptions/AiThreadLockedException.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Ai\Exceptions;
 
 use Exception;

--- a/app-modules/ai/src/Exceptions/AiThreadLockedException.php
+++ b/app-modules/ai/src/Exceptions/AiThreadLockedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AdvisingApp\Ai\Exceptions;
+
+use Exception;
+
+class AiThreadLockedException extends Exception {}

--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManageThreads.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManageThreads.php
@@ -430,8 +430,12 @@ trait CanManageThreads
     }
 
     #[Renderless]
-    public function isThreadRetryable(): bool
+    public function isThreadLocked(): bool
     {
-        return $this->thread?->locked_at !== null;
+        if (! $this->thread) {
+            return false;
+        }
+
+        return $this->thread->locked_at !== null;
     }
 }

--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManageThreads.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManageThreads.php
@@ -47,6 +47,7 @@ use Livewire\Attributes\Computed;
 use Filament\Actions\StaticAction;
 use Illuminate\Support\Collection;
 use AdvisingApp\Ai\Models\AiThread;
+use Livewire\Attributes\Renderless;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Select;
 use Filament\Support\Enums\Alignment;
@@ -405,5 +406,11 @@ trait CanManageThreads
             ->icon('heroicon-m-envelope')
             ->color('warning')
             ->modalSubmitAction(fn (StaticAction $action) => $action->color('primary'));
+    }
+
+    #[Renderless]
+    public function isThreadRetryable(): bool
+    {
+        return $this->thread?->locked_at !== null;
     }
 }

--- a/app-modules/ai/src/Http/Controllers/RetryMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/RetryMessageController.php
@@ -53,17 +53,15 @@ class RetryMessageController
                 $request->validated('content'),
             );
         } catch (AiThreadLockedException $exception) {
-            report($exception);
-
             return response()->json([
                 'isThreadLocked' => true,
-                'message' => 'The assistant is currently undergoing maintenance. We will inform you once you can retry sending your message.',
+                'message' => 'The assistant is currently undergoing maintenance.',
             ], 503);
         } catch (Throwable $exception) {
             report($exception);
 
             return response()->json([
-                'message' => 'The assistant has failed. Please retry later.',
+                'message' => 'An error happened when sending your message.',
             ], 503);
         }
 

--- a/app-modules/ai/src/Http/Controllers/RetryMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/RetryMessageController.php
@@ -48,10 +48,6 @@ class RetryMessageController
     public function __invoke(RetryMessageRequest $request, AiThread $thread): JsonResponse
     {
         try {
-            if ($thread->locked_at) {
-                throw new AiThreadLockedException();
-            }
-
             $responseContent = app(RetryMessage::class)(
                 $thread,
                 $request->validated('content'),

--- a/app-modules/ai/src/Http/Controllers/RetryMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/RetryMessageController.php
@@ -55,7 +55,7 @@ class RetryMessageController
         } catch (AiThreadLockedException $exception) {
             return response()->json([
                 'isThreadLocked' => true,
-                'message' => 'The assistant is currently undergoing maintenance.',
+                'message' => $exception->getMessage(),
             ], 503);
         } catch (Throwable $exception) {
             report($exception);

--- a/app-modules/ai/src/Http/Controllers/SendMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/SendMessageController.php
@@ -55,7 +55,7 @@ class SendMessageController
         } catch (AiThreadLockedException $exception) {
             return response()->json([
                 'isThreadLocked' => true,
-                'message' => 'The assistant is currently undergoing maintenance.',
+                'message' => $exception->getMessage(),
             ], 503);
         } catch (Throwable $exception) {
             report($exception);

--- a/app-modules/ai/src/Http/Controllers/SendMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/SendMessageController.php
@@ -53,8 +53,6 @@ class SendMessageController
                 $request->validated('content'),
             );
         } catch (AiThreadLockedException $exception) {
-            report($exception);
-
             return response()->json([
                 'isThreadLocked' => true,
                 'message' => 'The assistant is currently undergoing maintenance.',

--- a/app-modules/ai/src/Http/Controllers/SendMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/SendMessageController.php
@@ -48,10 +48,6 @@ class SendMessageController
     public function __invoke(SendMessageRequest $request, AiThread $thread): JsonResponse
     {
         try {
-            if ($thread->locked_at) {
-                throw new AiThreadLockedException();
-            }
-
             $responseContent = app(SendMessage::class)(
                 $thread,
                 $request->validated('content'),

--- a/app-modules/ai/src/Jobs/CloneAiThread.php
+++ b/app-modules/ai/src/Jobs/CloneAiThread.php
@@ -79,9 +79,14 @@ class CloneAiThread implements ShouldQueue
 
         $aiService = $threadReplica->assistant->model->getService();
 
-        $aiService->ensureAssistantExists($threadReplica->assistant);
-
-        $aiService->createThread($threadReplica);
+        $threadReplica->locked_at = now();
         $threadReplica->save();
+
+        try {
+            $aiService->ensureAssistantAndThreadExists($threadReplica->assistant);
+        } finally {
+            $threadReplica->locked_at = null;
+            $threadReplica->save();
+        }
     }
 }

--- a/app-modules/ai/src/Jobs/ReInitializeAiThread.php
+++ b/app-modules/ai/src/Jobs/ReInitializeAiThread.php
@@ -94,6 +94,14 @@ class ReInitializeAiThread implements ShouldQueue, TenantAware
     {
         auth()->setUser($this->thread->user);
 
-        $this->thread->assistant->model->getService()->ensureAssistantAndThreadExists($this->thread);
+        $this->thread->locked_at = now();
+        $this->thread->save();
+
+        try {
+            $this->thread->assistant->model->getService()->ensureAssistantAndThreadExists($this->thread);
+        } finally {
+            $this->thread->locked_at = null;
+            $this->thread->save();
+        }
     }
 }

--- a/app-modules/ai/src/Models/AiThread.php
+++ b/app-modules/ai/src/Models/AiThread.php
@@ -58,6 +58,11 @@ class AiThread extends BaseModel
         'assistant_id',
         'folder_id',
         'user_id',
+        'locked_at',
+    ];
+
+    protected $casts = [
+        'locked_at' => 'datetime',
     ];
 
     public function assistant(): BelongsTo

--- a/app-modules/ai/tests/Feature/Actions/RetryMessageTest.php
+++ b/app-modules/ai/tests/Feature/Actions/RetryMessageTest.php
@@ -44,6 +44,7 @@ use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Enums\AiApplication;
 use AdvisingApp\Ai\Actions\RetryMessage;
+use AdvisingApp\Ai\Exceptions\AiThreadLockedException;
 
 it('retries a message', function () {
     asSuperAdmin();
@@ -228,3 +229,13 @@ it('does not match messages with different content', function () {
     expect(AiMessage::count())
         ->toBe(3);
 });
+
+it('throws an exception if the thread is locked', function () {
+    asSuperAdmin();
+
+    $thread = AiThread::factory()->make([
+        'locked_at' => now(),
+    ]);
+
+    app(RetryMessage::class)($thread, 'Hello, world!');
+})->throws(AiThreadLockedException::class);

--- a/app-modules/ai/tests/Feature/Actions/SendMessageTest.php
+++ b/app-modules/ai/tests/Feature/Actions/SendMessageTest.php
@@ -42,6 +42,7 @@ use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Actions\SendMessage;
 use AdvisingApp\Ai\Enums\AiApplication;
+use AdvisingApp\Ai\Exceptions\AiThreadLockedException;
 
 it('sends a message', function () {
     asSuperAdmin();
@@ -87,3 +88,13 @@ it('sends a message', function () {
                 ->sanitizeHtml(),
         );
 });
+
+it('throws an exception if the thread is locked', function () {
+    asSuperAdmin();
+
+    $thread = AiThread::factory()->make([
+        'locked_at' => now(),
+    ]);
+
+    app(SendMessage::class)($thread, 'Hello, world!');
+})->throws(AiThreadLockedException::class);

--- a/app-modules/ai/tests/Feature/Filament/Pages/AIAssistantPageTest.php
+++ b/app-modules/ai/tests/Feature/Filament/Pages/AIAssistantPageTest.php
@@ -1250,7 +1250,7 @@ it('can not clone a thread to a super admin', function () use ($setUp) {
         ->assertHasActionErrors(['targetIds' => 'Super admin users cannot have a thread shared with them.']);
 });
 
-it('Super admin users do not show up in email user search', function () use ($setUp) {
+test('super admin users do not show up in email user search', function () use ($setUp) {
     $setUp();
 
     $superAdmin = User::factory()->create();
@@ -1267,7 +1267,7 @@ it('Super admin users do not show up in email user search', function () use ($se
         });
 });
 
-it('Super admin users do not show up in clone user search', function () use ($setUp) {
+test('super admin users do not show up in clone user search', function () use ($setUp) {
     $setUp();
 
     $superAdmin = User::factory()->create();

--- a/app-modules/ai/tests/Feature/Http/Controllers/RetryMessageControllerTest.php
+++ b/app-modules/ai/tests/Feature/Http/Controllers/RetryMessageControllerTest.php
@@ -111,12 +111,14 @@ it('returns a message if the assistant fails', function () {
 it('returns a message if the thread is locked', function () {
     asSuperAdmin();
 
+    $exception = new AiThreadLockedException();
+
     /** @phpstan-ignore-next-line */
     $this->mock(
         RetryMessage::class,
         fn (MockInterface $mock) => $mock
             ->shouldReceive('__invoke')->once()
-            ->andThrow(new AiThreadLockedException()),
+            ->andThrow($exception),
     );
 
     $thread = AiThread::factory()
@@ -134,7 +136,7 @@ it('returns a message if the thread is locked', function () {
         ->assertServiceUnavailable()
         ->assertJson([
             'isThreadLocked' => true,
-            'message' => 'The assistant is currently undergoing maintenance.',
+            'message' => $exception->getMessage(),
         ]);
 });
 

--- a/app-modules/ai/tests/Feature/Http/Controllers/RetryMessageControllerTest.php
+++ b/app-modules/ai/tests/Feature/Http/Controllers/RetryMessageControllerTest.php
@@ -46,6 +46,7 @@ use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Enums\AiApplication;
 use AdvisingApp\Ai\Actions\RetryMessage;
+use AdvisingApp\Ai\Exceptions\AiThreadLockedException;
 
 it('retries sending a message to a thread', function () {
     asSuperAdmin();
@@ -103,7 +104,37 @@ it('returns a message if the assistant fails', function () {
     ])
         ->assertServiceUnavailable()
         ->assertJson([
-            'message' => 'The assistant has failed. Please retry later.',
+            'message' => 'An error happened when sending your message.',
+        ]);
+});
+
+it('returns a message if the thread is locked', function () {
+    asSuperAdmin();
+
+    /** @phpstan-ignore-next-line */
+    $this->mock(
+        RetryMessage::class,
+        fn (MockInterface $mock) => $mock
+            ->shouldReceive('__invoke')->once()
+            ->andThrow(new AiThreadLockedException()),
+    );
+
+    $thread = AiThread::factory()
+        ->for(AiAssistant::factory()->create([
+            'application' => AiApplication::Test,
+            'is_default' => true,
+            'model' => AiModel::Test,
+        ]), 'assistant')
+        ->for(auth()->user())
+        ->create();
+
+    post(route('ai.threads.messages.retry', ['thread' => $thread]), [
+        'content' => AiMessage::factory()->make()->content,
+    ])
+        ->assertServiceUnavailable()
+        ->assertJson([
+            'isThreadLocked' => true,
+            'message' => 'The assistant is currently undergoing maintenance.',
         ]);
 });
 

--- a/app-modules/ai/tests/Feature/Http/Controllers/SendMessageControllerTest.php
+++ b/app-modules/ai/tests/Feature/Http/Controllers/SendMessageControllerTest.php
@@ -111,12 +111,14 @@ it('returns a message if the assistant fails', function () {
 it('returns a message if the thread is locked', function () {
     asSuperAdmin();
 
+    $exception = new AiThreadLockedException();
+
     /** @phpstan-ignore-next-line */
     $this->mock(
         SendMessage::class,
         fn (MockInterface $mock) => $mock
             ->shouldReceive('__invoke')->once()
-            ->andThrow(new AiThreadLockedException()),
+            ->andThrow($exception),
     );
 
     $thread = AiThread::factory()
@@ -134,7 +136,7 @@ it('returns a message if the thread is locked', function () {
         ->assertServiceUnavailable()
         ->assertJson([
             'isThreadLocked' => true,
-            'message' => 'The assistant is currently undergoing maintenance.',
+            'message' => $exception->getMessage(),
         ]);
 });
 

--- a/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
+++ b/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
@@ -118,24 +118,10 @@ abstract class BaseOpenAiService implements AiService
 
         $thread->thread_id = $response->id;
 
-        $hasExistingMessages = count($existingMessages);
-
         if (count($existingMessagesOverflow)) {
             foreach ($existingMessagesOverflow as $overflowMessage) {
                 $this->client->threads()->messages()->create($thread->thread_id, $overflowMessage);
             }
-        } elseif ($hasExistingMessages) {
-            $this->client->threads()->messages()->create($thread->thread_id, [
-                'content' => 'This is a test message, please ignore this and never mention it again.',
-                'role' => 'user',
-            ]);
-        }
-
-        if ($hasExistingMessages) {
-            $this->client->threads()->runs()->create($thread->thread_id, [
-                'assistant_id' => $thread->assistant->assistant_id,
-                'instructions' => $this->generateAssistantInstructions($thread->assistant, withDynamicContext: true),
-            ]);
         }
     }
 

--- a/app-modules/integration-open-ai/tests/Feature/Services/OpenAiGptTestServiceTest.php
+++ b/app-modules/integration-open-ai/tests/Feature/Services/OpenAiGptTestServiceTest.php
@@ -133,6 +133,78 @@ it('can create a thread', function () {
     $client->assertSent(Threads::class, 1);
 });
 
+it('can create a thread with existing messages', function () {
+    asSuperAdmin();
+
+    /** @var BaseOpenAiService $service */
+    $service = AiModel::OpenAiGptTest->getService();
+
+    /** @var ClientFake $client */
+    $client = $service->getClient();
+
+    $client->addResponses([
+        ThreadResponse::fake([
+            'id' => $threadId = Str::random(),
+        ]),
+    ]);
+
+    $thread = AiThread::factory()
+        ->for(auth()->user())
+        ->for(AiAssistant::factory()->state([
+            'application' => AiApplication::Test,
+            'assistant_id' => Str::random(),
+            'is_default' => true,
+            'model' => AiModel::OpenAiGptTest,
+        ]), 'assistant')
+        ->has(AiMessage::factory()->count(3), 'messages')
+        ->create();
+
+    $service->createThread($thread);
+
+    expect($thread->thread_id)
+        ->toBe($threadId);
+
+    $client->assertSent(Threads::class, 1);
+});
+
+it('can create a thread with more than 32 messages', function () {
+    asSuperAdmin();
+
+    /** @var BaseOpenAiService $service */
+    $service = AiModel::OpenAiGptTest->getService();
+
+    /** @var ClientFake $client */
+    $client = $service->getClient();
+
+    $client->addResponses([
+        ThreadResponse::fake([
+            'id' => $threadId = Str::random(),
+        ]),
+        ThreadMessageResponse::fake([]),
+        ThreadMessageResponse::fake([]),
+        ThreadMessageResponse::fake([]),
+    ]);
+
+    $thread = AiThread::factory()
+        ->for(auth()->user())
+        ->for(AiAssistant::factory()->state([
+            'application' => AiApplication::Test,
+            'assistant_id' => Str::random(),
+            'is_default' => true,
+            'model' => AiModel::OpenAiGptTest,
+        ]), 'assistant')
+        ->has(AiMessage::factory()->count(35), 'messages')
+        ->create();
+
+    $service->createThread($thread);
+
+    expect($thread->thread_id)
+        ->toBe($threadId);
+
+    $client->assertSent(Threads::class, 1);
+    $client->assertSent(ThreadsMessages::class, 3);
+});
+
 it('can delete a thread', function () {
     asSuperAdmin();
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-635

### Technical Description

A thread can be locked, when it has a `locked_at` set to a timestamp. When reinitialising a thread, it becomes locked. When a user sends or retries a message with a locked thread, they get an error message immediately that automatically updates when the thread becomes unlocked, allowing them to retry their message. The locked status of a thread gets checked every 10 seconds while the error message is present.

From my investigation we don't need to send test messages or runs when reinitialising a thread.  When a thread has over 32 messages, we send the first 32 as part of the thread creation request and then send messages individually after that.

### Screenshots (if appropriate)

<img width="764" alt="Screenshot 2024-06-10 at 14 56 47" src="https://github.com/canyongbs/advisingapp/assets/41773797/1b54fe0e-8b12-44e6-a267-56436b165ea4">

<img width="764" alt="Screenshot 2024-06-10 at 14 57 12" src="https://github.com/canyongbs/advisingapp/assets/41773797/99b62892-1c2f-453e-9567-1f58a905a334">