### PR TITLE
[ADVAPP-747] Enhance the prompt insertion experience for the Prompt Library feature so that users can filter prompts by their team.

### DIFF
--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManagePromptLibrary.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManagePromptLibrary.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Ai\Filament\Pages\Assistant\Concerns;
 
+use App\Models\User;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
 use Filament\Actions\Action;
@@ -113,13 +114,15 @@ trait CanManagePromptLibrary
                                     fn (Builder $query) => $query->whereBelongsTo(auth()->user()),
                                 )
                                 ->when(
-                                    $get('myTeamPrompts') && auth()->user()->has('teams'),
+                                    $get('myTeamPrompts'),
                                     function (Builder $query) {
-                                        $teamUsers = auth()->user()?->teams()?->first()?->users;
+                                        /** @var User $user */
+                                        $user = auth()->user();
+                                        $teamUsers = $user?->teams->first()?->users;
 
                                         if ($teamUsers) {
-                                            $query->whereHas('user', function ($q) use ($teamUsers) {
-                                                return $q->whereIn('id', $teamUsers->pluck('id'));
+                                            $query->whereHas('user', function (Builder $query) use ($teamUsers) {
+                                                return $query->whereIn('id', $teamUsers->pluck('id'));
                                             });
                                         }
                                     },


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-747

### Technical Description

> Added a new "My team's prompts only" in prompt library in Personal assistant upon click it will show the same team member prompt as well in list.

### Any deployment steps required?

> No

### Are any Feature Flags Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
