### PR TITLE
[ADVAPP-727]: Enhance the contextual information provided in alerts by including who created the alert

### DIFF
--- a/app-modules/alert/database/migrations/2024_07_17_101206_add_user_id_foreign_key_in_alerts_table.php
+++ b/app-modules/alert/database/migrations/2024_07_17_101206_add_user_id_foreign_key_in_alerts_table.php
@@ -34,12 +34,11 @@
 </COPYRIGHT>
 */
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('alerts', function (Blueprint $table) {

--- a/app-modules/alert/database/migrations/2024_07_17_101206_add_user_id_foreign_key_in_alerts_table.php
+++ b/app-modules/alert/database/migrations/2024_07_17_101206_add_user_id_foreign_key_in_alerts_table.php
@@ -42,14 +42,14 @@ return new class () extends Migration {
     public function up(): void
     {
         Schema::table('alerts', function (Blueprint $table) {
-            $table->foreignUuid('user_id')->nullable()->references('id')->on('users')->restrictOnDelete();
+            $table->foreignUuid('created_by')->nullable()->references('id')->on('users')->restrictOnDelete();
         });
     }
 
     public function down(): void
     {
         Schema::table('alerts', function (Blueprint $table) {
-            $table->dropColumn('user_id');
+            $table->dropColumn('created_by');
         });
     }
 };

--- a/app-modules/alert/database/migrations/2024_07_17_101206_add_user_id_foreign_key_in_alerts_table.php
+++ b/app-modules/alert/database/migrations/2024_07_17_101206_add_user_id_foreign_key_in_alerts_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('alerts', function (Blueprint $table) {
+            $table->foreignUuid('user_id')->nullable()->references('id')->on('users')->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('alerts', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/app-modules/alert/database/migrations/2024_07_17_101206_add_user_id_foreign_key_in_alerts_table.php
+++ b/app-modules/alert/database/migrations/2024_07_17_101206_add_user_id_foreign_key_in_alerts_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/app-modules/alert/database/migrations/2024_07_22_095019_created_by_feature_flag.php
+++ b/app-modules/alert/database/migrations/2024_07_22_095019_created_by_feature_flag.php
@@ -1,0 +1,17 @@
+<?php
+
+use Laravel\Pennant\Feature;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Feature::activate('alert_created_by');
+    }
+
+    public function down(): void
+    {
+        Feature::deactivate('alert_created_by');
+    }
+};

--- a/app-modules/alert/database/migrations/2024_07_22_095019_created_by_feature_flag.php
+++ b/app-modules/alert/database/migrations/2024_07_22_095019_created_by_feature_flag.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Laravel\Pennant\Feature;
 use Illuminate\Database\Migrations\Migration;
 

--- a/app-modules/alert/database/migrations/2024_07_22_095019_created_by_feature_flag.php
+++ b/app-modules/alert/database/migrations/2024_07_22_095019_created_by_feature_flag.php
@@ -37,8 +37,7 @@
 use Laravel\Pennant\Feature;
 use Illuminate\Database\Migrations\Migration;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Feature::activate('alert_created_by');

--- a/app-modules/alert/src/Models/Alert.php
+++ b/app-modules/alert/src/Models/Alert.php
@@ -80,7 +80,7 @@ class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription, 
         'severity',
         'status',
         'suggested_intervention',
-        'created_by'
+        'created_by',
     ];
 
     protected $casts = [
@@ -146,15 +146,15 @@ class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription, 
         // Do we need to be able to relate campaigns/actions to the RESULT of their actions?
     }
 
+    public function createdBy()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
     protected static function booted(): void
     {
         static::addGlobalScope('licensed', function (Builder $builder) {
             $builder->tap(new LicensedToEducatable('concern'));
         });
-    }
-
-    public function createdBy()
-    {
-        return $this->belongsTo(User::class, 'created_by');
     }
 }

--- a/app-modules/alert/src/Models/Alert.php
+++ b/app-modules/alert/src/Models/Alert.php
@@ -80,7 +80,7 @@ class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription, 
         'severity',
         'status',
         'suggested_intervention',
-        'user_id',
+        'created_by'
     ];
 
     protected $casts = [
@@ -146,15 +146,15 @@ class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription, 
         // Do we need to be able to relate campaigns/actions to the RESULT of their actions?
     }
 
