### PR TITLE
[ADVAPP-648]: Populate Tenant ID and User ID into Sentry reports

### DIFF
--- a/app/Listeners/ClearSentryUser.php
+++ b/app/Listeners/ClearSentryUser.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Listeners;
+
+use Sentry\State\Scope;
+
+use function Sentry\configureScope;
+
+class ClearSentryUser
+{
+    public function handle(object $event): void
+    {
+        configureScope(function (Scope $scope): void {
+            $scope->removeUser();
+        });
+    }
+}

--- a/app/Listeners/ClearSentryUser.php
+++ b/app/Listeners/ClearSentryUser.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Listeners;
 
 use Sentry\State\Scope;

--- a/app/Listeners/SetSentryUser.php
+++ b/app/Listeners/SetSentryUser.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Listeners;
+
+use Sentry\State\Scope;
+use App\Models\Authenticatable;
+use Illuminate\Auth\Events\Login;
+
+use function Sentry\configureScope;
+
+use Illuminate\Auth\Events\Authenticated;
+
+class SetSentryUser
+{
+    public function handle(Login|Authenticated $event): void
+    {
+        /** @var Authenticatable $user */
+        $user = $event->user;
+
+        if (filled($user)) {
+            configureScope(function (Scope $scope) use ($user): void {
+                $scope->setUser([
+                    'id' => $user->getKey(),
+                ]);
+            });
+        }
+    }
+}

--- a/app/Listeners/SetSentryUser.php
+++ b/app/Listeners/SetSentryUser.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Listeners;
 
 use Sentry\State\Scope;

--- a/app/Multitenancy/Listeners/RemoveSentryTenantTag.php
+++ b/app/Multitenancy/Listeners/RemoveSentryTenantTag.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Multitenancy\Listeners;
+
+use Sentry\State\Scope;
+
+use function Sentry\configureScope;
+
+use Spatie\Multitenancy\Events\ForgotCurrentTenantEvent;
+
+class RemoveSentryTenantTag
+{
+    public function handle(ForgotCurrentTenantEvent $event): void
+    {
+        configureScope(function (Scope $scope): void {
+            $scope
+                ->removeTag('tenant.id')
+                ->removeTag('tenant.name');
+        });
+    }
+}

--- a/app/Multitenancy/Listeners/RemoveSentryTenantTag.php
+++ b/app/Multitenancy/Listeners/RemoveSentryTenantTag.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Multitenancy\Listeners;
 
 use Sentry\State\Scope;

--- a/app/Multitenancy/Listeners/SetSentryTenantTag.php
+++ b/app/Multitenancy/Listeners/SetSentryTenantTag.php
@@ -10,8 +10,6 @@ use Spatie\Multitenancy\Events\MakingTenantCurrentEvent;
 
 class SetSentryTenantTag
 {
-    public function __construct() {}
-
     public function handle(MakingTenantCurrentEvent $event): void
     {
         configureScope(function (Scope $scope) use ($event): void {

--- a/app/Multitenancy/Listeners/SetSentryTenantTag.php
+++ b/app/Multitenancy/Listeners/SetSentryTenantTag.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Multitenancy\Listeners;
+
+use Sentry\State\Scope;
+
+use function Sentry\configureScope;
+
+use Spatie\Multitenancy\Events\MakingTenantCurrentEvent;
+
+class SetSentryTenantTag
+{
+    public function __construct() {}
+
+    public function handle(MakingTenantCurrentEvent $event): void
+    {
+        configureScope(function (Scope $scope) use ($event): void {
+            $scope->setTags([
+                'tenant.id' => $event->tenant->getKey(),
+                'tenant.name' => $event->tenant->name,
+            ]);
+        });
+    }
+}

--- a/app/Multitenancy/Listeners/SetSentryTenantTag.php
+++ b/app/Multitenancy/Listeners/SetSentryTenantTag.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Multitenancy\Listeners;
 
 use Sentry\State\Scope;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -37,9 +37,14 @@
 namespace App\Providers;
 
 use App\Models\Tenant;
+use Sentry\State\Scope;
 use App\Models\SystemUser;
 use Laravel\Pennant\Feature;
+
+use function Sentry\configureScope;
+
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Octane\Commands\ReloadCommand;
 use Filament\Actions\Imports\Jobs\ImportCsv;
@@ -96,5 +101,11 @@ class AppServiceProvider extends ServiceProvider
             URL::forceScheme('https');
             $this->app['request']->server->set('HTTPS', true);
         }
+
+        Queue::looping(function () {
+            configureScope(function (Scope $scope): void {
+                $scope->removeUser();
+            });
+        });
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -39,6 +39,8 @@ namespace App\Providers;
 use OwenIt\Auditing\Events\Auditing;
 use Illuminate\Auth\Events\Registered;
 use AdvisingApp\Audit\Listeners\AuditingListener;
+use App\Multitenancy\Listeners\SetSentryTenantTag;
+use Spatie\Multitenancy\Events\MakingTenantCurrentEvent;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -53,9 +55,11 @@ class EventServiceProvider extends ServiceProvider
         Registered::class => [
             SendEmailVerificationNotification::class,
         ],
-        // TODO: Move this to the auditing Module somehow
         Auditing::class => [
             AuditingListener::class,
+        ],
+        MakingTenantCurrentEvent::class => [
+            SetSentryTenantTag::class,
         ],
     ];
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -39,6 +39,7 @@ namespace App\Providers;
 use App\Listeners\SetSentryUser;
 use Illuminate\Auth\Events\Login;
 use App\Listeners\ClearSentryUser;
+use Illuminate\Auth\Events\Logout;
 use OwenIt\Auditing\Events\Auditing;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Events\Authenticated;
@@ -78,6 +79,9 @@ class EventServiceProvider extends ServiceProvider
             SetSentryUser::class,
         ],
         ScheduledTaskStarting::class => [
+            ClearSentryUser::class,
+        ],
+        Logout::class => [
             ClearSentryUser::class,
         ],
     ];

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -36,8 +36,11 @@
 
 namespace App\Providers;
 
