### PR TITLE
[ADVAPP-730]: Modify the cacheTag property for reports to be locked

### DIFF
--- a/app-modules/report/src/Filament/Widgets/ChartReportWidget.php
+++ b/app-modules/report/src/Filament/Widgets/ChartReportWidget.php
@@ -36,11 +36,13 @@
 
 namespace AdvisingApp\Report\Filament\Widgets;
 
-use Livewire\Attributes\On;
 use Filament\Widgets\ChartWidget;
+use Livewire\Attributes\Locked;
+use Livewire\Attributes\On;
 
 abstract class ChartReportWidget extends ChartWidget
 {
+    #[Locked]
     public string $cacheTag;
 
     protected static ?string $pollingInterval = null;

--- a/app-modules/report/src/Filament/Widgets/ChartReportWidget.php
+++ b/app-modules/report/src/Filament/Widgets/ChartReportWidget.php
@@ -36,9 +36,9 @@
 
 namespace AdvisingApp\Report\Filament\Widgets;
 
-use Filament\Widgets\ChartWidget;
-use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
+use Livewire\Attributes\Locked;
+use Filament\Widgets\ChartWidget;
 
 abstract class ChartReportWidget extends ChartWidget
 {

--- a/app-modules/report/src/Filament/Widgets/StatsOverviewReportWidget.php
+++ b/app-modules/report/src/Filament/Widgets/StatsOverviewReportWidget.php
@@ -37,8 +37,8 @@
 namespace AdvisingApp\Report\Filament\Widgets;
 
 use Livewire\Attributes\On;
-use Filament\Widgets\StatsOverviewWidget;
 use Livewire\Attributes\Locked;
+use Filament\Widgets\StatsOverviewWidget;
 
 abstract class StatsOverviewReportWidget extends StatsOverviewWidget
 {

--- a/app-modules/report/src/Filament/Widgets/StatsOverviewReportWidget.php
+++ b/app-modules/report/src/Filament/Widgets/StatsOverviewReportWidget.php
@@ -38,9 +38,11 @@ namespace AdvisingApp\Report\Filament\Widgets;
 
 use Livewire\Attributes\On;
 use Filament\Widgets\StatsOverviewWidget;
+use Livewire\Attributes\Locked;
 
 abstract class StatsOverviewReportWidget extends StatsOverviewWidget
 {
+    #[Locked]
     public string $cacheTag;
 
     protected static ?string $pollingInterval = null;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-730

### Technical Description

Locks the `$cacheTag` property to prevent frontend manipulation.

### Screenshots

N/A

### Any deployment steps required?

No.

### Are any Feature Flags Added?

No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
