### PR TITLE
[ADVAPP-701]: Change all workers to sleep for 3 seconds

### DIFF
--- a/docker/generate-queues.sh
+++ b/docker/generate-queues.sh
@@ -4,11 +4,12 @@ QUEUE_NAME=$1
 QUEUE_ENV_VAR=$2
 
 for run in $(seq "$TOTAL_QUEUE_WORKERS"); do
-if [ $run -eq 1 ]; then
-    SLEEP_TIME=0
-else
-    SLEEP_TIME=3;
-fi
+# if [ $run -eq 1 ]; then
+#     SLEEP_TIME=0
+# else
+#     SLEEP_TIME=3;
+# fi
+SLEEP_TIME=3;
 
 cp -r "/tmp/s6-overlay-templates/laravel-queue/service" "/etc/s6-overlay/s6-rc.d/$QUEUE_NAME-queue-$run";
 sed -i -e "s/VAR_QUEUE/$QUEUE_ENV_VAR/g" "/etc/s6-overlay/s6-rc.d/$QUEUE_NAME-queue-$run/run";


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-701

### Technical Description

Updates all workers to sleep for 3 seconds if there are no jobs to process to help with wasted resource usage. Leaving commented code in for now to revert back quickly if we need to change back to the old strategy in prod.

### Screenshots (if appropriate)

### Any deployment steps required?

> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please describe the deployment steps required below and apply the `Deployment Steps` label to the PR.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
