### PR TITLE
[ADVAPP-713]: Add a media conversion to AI Assistant avatar images

### DIFF
--- a/app-modules/ai/resources/views/components/assistant.blade.php
+++ b/app-modules/ai/resources/views/components/assistant.blade.php
@@ -405,7 +405,7 @@
                                             <img
                                                 class="h-8 w-8 rounded-full object-cover object-center"
                                                 x-bind:src="message.user_id ? (users[message.user_id]?.avatar_url ??
-                                                    @js(filament()->getUserAvatarUrl(auth()->user()))) : @js($this->thread->assistant->getFirstTemporaryUrl(now()->addHour(), 'avatar') ?: \Illuminate\Support\Facades\Vite::asset('resources/images/canyon-ai-headshot.jpg'))"
+                                                    @js(filament()->getUserAvatarUrl(auth()->user()))) : @js($this->thread->assistant->getFirstTemporaryUrl(now()->addHour(), 'avatar', 'thumbnail') ?: \Illuminate\Support\Facades\Vite::asset('resources/images/canyon-ai-headshot.jpg'))"
                                                 x-bind:alt="message.user_id ? (users[message.user_id]?.name ?? @js(auth()->user()->name . ' avatar')) :
                                                     @js($this->thread->assistant->name . ' avatar')"
                                             />

--- a/app-modules/ai/src/Models/AiAssistant.php
+++ b/app-modules/ai/src/Models/AiAssistant.php
@@ -94,6 +94,11 @@ class AiAssistant extends BaseModel implements HasMedia
         $this->addMediaConversion('avatar-height-250px')
             ->performOnCollections('avatar')
             ->height(250);
+
+        $this->addMediaConversion('thumbnail')
+            ->performOnCollections('avatar')
+            ->width(32)
+            ->height(32);
     }
 
     public function threads(): HasMany


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-713

### Technical Description

> Added a thumbnail (32*32 px) in AI Assistant.

### Any deployment steps required?

> Yes. We will need to run the Spatie Media command to regenerate conversions for the AiAssistants Model after this is merged and deployed

### Are any Feature Flags Added?

> No
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
