### PR TITLE
[ADVAPP-690]: Restrict the ability to modify the settings for the Institutional Assistant to the appropriate administrative sections Advising App

### DIFF
--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Pages/EditAiAssistant.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Pages/EditAiAssistant.php
@@ -106,11 +106,12 @@ class EditAiAssistant extends EditRecord
             });
     }
 
+    /** @var AiAssistant $assistant */
     public static function canAccess(array $parameters = []): bool
     {
         $assistant = $parameters['record'];
 
-        if ($assistant->is_default == true) {
+        if ($assistant->is_default) {
             return false;
         }
 

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Pages/EditAiAssistant.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Pages/EditAiAssistant.php
@@ -106,6 +106,17 @@ class EditAiAssistant extends EditRecord
             });
     }
 
+    public static function canAccess(array $parameters = []): bool
+    {
+        $assistant = $parameters['record'];
+
+        if ($assistant->is_default == true) {
+            return false;
+        }
+
+        return parent::canAccess();
+    }
+
     protected function getHeaderActions(): array
     {
         return [

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Pages/ListAiAssistants.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Pages/ListAiAssistants.php
@@ -77,7 +77,8 @@ class ListAiAssistants extends ListRecords
                 EditAction::make(),
             ])
             ->emptyStateHeading('No AI Assistants')
-            ->emptyStateDescription('Add a new custom AI Assistant by clicking the "Create AI Assistant" button above.');
+            ->emptyStateDescription('Add a new custom AI Assistant by clicking the "Create AI Assistant" button above.')
+            ->modifyQueryUsing(fn (Builder $query) => $query->whereisDefault(false));
     }
 
     protected function getHeaderActions(): array

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Pages/ListAiAssistants.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Pages/ListAiAssistants.php
@@ -78,7 +78,7 @@ class ListAiAssistants extends ListRecords
             ])
             ->emptyStateHeading('No AI Assistants')
             ->emptyStateDescription('Add a new custom AI Assistant by clicking the "Create AI Assistant" button above.')
-            ->modifyQueryUsing(fn (Builder $query) => $query->whereisDefault(false));
+            ->modifyQueryUsing(fn (Builder $query) => $query->where('is_default', false));
     }
 
     protected function getHeaderActions(): array


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-690

### Technical Description

> Restrict the ability to modify the settings for the Institutional Assistant to the appropriate administrative sections Advising App.

### Screenshots
According to the screenshot below default AI Assistant is not showing in the list.
![image](https://github.com/canyongbs/advisingapp/assets/170341684/7d8e9e01-934d-41c6-bbdb-baf7a7735e41)

As shown in the screenshot below, If trying to access the default assistant page, it gives the forbidden error.
![image](https://github.com/canyongbs/advisingapp/assets/170341684/2b2cd8f6-6d7e-4ff5-89e8-057ee2d3f9df)


_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