+use App\Listeners\SetSentryUser;
+use Illuminate\Auth\Events\Login;
 use OwenIt\Auditing\Events\Auditing;
 use Illuminate\Auth\Events\Registered;
+use Illuminate\Auth\Events\Authenticated;
 use AdvisingApp\Audit\Listeners\AuditingListener;
 use App\Multitenancy\Listeners\SetSentryTenantTag;
 use App\Multitenancy\Listeners\RemoveSentryTenantTag;
@@ -65,6 +68,12 @@ class EventServiceProvider extends ServiceProvider
         ],
         ForgotCurrentTenantEvent::class => [
             RemoveSentryTenantTag::class,
+        ],
+        Login::class => [
+            SetSentryUser::class,
+        ],
+        Authenticated::class => [
+            SetSentryUser::class,
         ],
     ];
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -38,11 +38,13 @@ namespace App\Providers;
 
 use App\Listeners\SetSentryUser;
 use Illuminate\Auth\Events\Login;
+use App\Listeners\ClearSentryUser;
 use OwenIt\Auditing\Events\Auditing;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Events\Authenticated;
 use AdvisingApp\Audit\Listeners\AuditingListener;
 use App\Multitenancy\Listeners\SetSentryTenantTag;
+use Illuminate\Console\Events\ScheduledTaskStarting;
 use App\Multitenancy\Listeners\RemoveSentryTenantTag;
 use Spatie\Multitenancy\Events\ForgotCurrentTenantEvent;
 use Spatie\Multitenancy\Events\MakingTenantCurrentEvent;
@@ -74,6 +76,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         Authenticated::class => [
             SetSentryUser::class,
+        ],
+        ScheduledTaskStarting::class => [
+            ClearSentryUser::class,
         ],
     ];
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -40,6 +40,8 @@ use OwenIt\Auditing\Events\Auditing;
 use Illuminate\Auth\Events\Registered;
 use AdvisingApp\Audit\Listeners\AuditingListener;
 use App\Multitenancy\Listeners\SetSentryTenantTag;
+use App\Multitenancy\Listeners\RemoveSentryTenantTag;
+use Spatie\Multitenancy\Events\ForgotCurrentTenantEvent;
 use Spatie\Multitenancy\Events\MakingTenantCurrentEvent;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -60,6 +62,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         MakingTenantCurrentEvent::class => [
             SetSentryTenantTag::class,
+        ],
+        ForgotCurrentTenantEvent::class => [
+            RemoveSentryTenantTag::class,
         ],
     ];
 

--- a/config/octane.php
+++ b/config/octane.php
@@ -35,6 +35,7 @@
 */
 
 use Laravel\Octane\Octane;
+use App\Listeners\ClearSentryUser;
 use Laravel\Octane\Events\TaskReceived;
 use Laravel\Octane\Events\TickReceived;
 use Laravel\Octane\Listeners\FlushOnce;
@@ -48,7 +49,6 @@ use Laravel\Octane\Events\RequestTerminated;
 use Laravel\Octane\Listeners\CollectGarbage;
 use Laravel\Octane\Listeners\ReportException;
 use Laravel\Octane\Events\WorkerErrorOccurred;
-use Laravel\Octane\Listeners\FlushUploadedFiles;
 use Laravel\Octane\Contracts\OperationTerminated;
 use Laravel\Octane\Listeners\StopWorkerIfNecessary;
 use Laravel\Octane\Listeners\DisconnectFromDatabases;
@@ -111,7 +111,7 @@ return [
         ],
 
         RequestTerminated::class => [
-            // FlushUploadedFiles::class,
+            ClearSentryUser::class,
         ],
 
         TaskReceived::class => [


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-648

### Technical Description

Sets the Tenant ID and User ID in Sentry context when appropriate and clears these values when the requests end or in other pertinent events like when a User logs out.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
