### PR TITLE
[ADVAPP-655]: Link Students and Prospects in Message Center to holistic record view

### DIFF
--- a/app-modules/engagement/resources/views/components/message-center-content.blade.php
+++ b/app-modules/engagement/resources/views/components/message-center-content.blade.php
@@ -48,7 +48,7 @@
                 <div
                     class="sticky top-0 z-[5] flex h-12 w-full items-center justify-between bg-gray-100 px-4 dark:bg-gray-700">
                     <h1 class="ml-2"> <a
-                        href="{{ $educatable->filamentResource()::getUrl('view', ['record' => $educatable->identifier()]) }}"
+                            href="{{ $educatable->filamentResource()::getUrl('view', ['record' => $educatable->identifier()]) }}"
                         >{{ $educatable->display_name }} </a></h1>
                     <x-filament::button wire:click="engage('{{ $educatable }}')">
                         Engage

--- a/app-modules/engagement/resources/views/components/message-center-content.blade.php
+++ b/app-modules/engagement/resources/views/components/message-center-content.blade.php
@@ -47,7 +47,9 @@
             >
                 <div
                     class="sticky top-0 z-[5] flex h-12 w-full items-center justify-between bg-gray-100 px-4 dark:bg-gray-700">
-                    <h1 class="ml-2">{{ $educatable->display_name }}</h1>
+                    <h1 class="ml-2"> <a
+                        href="{{ $educatable->filamentResource()::getUrl('view', ['record' => $educatable->identifier()]) }}"
+                        >{{ $educatable->display_name }} </a></h1>
                     <x-filament::button wire:click="engage('{{ $educatable }}')">
                         Engage
                     </x-filament::button>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-655

### Technical Description

> Add links on the name of student/prospect in the message center which on click redirects the to view page of respective student/prospect.
