### PR TITLE
[ADVAPP-723]: Enable default sort of Permissions Group ascending

### DIFF
--- a/app-modules/authorization/src/Filament/Resources/PermissionResource.php
+++ b/app-modules/authorization/src/Filament/Resources/PermissionResource.php
@@ -102,7 +102,8 @@ class PermissionResource extends Resource
             ])
             ->actions([
                 ViewAction::make(),
-            ]);
+            ])
+            ->defaultSort('group.name', 'asc');
     }
 
     public static function getRelations(): array


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-723

### Technical Description

>Make group name column in permission group default sort in ascending

### Any deployment steps required?

>No.

### Are any Feature Flags Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