-    public function user()
-    {
-        return $this->belongsTo(User::class);
-    }
-
     protected static function booted(): void
     {
         static::addGlobalScope('licensed', function (Builder $builder) {
             $builder->tap(new LicensedToEducatable('concern'));
         });
+    }
+
+    public function createdBy()
+    {
+        return $this->belongsTo(User::class, 'created_by');
     }
 }

--- a/app-modules/alert/src/Models/Alert.php
+++ b/app-modules/alert/src/Models/Alert.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\Alert\Models;
 
 use Exception;
+use App\Models\User;
 use App\Models\BaseModel;
 use Illuminate\Support\Collection;
 use AdvisingApp\Alert\Enums\AlertStatus;
@@ -59,7 +60,6 @@ use AdvisingApp\StudentDataModel\Models\Scopes\LicensedToEducatable;
 use AdvisingApp\StudentDataModel\Models\Concerns\BelongsToEducatable;
 use AdvisingApp\Campaign\Models\Contracts\ExecutableFromACampaignAction;
 use AdvisingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
-use App\Models\User;
 
 /**
  * @property-read Student|Prospect $concern
@@ -80,7 +80,7 @@ class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription, 
         'severity',
         'status',
         'suggested_intervention',
-        'user_id'
+        'user_id',
     ];
 
     protected $casts = [
@@ -146,15 +146,15 @@ class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription, 
         // Do we need to be able to relate campaigns/actions to the RESULT of their actions?
     }
 
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
     protected static function booted(): void
     {
         static::addGlobalScope('licensed', function (Builder $builder) {
             $builder->tap(new LicensedToEducatable('concern'));
         });
-    }
-
-    public function user()
-    {
-        return $this->belongsTo(User::class);
     }
 }

--- a/app-modules/alert/src/Models/Alert.php
+++ b/app-modules/alert/src/Models/Alert.php
@@ -59,6 +59,7 @@ use AdvisingApp\StudentDataModel\Models\Scopes\LicensedToEducatable;
 use AdvisingApp\StudentDataModel\Models\Concerns\BelongsToEducatable;
 use AdvisingApp\Campaign\Models\Contracts\ExecutableFromACampaignAction;
 use AdvisingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
+use App\Models\User;
 
 /**
  * @property-read Student|Prospect $concern
@@ -79,6 +80,7 @@ class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription, 
         'severity',
         'status',
         'suggested_intervention',
+        'user_id'
     ];
 
     protected $casts = [
@@ -149,5 +151,10 @@ class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription, 
         static::addGlobalScope('licensed', function (Builder $builder) {
             $builder->tap(new LicensedToEducatable('concern'));
         });
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectAlerts.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectAlerts.php
@@ -101,6 +101,8 @@ class ManageProspectAlerts extends ManageRelatedRecords
                 TextEntry::make('severity'),
                 TextEntry::make('suggested_intervention'),
                 TextEntry::make('status'),
+                TextEntry::make('user.name')->label('Created By'),
+                TextEntry::make('created_at')->label('Created Date'),
             ]);
     }
 
@@ -151,7 +153,12 @@ class ManageProspectAlerts extends ManageRelatedRecords
                     ->options(AlertStatus::class),
             ])
             ->headerActions([
-                CreateAction::make(),
+                CreateAction::make()
+                    ->mutateFormDataUsing(function (array $data): array {
+                        $data['user_id'] = auth()->id();
+
+                        return $data;
+                    }),
             ])
             ->actions([
                 ViewAction::make(),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectAlerts.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectAlerts.php
@@ -56,6 +56,7 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Tables\Actions\BulkActionGroup;
 use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Resources\Pages\ManageRelatedRecords;
+use Laravel\Pennant\Feature;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource;
 
 class ManageProspectAlerts extends ManageRelatedRecords
@@ -101,7 +102,7 @@ class ManageProspectAlerts extends ManageRelatedRecords
                 TextEntry::make('severity'),
                 TextEntry::make('suggested_intervention'),
                 TextEntry::make('status'),
-                TextEntry::make('user.name')->label('Created By'),
+                TextEntry::make('createdBy.name')->label('Created By')->default('N/A')->visible(Feature::active('alert_created_by')),
                 TextEntry::make('created_at')->label('Created Date'),
             ]);
     }
@@ -155,7 +156,9 @@ class ManageProspectAlerts extends ManageRelatedRecords
             ->headerActions([
                 CreateAction::make()
                     ->mutateFormDataUsing(function (array $data): array {
-                        $data['user_id'] = auth()->id();
+                        if (Feature::active('alert_created_by')) {
+                            $data['created_by'] = auth()->id();
+                        }
 
                         return $data;
                     }),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectAlerts.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectAlerts.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Prospect\Filament\Resources\ProspectResource\Pages;
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use Laravel\Pennant\Feature;
 use Filament\Infolists\Infolist;
 use Filament\Forms\Components\Select;
 use Illuminate\Support\Facades\Cache;
@@ -56,7 +57,6 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Tables\Actions\BulkActionGroup;
 use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Resources\Pages\ManageRelatedRecords;
-use Laravel\Pennant\Feature;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource;
 
 class ManageProspectAlerts extends ManageRelatedRecords

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentAlerts.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentAlerts.php
@@ -57,6 +57,7 @@ use Filament\Tables\Actions\DeleteBulkAction;
 use AdvisingApp\StudentDataModel\Models\Student;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource;
+use Laravel\Pennant\Feature;
 
 class ManageStudentAlerts extends ManageRelatedRecords
 {
@@ -101,7 +102,7 @@ class ManageStudentAlerts extends ManageRelatedRecords
                 TextEntry::make('severity'),
                 TextEntry::make('suggested_intervention'),
                 TextEntry::make('status'),
-                TextEntry::make('user.name')->label('Created By'),
+                TextEntry::make('createdBy.name')->label('Created By')->default('N/A')->visible(Feature::active('alert_created_by')),
                 TextEntry::make('created_at')->label('Created Date'),
             ]);
     }
@@ -155,8 +156,9 @@ class ManageStudentAlerts extends ManageRelatedRecords
             ->headerActions([
                 CreateAction::make()
                     ->mutateFormDataUsing(function (array $data): array {
-                        $data['user_id'] = auth()->id();
-
+                        if (Feature::active('alert_created_by')) {
+                            $data['created_by'] = auth()->id();
+                        }
                         return $data;
                     }),
             ])

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentAlerts.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentAlerts.php
@@ -101,6 +101,8 @@ class ManageStudentAlerts extends ManageRelatedRecords
                 TextEntry::make('severity'),
                 TextEntry::make('suggested_intervention'),
                 TextEntry::make('status'),
+                TextEntry::make('user.name')->label('Created By'),
+                TextEntry::make('created_at')->label('Created Date'),
             ]);
     }
 
@@ -151,7 +153,12 @@ class ManageStudentAlerts extends ManageRelatedRecords
                     ->options(AlertStatus::class),
             ])
             ->headerActions([
-                CreateAction::make(),
+                CreateAction::make()
+                    ->mutateFormDataUsing(function (array $data): array {
+                        $data['user_id'] = auth()->id();
+
+                        return $data;
+                    }),
             ])
             ->actions([
                 ViewAction::make(),

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentAlerts.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentAlerts.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\Pages;
 
 use Filament\Forms\Form;
 use Filament\Tables\Table;
+use Laravel\Pennant\Feature;
 use Filament\Infolists\Infolist;
 use Filament\Forms\Components\Select;
 use Illuminate\Support\Facades\Cache;
@@ -57,7 +58,6 @@ use Filament\Tables\Actions\DeleteBulkAction;
 use AdvisingApp\StudentDataModel\Models\Student;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource;
-use Laravel\Pennant\Feature;
 
 class ManageStudentAlerts extends ManageRelatedRecords
 {
@@ -159,6 +159,7 @@ class ManageStudentAlerts extends ManageRelatedRecords
                         if (Feature::active('alert_created_by')) {
                             $data['created_by'] = auth()->id();
                         }
+
                         return $data;
                     }),
             ])


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-727

### Technical Description

> Add user_id for alerts, which saves the user_id who created the alert. And the name of the user can be seen in view modal of alert for both prospect and students.

### Any deployment steps required?

> No.

### Are any Feature Flags Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
