### PR TITLE
[ADVAPP-672]: Add local MFA recovery code usage

### DIFF
--- a/app-modules/authorization/resources/views/login.blade.php
+++ b/app-modules/authorization/resources/views/login.blade.php
@@ -72,4 +72,18 @@
             :full-width="$this->hasFullWidthFormActions()"
         />
     </x-filament-panels::form>
+    @if($this->needsMFA && ! $this->needsMfaSetup)
+        <x-filament::link
+            size="sm"
+            class="cursor-pointer"
+            wire:click.prevent="toggleUsingRecoveryCodes()"
+            tag="button"
+        >
+            @if($this->usingRecoveryCode)
+                Use MFA Code
+            @else
+                Use Recovery Code
+            @endif
+        </x-filament::link>
+    @endif
 </x-filament-panels::page.simple>

--- a/app-modules/authorization/resources/views/login.blade.php
+++ b/app-modules/authorization/resources/views/login.blade.php
@@ -72,14 +72,14 @@
             :full-width="$this->hasFullWidthFormActions()"
         />
     </x-filament-panels::form>
-    @if($this->needsMFA && ! $this->needsMfaSetup)
+    @if ($this->needsMFA && !$this->needsMfaSetup)
         <x-filament::link
-            size="sm"
             class="cursor-pointer"
+            size="sm"
             wire:click.prevent="toggleUsingRecoveryCodes()"
             tag="button"
         >
-            @if($this->usingRecoveryCode)
+            @if ($this->usingRecoveryCode)
                 Use MFA Code
             @else
                 Use Recovery Code

--- a/app-modules/authorization/src/Filament/Pages/Auth/Login.php
+++ b/app-modules/authorization/src/Filament/Pages/Auth/Login.php
@@ -234,6 +234,10 @@ class Login extends FilamentLogin
                                 ? '-'
                                 : null
                             )
+                            ->helperText(fn (Login $livewire) => $livewire->usingRecoveryCode
+                                ? 'Enter one of your recovery codes provided when you enabled multifactor authentication. Recovery codes are one-time use only. If you have used all of your recovery codes, you will need to contact your administrator to reset your multifactor authentication.'
+                                : null
+                            )
                             ->numeric(fn (Login $livewire) => ! $livewire->usingRecoveryCode)
                             ->string(fn (Login $livewire) => $livewire->usingRecoveryCode)
                             ->required(fn (Login $livewire) => $livewire->needsMFA)

--- a/app-modules/authorization/src/Filament/Pages/Auth/Login.php
+++ b/app-modules/authorization/src/Filament/Pages/Auth/Login.php
@@ -51,7 +51,6 @@ use Filament\Http\Responses\Auth\Contracts\LoginResponse;
 use AdvisingApp\MultifactorAuthentication\Services\MultifactorService;
 use AdvisingApp\MultifactorAuthentication\Settings\MultifactorSettings;
 use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
-use Illuminate\Support\Facades\Log;
 
 class Login extends FilamentLogin
 {
@@ -130,7 +129,7 @@ class Login extends FilamentLogin
                     Filament::auth()->logout();
 
                     $this->needsMFA = false;
-                    
+
                     $this->usingRecoveryCode = false;
 
                     $this->data['code'] = null;
@@ -145,7 +144,7 @@ class Login extends FilamentLogin
 
                     $this->mountAction('recoveryCodes', [
                         'user' => $user,
-                        'remember' => $data['remember']
+                        'remember' => $data['remember'],
                     ]);
 
                     return null;
@@ -190,6 +189,11 @@ class Login extends FilamentLogin
     public function getMultifactorQrCode()
     {
         return app(MultifactorService::class)->getMultifactorQrCodeSvg($this->user->getMultifactorQrCodeUrl());
+    }
+
+    public function toggleUsingRecoveryCodes(): void
+    {
+        $this->usingRecoveryCode = ! $this->usingRecoveryCode;
     }
 
     protected function isValidCode(User $user, string $code): bool
@@ -248,23 +252,28 @@ class Login extends FilamentLogin
                             ->hidden(fn (Login $livewire) => $livewire->needsMFA)
                             ->dehydratedWhenHidden(),
                         TextInput::make('code')
-                            ->label(fn (Login $livewire) => ! $livewire->usingRecoveryCode
+                            ->label(
+                                fn (Login $livewire) => ! $livewire->usingRecoveryCode
                                 ? 'Multifactor Authentication Code'
                                 : 'Multifactor Recovery Code'
                             )
-                            ->placeholder(fn (Login $livewire) => ! $livewire->usingRecoveryCode
+                            ->placeholder(
+                                fn (Login $livewire) => ! $livewire->usingRecoveryCode
                                 ? '###-###'
                                 : 'abcdef-98765'
                             )
-                            ->mask(fn (Login $livewire) => ! $livewire->usingRecoveryCode
+                            ->mask(
+                                fn (Login $livewire) => ! $livewire->usingRecoveryCode
                                 ? '999-999'
                                 : null
                             )
-                            ->stripCharacters(fn (Login $livewire) => ! $livewire->usingRecoveryCode
+                            ->stripCharacters(
+                                fn (Login $livewire) => ! $livewire->usingRecoveryCode
                                 ? '-'
                                 : null
                             )
-                            ->helperText(fn (Login $livewire) => $livewire->usingRecoveryCode
+                            ->helperText(
+                                fn (Login $livewire) => $livewire->usingRecoveryCode
                                 ? 'Enter one of your recovery codes provided when you enabled multifactor authentication. Recovery codes are one-time use only. If you have used all of your recovery codes, you will need to contact your administrator to reset your multifactor authentication.'
                                 : null
                             )
@@ -277,10 +286,5 @@ class Login extends FilamentLogin
                     ->statePath('data'),
             ),
         ];
-    }
-
-    public function toggleUsingRecoveryCodes(): void
-    {
-        $this->usingRecoveryCode = ! $this->usingRecoveryCode;
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-672

### Technical Description

Fixes issue with MFA setup and sets up the ability to use recovery codes during login.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
