### PR TITLE
[Bugfix] Force using file_search if files are attached to AI chat

### DIFF
--- a/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
+++ b/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
@@ -244,12 +244,20 @@ abstract class BaseOpenAiService implements AiService
 
         $aiSettings = app(AiSettings::class);
 
-        $stream = $this->client->threads()->runs()->createStreamed($message->thread->thread_id, [
+        $runData = [
             'assistant_id' => $message->thread->assistant->assistant_id,
             'instructions' => $instructions,
             'max_completion_tokens' => $aiSettings->max_tokens,
             'temperature' => $aiSettings->temperature,
-        ]);
+        ];
+
+        if (! empty($createdFiles)) {
+            $runData['tools'] = [
+                ['type' => 'file_search'],
+            ];
+        }
+
+        $stream = $this->client->threads()->runs()->createStreamed($message->thread->thread_id, $runData);
 
         return function () use ($saveResponse, $stream): Generator {
             $response = new AiMessage();
@@ -361,12 +369,20 @@ abstract class BaseOpenAiService implements AiService
 
         $aiSettings = app(AiSettings::class);
 
-        $stream = $this->client->threads()->runs()->createStreamed($message->thread->thread_id, [
+        $runData = [
             'assistant_id' => $message->thread->assistant->assistant_id,
             'instructions' => $instructions,
             'max_completion_tokens' => $aiSettings->max_tokens,
             'temperature' => $aiSettings->temperature,
-        ]);
+        ];
+
+        if (! empty($createdFiles)) {
+            $runData['tools'] = [
+                ['type' => 'file_search'],
+            ];
+        }
+
+        $stream = $this->client->threads()->runs()->createStreamed($message->thread->thread_id, $runData);
 
         return function () use ($saveResponse, $stream): Generator {
             $response = new AiMessage();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Even if the Assistant does not have `file_search` turned on force the run to enable it if files are attached.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
