### PR TITLE
[ADVAPP-664]: Introduce the ability to receive the product health check data at the tenant level available via API call

### DIFF
--- a/app/Http/Middleware/CheckOlympusKey.php
+++ b/app/Http/Middleware/CheckOlympusKey.php
@@ -39,13 +39,16 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use App\Settings\OlympusSettings;
+use Spatie\Multitenancy\Landlord;
 use Symfony\Component\HttpFoundation\Response;
 
 class CheckOlympusKey
 {
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->bearerToken() !== app(OlympusSettings::class)->key) {
+        $key = Landlord::execute(fn (): ?string => app(OlympusSettings::class)->key);
+
+        if ($request->bearerToken() !== $key) {
             if ($request->expectsJson()) {
                 return response()->json([
                     'message' => 'Invalid Olympus key',

--- a/routes/api.php
+++ b/routes/api.php
@@ -37,7 +37,14 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Middleware\CheckOlympusKey;
 use App\Http\Controllers\UpdateAzureSsoSettingsController;
+use Spatie\Health\Http\Controllers\HealthCheckJsonResultsController;
 
-Route::middleware([CheckOlympusKey::class])
-    ->post('azure-sso/update', UpdateAzureSsoSettingsController::class)
-    ->name('azure-sso.update');
+Route::middleware([
+    CheckOlympusKey::class,
+])->group(function () {
+    Route::post('/azure-sso/update', UpdateAzureSsoSettingsController::class)
+        ->name('azure-sso.update');
+
+    Route::get('/health', HealthCheckJsonResultsController::class)
+        ->name('health');
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-664

### Technical Description

Added `/health` route to the api to return health results.
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
