### PR TITLE
[ADVAPP-644]: Resolve SQS large payload errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
         "canyon-gbs/integration-open-ai": "*",
         "canyon-gbs/multifactor-authentication": "*",
         "composer/composer": "^2.7",
+        "defectivecode/laravel-sqs-extended": "^1.0",
         "filament/filament": "^3.2",
         "filament/spatie-laravel-media-library-plugin": "^3.1",
         "filament/spatie-laravel-settings-plugin": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "386c540400071cf6f2f42d2c4b61647b",
+    "content-hash": "8e20169b81c0f8d2afad45fc0b4e69dd",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3851,6 +3851,69 @@
                 "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
             },
             "time": "2024-04-12T12:12:48+00:00"
+        },
+        {
+            "name": "defectivecode/laravel-sqs-extended",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DefectiveCode/laravel-sqs-extended.git",
+                "reference": "f567e52b4fb1439b0d6e426c2c0bcfb2fcfce922"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DefectiveCode/laravel-sqs-extended/zipball/f567e52b4fb1439b0d6e426c2c0bcfb2fcfce922",
+                "reference": "f567e52b4fb1439b0d6e426c2c0bcfb2fcfce922",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.189.0",
+                "illuminate/container": "~9|~10|~11",
+                "illuminate/contracts": "~9|~10|~11",
+                "illuminate/filesystem": "~9|~10|~11",
+                "illuminate/queue": "~9|~10|~11",
+                "illuminate/support": "~9|~10|~11",
+                "league/flysystem": "~3",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.8",
+                "mockery/mockery": "^1.6",
+                "nunomaduro/collision": "^7.0",
+                "orchestra/testbench": "^8.3",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "laravel/vapor-core": "Allows SQS disk based storage while using Laravel Vapor."
+            },
+            "type": "laravel",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "DefectiveCode\\LaravelSqsExtended\\SqsDiskServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DefectiveCode\\LaravelSqsExtended\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Corey McCormick",
+                    "email": "corey@defectivecode.com"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/DefectiveCode/laravel-sqs-extended/issues",
+                "source": "https://github.com/DefectiveCode/laravel-sqs-extended/tree/1.0.0"
+            },
+            "time": "2024-06-04T17:58:12+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/config/queue.php
+++ b/config/queue.php
@@ -84,7 +84,7 @@ return [
         ],
 
         'sqs' => [
-            'driver' => 'sqs',
+            'driver' => 'sqs-disk',
             'key' => env('AWS_SQS_ACCESS_KEY_ID'),
             'secret' => env('AWS_SQS_SECRET_ACCESS_KEY'),
             'prefix' => env('SQS_PREFIX', 'https://sqs.us-east-1.amazonaws.com/your-account-id'),
@@ -92,6 +92,12 @@ return [
             'suffix' => env('SQS_SUFFIX'),
             'region' => env('AWS_SQS_DEFAULT_REGION', 'us-east-1'),
             'after_commit' => false,
+            'disk_options' => [
+                'always_store' => false,
+                'cleanup' => true,
+                'disk' => env('FILESYSTEM_DISK', 'local'),
+                'prefix' => 'sqs-payloads',
+            ],
         ],
 
         'redis' => [

--- a/config/queue.php
+++ b/config/queue.php
@@ -83,6 +83,21 @@ return [
             'after_commit' => false,
         ],
 
+        /*
+        |--------------------------------------------------------------------------
+        | SQS Disk Queue Configuration
+        |--------------------------------------------------------------------------
+        |
+        |
+        | always_store: Determines if all payloads should be stored on a disk regardless if they are over SQS's 256KB limit.
+        | cleanup:      Determines if the payload files should be removed from the disk once the job is processed. Leaveing the
+        |                 files behind can be useful to replay the queue jobs later for debugging reasons.
+        | disk:         The disk to save SQS payloads to.  This disk should be configured in your Laravel filesystems.php config file.
+        | prefix        The prefix (folder) to store the payloads with.  This is useful if you are sharing a disk with other SQS queues.
+        |                 Using a prefix allows for the queue:clear command to destroy the files separately from other sqs-disk backed queues
+        |                 sharing the same disk.
+        |
+        */
         'sqs' => [
             'driver' => 'sqs-disk',
             'key' => env('AWS_SQS_ACCESS_KEY_ID'),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-644

### Technical Description

Sets up the usage of the SQS Disk Driver for our queue management process when using SQS. When the driver determines the payload would be too large for SQS Payload limitations, it will store the payload in S3 and re-hydrate it when the queue worker picks up the job.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
