### PR TITLE
[BUGFIX]: Change the default amount of queue workers to 1 in local development

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
     build:
       target: development
       args:
-        TOTAL_QUEUE_WORKERS: '${TOTAL_QUEUE_WORKERS:-10}'
+        TOTAL_QUEUE_WORKERS: '${TOTAL_QUEUE_WORKERS:-1}'
     environment:
       SSL_MODE: "mixed"
       LANDLORD_MIGRATE: '${LANDLORD_MIGRATE:-true}'


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Changes the default amount of queue workers to just 1 in local development.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
