### PR TITLE
[ADVAPP-588]: Introduce administrator recovery and support for MFA issues for local accounts

### DIFF
--- a/app-modules/authorization/tests/Feature/Filament/Resources/User/ViewUserTest.php
+++ b/app-modules/authorization/tests/Feature/Filament/Resources/User/ViewUserTest.php
@@ -53,11 +53,9 @@ it('renders impersonate button for non super admin users when user is super admi
 
     $user = User::factory()->create();
 
-    $component = livewire(ViewUser::class, [
+    livewire(ViewUser::class, [
         'record' => $user->getRouteKey(),
-    ]);
-
-    $component
+    ])
         ->assertSuccessful()
         ->assertActionVisible(Impersonate::class);
 });
@@ -69,11 +67,9 @@ it('does not render impersonate button for super admin users at all', function (
     $user = User::factory()->create();
     asSuperAdmin($user);
 
-    $component = livewire(ViewUser::class, [
+    livewire(ViewUser::class, [
         'record' => $superAdmin->getRouteKey(),
-    ]);
-
-    $component
+    ])
         ->assertSuccessful()
         ->assertActionHidden(Impersonate::class);
 });
@@ -101,11 +97,9 @@ it('allows super admin user to impersonate', function () {
 
     $user = User::factory()->create();
 
-    $component = livewire(ViewUser::class, [
+    livewire(ViewUser::class, [
         'record' => $user->getRouteKey(),
-    ]);
-
-    $component
+    ])
         ->assertSuccessful()
         ->callAction(Impersonate::class);
 
@@ -120,11 +114,9 @@ it('allows user with permission to impersonate', function () {
 
     $second = User::factory()->create();
 
-    $component = livewire(ViewUser::class, [
+    livewire(ViewUser::class, [
         'record' => $second->getRouteKey(),
-    ]);
-
-    $component
+    ])
         ->assertSuccessful()
         ->callAction(Impersonate::class);
 
@@ -133,9 +125,7 @@ it('allows user with permission to impersonate', function () {
 });
 
 it('does not display the mfa_status Action for an external User', function () {
-    $user = User::factory()->create([
-        'is_external' => true,
-    ]);
+    $user = User::factory()->external()->create();
 
     asSuperAdmin();
 
@@ -152,11 +142,9 @@ it('displays the proper mfa_status Action for an internal User without MFA enabl
 
     asSuperAdmin();
 
-    $component = livewire(ViewUser::class, [
+    livewire(ViewUser::class, [
         'record' => $user->getRouteKey(),
-    ]);
-
-    $component
+    ])
         ->assertActionHasLabel('mfa_status', 'MFA Disabled')
         ->assertActionHasColor('mfa_status', 'gray');
 });
@@ -170,11 +158,9 @@ it('displays the proper mfa_status Action for an internal User with MFA enabled 
 
     asSuperAdmin();
 
-    $component = livewire(ViewUser::class, [
+    livewire(ViewUser::class, [
         'record' => $user->getRouteKey(),
-    ]);
-
-    $component
+    ])
         ->assertActionHasLabel('mfa_status', 'MFA Enabled | Not Confirmed')
         ->assertActionHasColor('mfa_status', 'warning');
 });
@@ -186,25 +172,19 @@ it('displays the proper mfa_status Action for an internal User with MFA enabled 
 
     $user->enableMultifactorAuthentication();
 
-    $user->forceFill([
-        'multifactor_confirmed_at' => now(),
-    ])->save();
+    $user->confirmMultifactorAuthentication();
 
     asSuperAdmin();
 
-    $component = livewire(ViewUser::class, [
+    livewire(ViewUser::class, [
         'record' => $user->getRouteKey(),
-    ]);
-
-    $component
+    ])
         ->assertActionHasLabel('mfa_status', 'MFA Enabled')
         ->assertActionHasColor('mfa_status', 'success');
 });
 
 it('does not display the mfa_reset Action if the user is external', function () {
-    $user = User::factory()->create([
-        'is_external' => true,
-    ]);
+    $user = User::factory()->external()->create();
 
     asSuperAdmin();
 
@@ -215,15 +195,11 @@ it('does not display the mfa_reset Action if the user is external', function () 
 });
 
 it('does not display the mfa_reset Action if the authed user does not have the proper permission', function () {
-    $user = User::factory()->create([
-        'is_external' => true,
-    ]);
+    $user = User::factory()->external()->create();
 
     $user->enableMultifactorAuthentication();
 
-    $user->forceFill([
-        'multifactor_confirmed_at' => now(),
-    ])->save();
+    $user->confirmMultifactorAuthentication();
 
     $actingAsUser = User::factory()->create();
     $actingAsUser->givePermissionTo('user.view-any', 'user.*.view');
@@ -253,11 +229,9 @@ it('displays the mfa_reset Action if the user is internal, has MFA enabled and/o
     $actingAsUser->givePermissionTo('user.view-any', 'user.*.view', 'user.*.update');
     actingAs($actingAsUser);
 
-    $component = livewire(ViewUser::class, [
+    livewire(ViewUser::class, [
         'record' => $user->getRouteKey(),
-    ]);
-
-    $component
+    ])
         ->assertActionVisible('mfa_reset');
 })->with([
     'Has MFA Enabled' => function () {
@@ -278,9 +252,7 @@ it('displays the mfa_reset Action if the user is internal, has MFA enabled and/o
             function (User $user) {
                 $user->enableMultifactorAuthentication();
 
-                $user->forceFill([
-                    'multifactor_confirmed_at' => now(),
-                ])->save();
+                $user->confirmMultifactorAuthentication();
             }
         );
     },
@@ -293,9 +265,7 @@ it('resets the users MFA when the mfa_reset Action is triggered', function () {
 
     $user->enableMultifactorAuthentication();
 
-    $user->forceFill([
-        'multifactor_confirmed_at' => now(),
-    ])->save();
+    $user->confirmMultifactorAuthentication();
 
     $user->refresh();
 
@@ -305,11 +275,9 @@ it('resets the users MFA when the mfa_reset Action is triggered', function () {
 
     asSuperAdmin();
 
-    $component = livewire(ViewUser::class, [
+    livewire(ViewUser::class, [
         'record' => $user->getRouteKey(),
-    ]);
-
-    $component
+    ])
         ->callAction('mfa_reset');
 
     $user->refresh();

--- a/app-modules/authorization/tests/Feature/Filament/Resources/User/ViewUserTest.php
+++ b/app-modules/authorization/tests/Feature/Filament/Resources/User/ViewUserTest.php
@@ -43,7 +43,6 @@ use Illuminate\View\ViewException;
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function Pest\Laravel\assertDatabaseHas;
-use function PHPUnit\Framework\assertNotNull;
 
 use STS\FilamentImpersonate\Pages\Actions\Impersonate;
 use App\Filament\Resources\UserResource\Pages\EditUser;
@@ -133,7 +132,7 @@ it('allows user with permission to impersonate', function () {
     expect(auth()->id())->toBe($second->id);
 });
 
-it('does not display the mfa_status Action for an external User', function() {
+it('does not display the mfa_status Action for an external User', function () {
     $user = User::factory()->create([
         'is_external' => true,
     ]);
@@ -146,7 +145,7 @@ it('does not display the mfa_status Action for an external User', function() {
         ->assertActionHidden('mfa_status');
 });
 
-it('displays the proper mfa_status Action for an internal User without MFA enabled', function() {
+it('displays the proper mfa_status Action for an internal User without MFA enabled', function () {
     $user = User::factory()->create([
         'is_external' => false,
     ]);
@@ -162,7 +161,7 @@ it('displays the proper mfa_status Action for an internal User without MFA enabl
         ->assertActionHasColor('mfa_status', 'gray');
 });
 
-it('displays the proper mfa_status Action for an internal User with MFA enabled but not confirmed', function() {
+it('displays the proper mfa_status Action for an internal User with MFA enabled but not confirmed', function () {
     $user = User::factory()->create([
         'is_external' => false,
     ]);
@@ -180,7 +179,7 @@ it('displays the proper mfa_status Action for an internal User with MFA enabled 
         ->assertActionHasColor('mfa_status', 'warning');
 });
 
-it('displays the proper mfa_status Action for an internal User with MFA enabled and confirmed', function() {
+it('displays the proper mfa_status Action for an internal User with MFA enabled and confirmed', function () {
     $user = User::factory()->create([
         'is_external' => false,
     ]);
@@ -202,7 +201,7 @@ it('displays the proper mfa_status Action for an internal User with MFA enabled 
         ->assertActionHasColor('mfa_status', 'success');
 });
 
-it('does not display the mfa_reset Action if the user is external', function() {
+it('does not display the mfa_reset Action if the user is external', function () {
     $user = User::factory()->create([
         'is_external' => true,
     ]);
@@ -215,7 +214,7 @@ it('does not display the mfa_reset Action if the user is external', function() {
         ->assertActionHidden('mfa_reset');
 });
 
-it('does not display the mfa_reset Action if the authed user does not have the proper permission', function() {
+it('does not display the mfa_reset Action if the authed user does not have the proper permission', function () {
     $user = User::factory()->create([
         'is_external' => true,
     ]);
@@ -236,7 +235,7 @@ it('does not display the mfa_reset Action if the authed user does not have the p
         ->assertActionHidden('mfa_reset');
 });
 
-it('does not display the mfa_reset Action if the user is internal but has not enabled and/or confirmed MFA', function() {
+it('does not display the mfa_reset Action if the user is internal but has not enabled and/or confirmed MFA', function () {
     $user = User::factory()->create([
         'is_external' => false,
     ]);
@@ -249,7 +248,7 @@ it('does not display the mfa_reset Action if the user is internal but has not en
         ->assertActionHidden('mfa_reset');
 });
 
-it('displays the mfa_reset Action if the user is internal, has MFA enabled and/or confirmed, and the authed user has proper permission', function(User $user) {
+it('displays the mfa_reset Action if the user is internal, has MFA enabled and/or confirmed, and the authed user has proper permission', function (User $user) {
     $actingAsUser = User::factory()->create();
     $actingAsUser->givePermissionTo('user.view-any', 'user.*.view', 'user.*.update');
     actingAs($actingAsUser);
@@ -287,7 +286,7 @@ it('displays the mfa_reset Action if the user is internal, has MFA enabled and/o
     },
 ]);
 
-it('resets the users MFA when the mfa_reset Action is triggered', function() {
+it('resets the users MFA when the mfa_reset Action is triggered', function () {
     $user = User::factory()->create([
         'is_external' => false,
     ]);

--- a/app-modules/authorization/tests/Feature/Filament/Resources/User/ViewUserTest.php
+++ b/app-modules/authorization/tests/Feature/Filament/Resources/User/ViewUserTest.php
@@ -136,9 +136,7 @@ it('does not display the mfa_status Action for an external User', function () {
 });
 
 it('displays the proper mfa_status Action for an internal User without MFA enabled', function () {
-    $user = User::factory()->create([
-        'is_external' => false,
-    ]);
+    $user = User::factory()->internal()->create();
 
     asSuperAdmin();
 
@@ -150,9 +148,7 @@ it('displays the proper mfa_status Action for an internal User without MFA enabl
 });
 
 it('displays the proper mfa_status Action for an internal User with MFA enabled but not confirmed', function () {
-    $user = User::factory()->create([
-        'is_external' => false,
-    ]);
+    $user = User::factory()->internal()->create();
 
     $user->enableMultifactorAuthentication();
 
@@ -166,9 +162,7 @@ it('displays the proper mfa_status Action for an internal User with MFA enabled 
 });
 
 it('displays the proper mfa_status Action for an internal User with MFA enabled and confirmed', function () {
-    $user = User::factory()->create([
-        'is_external' => false,
-    ]);
+    $user = User::factory()->internal()->create();
 
     $user->enableMultifactorAuthentication();
 
@@ -212,9 +206,7 @@ it('does not display the mfa_reset Action if the authed user does not have the p
 });
 
 it('does not display the mfa_reset Action if the user is internal but has not enabled and/or confirmed MFA', function () {
-    $user = User::factory()->create([
-        'is_external' => false,
-    ]);
+    $user = User::factory()->internal()->create();
 
     asSuperAdmin();
 
@@ -236,9 +228,7 @@ it('displays the mfa_reset Action if the user is internal, has MFA enabled and/o
 })->with([
     'Has MFA Enabled' => function () {
         return tap(
-            User::factory()->create([
-                'is_external' => false,
-            ]),
+            User::factory()->internal()->create(),
             function (User $user) {
                 $user->enableMultifactorAuthentication();
             }
@@ -246,9 +236,7 @@ it('displays the mfa_reset Action if the user is internal, has MFA enabled and/o
     },
     'Has MFA Confirmed' => function () {
         return tap(
-            User::factory()->create([
-                'is_external' => false,
-            ]),
+            User::factory()->internal()->create(),
             function (User $user) {
                 $user->enableMultifactorAuthentication();
 
@@ -259,9 +247,7 @@ it('displays the mfa_reset Action if the user is internal, has MFA enabled and/o
 ]);
 
 it('resets the users MFA when the mfa_reset Action is triggered', function () {
-    $user = User::factory()->create([
-        'is_external' => false,
-    ]);
+    $user = User::factory()->internal()->create();
 
     $user->enableMultifactorAuthentication();
 

--- a/app-modules/multifactor-authentication/src/Traits/MultifactorAuthenticatable.php
+++ b/app-modules/multifactor-authentication/src/Traits/MultifactorAuthenticatable.php
@@ -40,6 +40,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use AdvisingApp\MultifactorAuthentication\Services\MultifactorService;
+use App\Models\Tenant;
 
 trait MultifactorAuthenticatable
 {
@@ -109,7 +110,7 @@ trait MultifactorAuthenticatable
     public function getMultifactorQrCodeUrl()
     {
         return app(MultifactorService::class)->getQrCodeUrl(
-            config('app.name'),
+            config('app.name') . ' | ' . Tenant::current()->name,
             $this->email,
             decrypt($this->multifactor_secret)
         );

--- a/app-modules/multifactor-authentication/src/Traits/MultifactorAuthenticatable.php
+++ b/app-modules/multifactor-authentication/src/Traits/MultifactorAuthenticatable.php
@@ -36,11 +36,11 @@
 
 namespace AdvisingApp\MultifactorAuthentication\Traits;
 
+use App\Models\Tenant;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use AdvisingApp\MultifactorAuthentication\Services\MultifactorService;
-use App\Models\Tenant;
 
 trait MultifactorAuthenticatable
 {

--- a/app/Filament/Resources/UserResource/Pages/ViewUser.php
+++ b/app/Filament/Resources/UserResource/Pages/ViewUser.php
@@ -36,19 +36,18 @@
 
 namespace App\Filament\Resources\UserResource\Pages;
 
-use AdvisingApp\Authorization\Models\License;
-use App\Filament\Forms\Components\Licenses;
-use App\Filament\Resources\UserResource;
-use App\Models\User;
 use Carbon\Carbon;
+use App\Models\User;
+use Filament\Forms\Form;
 use Filament\Actions\Action;
 use Filament\Actions\EditAction;
-use Filament\Forms\Components\Section;
-use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
-use Filament\Forms\Form;
-use Filament\Infolists\Components\IconEntry;
+use Filament\Forms\Components\Section;
+use App\Filament\Resources\UserResource;
+use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\ViewRecord;
+use App\Filament\Forms\Components\Licenses;
+use AdvisingApp\Authorization\Models\License;
 use STS\FilamentImpersonate\Pages\Actions\Impersonate;
 
 class ViewUser extends ViewRecord
@@ -105,19 +104,19 @@ class ViewUser extends ViewRecord
                 ->badge()
                 ->disabled()
                 ->visible(fn (User $record) => ! $record->is_external)
-                ->label(fn (User $record) => match(true) {
+                ->label(fn (User $record) => match (true) {
                     $record->hasConfirmedMultifactor() => 'MFA Enabled',
                     $record->hasEnabledMultifactor() => 'MFA Enabled | Not Confirmed',
                     default => 'MFA Disabled',
                 })
-                ->color(fn (User $record) => match(true) {
+                ->color(fn (User $record) => match (true) {
                     $record->hasConfirmedMultifactor() => 'success',
                     $record->hasEnabledMultifactor() => 'warning',
                     default => 'gray',
                 }),
             Action::make('mfa_reset')
-                ->visible(fn (User $record) =>
-                    ! $record->is_external 
+                ->visible(
+                    fn (User $record) => ! $record->is_external
                     && $record->hasConfirmedMultifactor() || $record->hasEnabledMultifactor()
                     && auth()->user()->can('resetMultifactorAuthentication', $record),
                 )

--- a/app/Filament/Resources/UserResource/Pages/ViewUser.php
+++ b/app/Filament/Resources/UserResource/Pages/ViewUser.php
@@ -115,6 +115,16 @@ class ViewUser extends ViewRecord
                     $record->hasEnabledMultifactor() => 'warning',
                     default => 'gray',
                 }),
+            Action::make('mfa_reset')
+                ->visible(fn (User $record) =>
+                    ! $record->is_external 
+                    && $record->hasConfirmedMultifactor() || $record->hasEnabledMultifactor()
+                    && auth()->user()->can('resetMultifactorAuthentication', $record),
+                )
+                ->label('Reset MFA')
+                ->icon('heroicon-s-lock-open')
+                ->modalDescription('Are you sure you want to reset the multifactor authentication for this user?')
+                ->action(fn (User $record) => $record->disableMultifactorAuthentication()),
             Impersonate::make()
                 ->record($user),
             EditAction::make(),

--- a/app/Filament/Resources/UserResource/Pages/ViewUser.php
+++ b/app/Filament/Resources/UserResource/Pages/ViewUser.php
@@ -36,17 +36,19 @@
 
 namespace App\Filament\Resources\UserResource\Pages;
 
-use Carbon\Carbon;
-use App\Models\User;
-use Filament\Forms\Form;
-use Filament\Actions\EditAction;
-use Filament\Forms\Components\Toggle;
-use Filament\Forms\Components\Section;
-use App\Filament\Resources\UserResource;
-use Filament\Forms\Components\TextInput;
-use Filament\Resources\Pages\ViewRecord;
-use App\Filament\Forms\Components\Licenses;
 use AdvisingApp\Authorization\Models\License;
+use App\Filament\Forms\Components\Licenses;
+use App\Filament\Resources\UserResource;
+use App\Models\User;
+use Carbon\Carbon;
+use Filament\Actions\Action;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Form;
+use Filament\Infolists\Components\IconEntry;
+use Filament\Resources\Pages\ViewRecord;
 use STS\FilamentImpersonate\Pages\Actions\Impersonate;
 
 class ViewUser extends ViewRecord
@@ -99,6 +101,20 @@ class ViewUser extends ViewRecord
         $user = $this->getRecord();
 
         return [
+            Action::make('mfa_status')
+                ->badge()
+                ->disabled()
+                ->visible(fn (User $record) => ! $record->is_external)
+                ->label(fn (User $record) => match(true) {
+                    $record->hasConfirmedMultifactor() => 'MFA Enabled',
+                    $record->hasEnabledMultifactor() => 'MFA Enabled | Not Confirmed',
+                    default => 'MFA Disabled',
+                })
+                ->color(fn (User $record) => match(true) {
+                    $record->hasConfirmedMultifactor() => 'success',
+                    $record->hasEnabledMultifactor() => 'warning',
+                    default => 'gray',
+                }),
             Impersonate::make()
                 ->record($user),
             EditAction::make(),

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -113,4 +113,12 @@ class UserPolicy
             denyResponse: 'You do not have permission to permanently delete this user.'
         );
     }
+
+    public function resetMultifactorAuthentication(Authenticatable $authenticatable, User $model): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['user.*.update', "user.{$model->id}.update"],
+            denyResponse: 'You do not have permission to update this user, therefore you may not reset their MFA.'
+        );
+    }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -81,6 +81,13 @@ class UserFactory extends Factory
         ]);
     }
 
+    public function internal(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_external' => false,
+        ]);
+    }
+
     /**
      * @param LicenseType | array<LicenseType> $licenseTypes
      */


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-588

### Technical Description

This adds the ability for Admins to see a user's MFA status on the User View page. It also allows Users with the User Update permission to reset a user's MFA status via a header Action.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
