### PR TITLE
[ADVAPP - 637] - Message center not respecting user timezone

### DIFF
--- a/app-modules/engagement/resources/views/components/message-center-inbox.blade.php
+++ b/app-modules/engagement/resources/views/components/message-center-inbox.blade.php
@@ -33,6 +33,7 @@
 --}}
 @php
     use Carbon\Carbon;
+    use App\Settings\DisplaySettings;
 @endphp
 
 <div
@@ -82,8 +83,8 @@
                                         </div>
                                         <div class="w-full text-xs font-normal text-gray-700 dark:text-gray-400">
                                             Last engaged at
-
-                                            {{ Carbon::parse($educatable->latest_activity)->format('g:ia - M j, Y') }}
+                                            @php $timezone =  app(DisplaySettings::class)->getTimezone() @endphp
+                                            {{ Carbon::parse($educatable->latest_activity)->setTimezone($timezone)->format('g:ia - M j, Y') }}
                                         </div>
                                     </div>
                                 </li>

--- a/app-modules/engagement/src/Filament/Pages/MessageCenter.php
+++ b/app-modules/engagement/src/Filament/Pages/MessageCenter.php
@@ -334,7 +334,7 @@ class MessageCenter extends Page
         if ($this->filterPeopleType === 'students' || $this->filterPeopleType === 'all') {
             $studentIds = $this->getStudentIds();
             $studentLatestActivity = $this->getLatestActivityForEducatables($studentIds);
-
+            
             $studentPopulationQuery = Student::query()
                 ->when($this->search, function ($query, $search) {
                     $query->where('full_name', 'like', "%{$search}%")
@@ -371,7 +371,7 @@ class MessageCenter extends Page
         } else {
             $educatables = $studentPopulationQuery->unionAll($prospectPopulationQuery);
         }
-
+        
         $this->loadingInbox = false;
 
         return [

--- a/app-modules/engagement/src/Filament/Pages/MessageCenter.php
+++ b/app-modules/engagement/src/Filament/Pages/MessageCenter.php
@@ -334,7 +334,7 @@ class MessageCenter extends Page
         if ($this->filterPeopleType === 'students' || $this->filterPeopleType === 'all') {
             $studentIds = $this->getStudentIds();
             $studentLatestActivity = $this->getLatestActivityForEducatables($studentIds);
-            
+
             $studentPopulationQuery = Student::query()
                 ->when($this->search, function ($query, $search) {
                     $query->where('full_name', 'like', "%{$search}%")
@@ -371,7 +371,7 @@ class MessageCenter extends Page
         } else {
             $educatables = $studentPopulationQuery->unionAll($prospectPopulationQuery);
         }
-        
+
         $this->loadingInbox = false;
 
         return [


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-637

### Technical Description

> Based on timezone selected by use show the times and date when logged in, in that timezone and if not selected any timezone the default will be used.
