### PR TITLE
[ADVAPP-641]: Update state management to allow tasks to go from Cancelled back to In Progress

### DIFF
--- a/app-modules/task/src/Enums/TaskStatus.php
+++ b/app-modules/task/src/Enums/TaskStatus.php
@@ -54,6 +54,7 @@ enum TaskStatus: string implements HasColor, HasLabel
 
     case Completed = 'completed';
 
+    #[AllowTransitionTo(self::InProgress)]
     case Canceled = 'canceled';
 
     public function getColor(): string

--- a/app-modules/task/tests/ListTasksTest.php
+++ b/app-modules/task/tests/ListTasksTest.php
@@ -142,7 +142,6 @@ test('Task status change from pending to in progress', function () {
     ]);
 
     livewire(ListTasks::class)
-        ->mountTableAction(TaskViewAction::class, $task)
         ->callTableAction('view.mark_as_in_progress', $task);
     
     $task->refresh();
@@ -164,7 +163,6 @@ test('Task status change from pending to canceled', function () {
     ]);
 
     livewire(ListTasks::class)
-        ->mountTableAction(TaskViewAction::class, $task)
         ->callTableAction('view.mark_as_canceled', $task);
     
     $task->refresh();
@@ -186,7 +184,6 @@ test('Task status change from in progress to completed', function () {
     ]);
 
     livewire(ListTasks::class)
-        ->mountTableAction(TaskViewAction::class, $task)
         ->callTableAction('view.mark_as_completed', $task);
     
     $task->refresh();
@@ -208,7 +205,6 @@ test('Task status change from in progress to canceled', function () {
     ]);
 
     livewire(ListTasks::class)
-        // ->mountTableAction(TaskViewAction::class, $task)
         ->callTableAction('view.mark_as_canceled', $task);
     
     $task->refresh();
@@ -229,10 +225,10 @@ test('Task status change from canceled to in progress', function () {
         'status' => TaskStatus::Canceled
     ]);
 
-    $component = livewire(ListTasks::class)
-        // ->mountTableAction(TaskViewAction::class, $task)
+    livewire(ListTasks::class)
+        ->removeTableFilters()
         ->callTableAction('view.mark_as_in_progress', $task);
-    dd($component->errors());
+
     $task->refresh();
     expect($task->status)->toEqual(TaskStatus::InProgress);
 });

--- a/app-modules/task/tests/ListTasksTest.php
+++ b/app-modules/task/tests/ListTasksTest.php
@@ -46,11 +46,7 @@ use function Pest\Livewire\livewire;
 use AdvisingApp\Task\Enums\TaskStatus;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Task\Filament\Resources\TaskResource;
-use AdvisingApp\Task\Filament\Resources\TaskResource\Components\TaskViewAction;
 use AdvisingApp\Task\Filament\Resources\TaskResource\Pages\ListTasks;
-use AdvisingApp\Task\Filament\Resources\TaskResource\Pages\ViewTask;
-use Filament\Actions\ViewAction;
-use Illuminate\Support\Facades\Log;
 
 test('ListTasks page displays the correct details for available my tasks', function () {
     asSuperAdmin();
@@ -128,101 +124,96 @@ test('ListTasks is gated with proper access control', function () {
 //test('mark_as_in_progress is only visible to those with the proper access', function () {});
 
 test('Task status change from pending to in progress', function () {
-
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
     $user->givePermissionTo('task.*.update');
     $user->givePermissionTo('task.view-any');
-    $user->givePermissionTo("task.*.view");
+    $user->givePermissionTo('task.*.view');
 
     actingAs($user);
 
     $task = Task::factory()->create([
-        'status' => TaskStatus::Pending
+        'status' => TaskStatus::Pending,
     ]);
 
     livewire(ListTasks::class)
         ->callTableAction('view.mark_as_in_progress', $task);
-    
+
     $task->refresh();
     expect($task->status)->toEqual(TaskStatus::InProgress);
 });
 
 test('Task status change from pending to canceled', function () {
-
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
     $user->givePermissionTo('task.*.update');
     $user->givePermissionTo('task.view-any');
-    $user->givePermissionTo("task.*.view");
+    $user->givePermissionTo('task.*.view');
 
     actingAs($user);
 
     $task = Task::factory()->create([
-        'status' => TaskStatus::Pending
+        'status' => TaskStatus::Pending,
     ]);
 
     livewire(ListTasks::class)
         ->callTableAction('view.mark_as_canceled', $task);
-    
+
     $task->refresh();
     expect($task->status)->toEqual(TaskStatus::Canceled);
 });
 
 test('Task status change from in progress to completed', function () {
-
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
     $user->givePermissionTo('task.*.update');
     $user->givePermissionTo('task.view-any');
-    $user->givePermissionTo("task.*.view");
+    $user->givePermissionTo('task.*.view');
 
     actingAs($user);
 
     $task = Task::factory()->create([
-        'status' => TaskStatus::InProgress
+        'status' => TaskStatus::InProgress,
     ]);
 
     livewire(ListTasks::class)
         ->callTableAction('view.mark_as_completed', $task);
-    
+
     $task->refresh();
     expect($task->status)->toEqual(TaskStatus::Completed);
 });
 
 test('Task status change from in progress to canceled', function () {
-
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
     $user->givePermissionTo('task.*.update');
     $user->givePermissionTo('task.view-any');
-    $user->givePermissionTo("task.*.view");
+    $user->givePermissionTo('task.*.view');
 
     actingAs($user);
 
     $task = Task::factory()->create([
-        'status' => TaskStatus::InProgress
+        'status' => TaskStatus::InProgress,
     ]);
 
     livewire(ListTasks::class)
         ->callTableAction('view.mark_as_canceled', $task);
-    
+
     $task->refresh();
     expect($task->status)->toEqual(TaskStatus::Canceled);
 });
 
 test('Task status change from canceled to in progress', function () {
-
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
     $user->givePermissionTo('task.*.update');
     $user->givePermissionTo('task.view-any');
-    $user->givePermissionTo("task.*.view");
+    $user->givePermissionTo('task.*.view');
 
     actingAs($user);
 
     $task = Task::factory()->create([
-        'status' => TaskStatus::Canceled
+        'status' => TaskStatus::Canceled,
     ]);
 
     livewire(ListTasks::class)


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-641

### Technical Description

> Describe your changes in detail. This should include technical/architectural decisions and reasoning, if applicable.
> Update state management to allow tasks status from Cancelled to In Progress. Also, Added test cases for each allowed transition test cases: 

1. Pending to In Progress
2. Pending to Canceled
3. In Progress to Completed
4. In Progress to Canceled
5. Canceled to In Progress


_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
