### PR TITLE
[ADVAPP-715]: The order of the primary navigation for the reporting group has regressed to a prior state

### DIFF
--- a/app/Filament/Clusters/ReportLibrary.php
+++ b/app/Filament/Clusters/ReportLibrary.php
@@ -44,5 +44,5 @@ class ReportLibrary extends Cluster
 
     protected static ?string $navigationGroup = 'Reporting';
 
-    protected static ?int $navigationSort = 111;
+    protected static ?int $navigationSort = 10;
 }


### PR DESCRIPTION
…ing group has regressed to a prior state

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-715

### Technical Description

Fix the primary navigation reporting group.

### Screenshots
![image](https://github.com/canyongbs/advisingapp/assets/170341685/5412f1ad-766f-428a-a51a-d56c8e925562)

### Any deployment steps required?

No

### Are any Feature Flags Added?
No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
