### PR TITLE
[ADVAPP-678]: Reduce local queues and workers to only run a single instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,11 +52,12 @@ AWS_SQS_ACCESS_KEY_ID=
 AWS_SQS_SECRET_ACCESS_KEY=
 SQS_PREFIX=
 SQS_QUEUE=default
-LANDLORD_SQS_QUEUE=landlord
-OUTBOUND_COMMUNICATION_QUEUE=outbound-communication
-AUDIT_QUEUE_QUEUE=audit
-MEETING_CENTER_QUEUE=meeting-center
-IMPORT_EXPORT_QUEUE=import-export
+# Each of the following queues can be set to a different value if needed, but are set to the default for normal local development
+LANDLORD_SQS_QUEUE=default # or landlord
+OUTBOUND_COMMUNICATION_QUEUE=default # or outbound-communication
+AUDIT_QUEUE_QUEUE=default # or audit
+MEETING_CENTER_QUEUE=default # or meeting-center
+IMPORT_EXPORT_QUEUE=default # or import-export
 SQS_SUFFIX=
 AWS_SQS_DEFAULT_REGION=us-east-1
 
@@ -119,9 +120,13 @@ BUILD_ASSETS=true
 # A comma separated list of emails that will be seeded as internal users
 DEMO_INTERNAL_USER_EMAILS=
 
-# Will specify the amount of queue worker processes to keep running when the container starts
-# Requires image rebuild if changed, will default to 10 if not set
-#TOTAL_QUEUE_WORKERS=10
+# If set to true queue workers will be created for each queue
+# When false it will only create queue workers for the SQS_QUEUE default queue
+# MULTIPLE_DEVELOPMENT_QUEUES=false
+
+# Will specify the amount of queue worker processes per queue to keep running when the container starts
+# Requires image rebuild if changed, will default to 3 if not set
+#TOTAL_QUEUE_WORKERS=3
 
 ### END DEV SETTINGS ###
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,7 @@ services:
       target: development
       args:
         TOTAL_QUEUE_WORKERS: '${TOTAL_QUEUE_WORKERS:-1}'
+        MULTIPLE_DEVELOPMENT_QUEUES: '${MULTIPLE_DEVELOPMENT_QUEUES:-false}'
     environment:
       SSL_MODE: "mixed"
       LANDLORD_MIGRATE: '${LANDLORD_MIGRATE:-true}'

--- a/docker/generate-queues.sh
+++ b/docker/generate-queues.sh
@@ -1,26 +1,17 @@
 #!/bin/sh
 
-generate_services () {
-  QUEUE_NAME=$1
-  QUEUE_ENV_VAR=$2
+QUEUE_NAME=$1
+QUEUE_ENV_VAR=$2
 
-  for run in $(seq "$TOTAL_QUEUE_WORKERS"); do
-    if [ $run -eq 1 ]; then
-      SLEEP_TIME=0
-    else
-      SLEEP_TIME=3;
-    fi
+for run in $(seq "$TOTAL_QUEUE_WORKERS"); do
+if [ $run -eq 1 ]; then
+    SLEEP_TIME=0
+else
+    SLEEP_TIME=3;
+fi
 
-    cp -r "/tmp/s6-overlay-templates/laravel-queue/service" "/etc/s6-overlay/s6-rc.d/$QUEUE_NAME-queue-$run";
-    sed -i -e "s/VAR_QUEUE/$QUEUE_ENV_VAR/g" "/etc/s6-overlay/s6-rc.d/$QUEUE_NAME-queue-$run/run";
-    sed -i -e "s/TEMPLATE_SLEEP/$SLEEP_TIME/g" "/etc/s6-overlay/s6-rc.d/$QUEUE_NAME-queue-$run/run";
-    cp "/tmp/s6-overlay-templates/laravel-queue/laravel-queue" "/etc/s6-overlay/s6-rc.d/user/contents.d/$QUEUE_NAME-queue-$run";
-  done
-}
-
-generate_services "default" "\$SQS_QUEUE"
-generate_services "landlord" "\$LANDLORD_SQS_QUEUE"
-generate_services "outbound-communication" "\$OUTBOUND_COMMUNICATION_QUEUE"
-generate_services "audit" "\$AUDIT_QUEUE_QUEUE"
-generate_services "meeting-center" "\$MEETING_CENTER_QUEUE"
-generate_services "import-export" "\$IMPORT_EXPORT_QUEUE"
+cp -r "/tmp/s6-overlay-templates/laravel-queue/service" "/etc/s6-overlay/s6-rc.d/$QUEUE_NAME-queue-$run";
+sed -i -e "s/VAR_QUEUE/$QUEUE_ENV_VAR/g" "/etc/s6-overlay/s6-rc.d/$QUEUE_NAME-queue-$run/run";
+sed -i -e "s/TEMPLATE_SLEEP/$SLEEP_TIME/g" "/etc/s6-overlay/s6-rc.d/$QUEUE_NAME-queue-$run/run";
+cp "/tmp/s6-overlay-templates/laravel-queue/laravel-queue" "/etc/s6-overlay/s6-rc.d/user/contents.d/$QUEUE_NAME-queue-$run";
+done


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-678

### Technical Description

Reduces the amount of queues run locally to just the single default queue locally by default.

A new `MULTIPLE_DEVELOPMENT_QUEUES` `.env` variable can be set to true if it is desired that multiple queues be running locally.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
