### PR TITLE
[ADVAPP-741]: Update the model names used throughout artificial intelligence features

### DIFF
--- a/app-modules/ai/src/Enums/AiModel.php
+++ b/app-modules/ai/src/Enums/AiModel.php
@@ -59,10 +59,10 @@ enum AiModel: string implements HasLabel
     public function getLabel(): ?string
     {
         return match ($this) {
-            self::OpenAiGpt35 => 'OpenAI GPT-3.5',
-            self::OpenAiGpt4 => 'OpenAI GPT-4',
-            self::OpenAiGpt4o => 'OpenAI GPT-4o',
-            self::OpenAiGptTest => 'OpenAI GPT Test',
+            self::OpenAiGpt35 => 'Canyon GPT-3.5',
+            self::OpenAiGpt4 => 'Canyon GPT-4',
+            self::OpenAiGpt4o => 'Canyon GPT-4o',
+            self::OpenAiGptTest => 'Canyon GPT Test',
             self::Test => 'Test',
         };
     }
@@ -86,12 +86,15 @@ enum AiModel: string implements HasLabel
         $models = self::cases();
 
         if (app()->hasDebugModeEnabled()) {
-            return $models;
+            return array_filter(
+                $models,
+                fn (AiModel $model): bool => $model !== self::OpenAiGptTest,
+            );
         }
 
         return array_filter(
             $models,
-            fn (AiModel $model): bool => $model !== self::Test,
+            fn (AiModel $model): bool => ! in_array($model, [self::Test, self::OpenAiGptTest]),
         );
     }
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-741

### Technical Description

Renames the models. Also implements a small fix to ensure that the GPT test model is not an option to select for the default model.

### Any deployment steps required?

No

### Are any Feature Flags Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
