### PR TITLE
[ADVAPP-756]: Enhance validation on the file type for Custom Assistant to svg, png, gif, jpg, for the avatar feature.

### DIFF
--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -66,7 +66,12 @@ class AiAssistantForm
                     ->collection('avatar')
                     ->visibility('private')
                     ->avatar()
-                    ->columnSpanFull(),
+                    ->columnSpanFull()
+                    ->acceptedFileTypes([
+                        'image/png',
+                        'image/jpeg',
+                        'image/gif',
+                    ]),
                 TextInput::make('name')
                     ->required()
                     ->string()
@@ -87,22 +92,22 @@ class AiAssistantForm
                         fn (Get $get): array => filled(AiApplication::parse($get('application')))
                             ? collect(AiApplication::parse($get('application'))
                                 ->getModels())
-                                ->mapWithKeys(fn (AiModel $model): array => [$model->value => $model->getLabel()])
-                                ->all()
+                            ->mapWithKeys(fn (AiModel $model): array => [$model->value => $model->getLabel()])
+                            ->all()
                             : []
                     )
                     ->searchable()
                     ->required()
                     ->rules(
                         fn (Get $get): array => filled(AiApplication::parse($get('application')))
-                        ? [
-                            Rule::enum(AiModel::class)
-                                ->only(
-                                    AiApplication::parse($get('application'))
-                                        ->getModels()
-                                ),
-                        ]
-                        : []
+                            ? [
+                                Rule::enum(AiModel::class)
+                                    ->only(
+                                        AiApplication::parse($get('application'))
+                                            ->getModels()
+                                    ),
+                            ]
+                            : []
                     )
                     ->visible(fn (Get $get): bool => filled($get('application'))),
                 Textarea::make('description')
@@ -142,7 +147,7 @@ class AiAssistantForm
                             return true;
                         }
 
-                        return ! AiModel::parse($model)->supportsAssistantFileUploads();
+                        return !AiModel::parse($model)->supportsAssistantFileUploads();
                     })
                     ->schema([
                         Repeater::make('files')
@@ -179,7 +184,7 @@ class AiAssistantForm
                                 $files = $get('files');
                                 $firstFile = reset($files);
 
-                                if (! $firstFile || blank($firstFile['name'])) {
+                                if (!$firstFile || blank($firstFile['name'])) {
                                     return 'full';
                                 }
 

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -92,8 +92,8 @@ class AiAssistantForm
                         fn (Get $get): array => filled(AiApplication::parse($get('application')))
                             ? collect(AiApplication::parse($get('application'))
                                 ->getModels())
-                            ->mapWithKeys(fn (AiModel $model): array => [$model->value => $model->getLabel()])
-                            ->all()
+                                ->mapWithKeys(fn (AiModel $model): array => [$model->value => $model->getLabel()])
+                                ->all()
                             : []
                     )
                     ->searchable()
@@ -147,7 +147,7 @@ class AiAssistantForm
                             return true;
                         }
 
-                        return !AiModel::parse($model)->supportsAssistantFileUploads();
+                        return ! AiModel::parse($model)->supportsAssistantFileUploads();
                     })
                     ->schema([
                         Repeater::make('files')
@@ -184,7 +184,7 @@ class AiAssistantForm
                                 $files = $get('files');
                                 $firstFile = reset($files);
 
-                                if (!$firstFile || blank($firstFile['name'])) {
+                                if (! $firstFile || blank($firstFile['name'])) {
                                     return 'full';
                                 }
 

--- a/app-modules/ai/src/Models/AiAssistant.php
+++ b/app-modules/ai/src/Models/AiAssistant.php
@@ -46,6 +46,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use AdvisingApp\Ai\Models\Concerns\CanAddAssistantLicenseGlobalScope;
 use AdvisingApp\Ai\Exceptions\DefaultAssistantLockedPropertyException;
+use Spatie\MediaLibrary\MediaCollections\File;
 
 /**
  * @mixin IdeHelperAiAssistant
@@ -80,12 +81,16 @@ class AiAssistant extends BaseModel implements HasMedia
     public function registerMediaCollections(): void
     {
         $this->addMediaCollection('avatar')
-            ->acceptsFile(function () {
+            ->acceptsFile(function (File $file) {
                 if ($this->application === AiApplication::PersonalAssistant && $this->is_default) {
                     throw new DefaultAssistantLockedPropertyException('avatar');
                 }
 
-                return true;
+                return in_array($file->mimeType, [
+                    'image/png',
+                    'image/jpeg',
+                    'image/gif',
+                ]);
             });
     }
 

--- a/app-modules/ai/src/Models/AiAssistant.php
+++ b/app-modules/ai/src/Models/AiAssistant.php
@@ -42,11 +42,11 @@ use Spatie\MediaLibrary\HasMedia;
 use AdvisingApp\Ai\Enums\AiApplication;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\MediaLibrary\MediaCollections\File;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use AdvisingApp\Ai\Models\Concerns\CanAddAssistantLicenseGlobalScope;
 use AdvisingApp\Ai\Exceptions\DefaultAssistantLockedPropertyException;
-use Spatie\MediaLibrary\MediaCollections\File;
 
 /**
  * @mixin IdeHelperAiAssistant


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-756

### Technical Description

> Add validations in custom assistant avatar to only allow png, jpeg and gif files.

### Any deployment steps required?

> No.

### Are any Feature Flags Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
