### PR TITLE
[ADVAPP-734]: Remove screenshots section from Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,18 +8,6 @@
 >
 > Please ensure that at least one correct change type label is added to the PR. For example, if you are adding a new feature, please add the `Change Type | New Feature` label.
 
-### Screenshots
-
-> Place any relevant screenshots here, replacing this block.
->
-> Any task from a Jira ticket labeled "New Feature", "Improvement", or "Bug" is required to have at least one screenshot added here and uploaded as a comment to the ticket.
->
-> For any change not related to a Jira ticket, any change that would fall under the concept of a new feature, change to an existing feature, or bug requires at least one screenshot to be added here.
->
-> Screenshots should be `1920 x 1080` resolution and be free of PII, , sensitive information, or inappropriate content.
->
-> If no screenshot is required and none are added, replace this block with "N/A".
-
 ### Any deployment steps required?
 
 > A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-734

### Technical Description

Removes the screenshots section from PR templates. Updates DevOps submodule to the most recent version.

### Screenshots

N/A

### Any deployment steps required?

No

### Are any Feature Flags Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
