### PR TITLE
[ADVAPP-751]: Enhance the user experience for usage auditing by administrators

### DIFF
--- a/app-modules/ai/src/Filament/Resources/LegacyAiMessageLogResource.php
+++ b/app-modules/ai/src/Filament/Resources/LegacyAiMessageLogResource.php
@@ -59,13 +59,15 @@ class LegacyAiMessageLogResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-chat-bubble-left-ellipsis';
 
-    protected static ?string $navigationLabel = 'Personal Assistant';
+    protected static ?string $navigationLabel = 'Assistant Utilization';
 
     protected static ?int $navigationSort = 30;
 
     protected static ?string $modelLabel = 'message log';
 
     protected static ?string $cluster = UsageAuditing::class;
+
+    protected static ?string $slug = 'assistant-utilization';
 
     public static function infolist(Infolist $infolist): Infolist
     {
@@ -112,7 +114,8 @@ class LegacyAiMessageLogResource extends Resource
                 BulkActionGroup::make([
                     DeleteBulkAction::make(),
                     ExportBulkAction::make()
-                        ->exporter(LegacyAiMessageExporter::class),
+                        ->exporter(LegacyAiMessageExporter::class)
+                        ->label('Export Records'),
                 ]),
             ])
             ->defaultSort('sent_at', 'desc');

--- a/app-modules/ai/src/Filament/Resources/LegacyAiMessageLogResource/Pages/ManageLegacyAiMessageLogs.php
+++ b/app-modules/ai/src/Filament/Resources/LegacyAiMessageLogResource/Pages/ManageLegacyAiMessageLogs.php
@@ -45,13 +45,14 @@ class ManageLegacyAiMessageLogs extends ManageRecords
 {
     protected static string $resource = LegacyAiMessageLogResource::class;
 
-    protected static ?string $title = 'Personal Assistant';
+    protected static ?string $title = 'Assistant Utilization';
 
     protected function getHeaderActions(): array
     {
         return [
             Actions\ExportAction::make()
-                ->exporter(LegacyAiMessageExporter::class),
+                ->exporter(LegacyAiMessageExporter::class)
+                ->label('Export Records'),
         ];
     }
 }

--- a/app-modules/audit/config/audit.php
+++ b/app-modules/audit/config/audit.php
@@ -35,6 +35,7 @@
 */
 
 use AdvisingApp\Audit\Models\Audit;
+use App\AuditResolvers\ChangeAgentNameResolver;
 
 return [
     'enabled' => env('AUDITING_ENABLED', true),
@@ -81,6 +82,7 @@ return [
         'ip_address' => OwenIt\Auditing\Resolvers\IpAddressResolver::class,
         'user_agent' => OwenIt\Auditing\Resolvers\UserAgentResolver::class,
         'url' => OwenIt\Auditing\Resolvers\UrlResolver::class,
+        'change_agent_name' => ChangeAgentNameResolver::class,
     ],
 
     /*

--- a/app-modules/audit/database/migrations/2024_07_22_090701_add_change_agent_name_column_to_audits_table.php
+++ b/app-modules/audit/database/migrations/2024_07_22_090701_add_change_agent_name_column_to_audits_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('audits', function (Blueprint $table) {
+            $table->string('change_agent_name')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('audits', function (Blueprint $table) {
+            $table->dropColumn('change_agent_name');
+        });
+    }
+};

--- a/app-modules/audit/database/migrations/2024_07_22_090701_add_change_agent_name_column_to_audits_table.php
+++ b/app-modules/audit/database/migrations/2024_07_22_090701_add_change_agent_name_column_to_audits_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;

--- a/app-modules/audit/database/migrations/2024_07_22_091520_data_activate_change_agent_name.php
+++ b/app-modules/audit/database/migrations/2024_07_22_091520_data_activate_change_agent_name.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Laravel\Pennant\Feature;
 use Illuminate\Database\Migrations\Migration;
 

--- a/app-modules/audit/database/migrations/2024_07_22_091520_data_activate_change_agent_name.php
+++ b/app-modules/audit/database/migrations/2024_07_22_091520_data_activate_change_agent_name.php
@@ -1,0 +1,16 @@
+<?php
+
+use Laravel\Pennant\Feature;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Feature::activate('change-agent-name');
+    }
+
+    public function down(): void
+    {
+        Feature::deactivate('change-agent-name');
+    }
+};

--- a/app-modules/audit/database/migrations/2024_07_22_092622_data_migration_agent_name.php
+++ b/app-modules/audit/database/migrations/2024_07_22_092622_data_migration_agent_name.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Migrations\Migration;

--- a/app-modules/audit/database/migrations/2024_07_22_092622_data_migration_agent_name.php
+++ b/app-modules/audit/database/migrations/2024_07_22_092622_data_migration_agent_name.php
@@ -1,0 +1,45 @@
+<?php
+
+use Laravel\Pennant\Feature;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        if (Feature::active('change-agent-name')) {
+            try {
+                DB::beginTransaction();
+
+                $audits = DB::table('audits')
+                    ->join('users', 'audits.change_agent_id', '=', 'users.id')
+                    ->select('audits.id', 'users.name')
+                    ->get();
+
+                foreach ($audits as $audit) {
+                    DB::table('audits')
+                        ->where('id', $audit->id)
+                        ->update(['change_agent_name' => $audit->name]);
+                }
+
+                DB::commit();
+            } catch (Exception $e) {
+                DB::rollBack();
+
+                throw new Exception($e);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        if (Feature::active('change-agent-name')) {
+            try {
+                DB::table('audits')
+                    ->update(['change_agent_name' => null]);
+            } catch (Exception $e) {
+                throw new Exception($e);
+            }
+        }
+    }
+};

--- a/app-modules/audit/database/migrations/2024_07_22_092622_data_migration_agent_name.php
+++ b/app-modules/audit/database/migrations/2024_07_22_092622_data_migration_agent_name.php
@@ -65,11 +65,7 @@ return new class () extends Migration {
 
     public function down(): void
     {
-        try {
-            DB::table('audits')
-                ->update(['change_agent_name' => null]);
-        } catch (Exception $error) {
-            throw $error;
-        }
+        DB::table('audits')
+            ->update(['change_agent_name' => null]);
     }
 };

--- a/app-modules/audit/src/Filament/Exports/AuditExporter.php
+++ b/app-modules/audit/src/Filament/Exports/AuditExporter.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Audit\Filament\Exports;
 
+use Laravel\Pennant\Feature;
 use AdvisingApp\Audit\Models\Audit;
 use Filament\Actions\Exports\Exporter;
 use Filament\Actions\Exports\ExportColumn;
@@ -60,6 +61,17 @@ class AuditExporter extends Exporter
             ExportColumn::make('url'),
             ExportColumn::make('ip_address')
                 ->label('IP address'),
+            ExportColumn::make('change_agent_id')
+                ->label('Change Agent ID'),
+            ExportColumn::make('change_agent_name')
+                ->label('Change Agent Name')
+                ->state(function ($record) {
+                    if (Feature::active('change-agent-name')) {
+                        return $record->change_agent_name ?? 'System';
+                    }
+
+                    return $record->user->name ?? 'System';
+                }),
             ExportColumn::make('user_agent'),
             ExportColumn::make('tags'),
             ExportColumn::make('created_at'),

--- a/app-modules/audit/src/Filament/Exports/AuditExporter.php
+++ b/app-modules/audit/src/Filament/Exports/AuditExporter.php
@@ -64,15 +64,13 @@ class AuditExporter extends Exporter
             ExportColumn::make('change_agent_id')
                 ->label('Change Agent ID')
                 ->default('N/A'),
-            ExportColumn::make('change_agent_name')
-                ->label('Change Agent Name')
-                ->state(function ($record) {
-                    if (Feature::active('change-agent-name')) {
+            ...(Feature::active('change-agent-name') ? [
+                ExportColumn::make('change_agent_name')
+                    ->label('Change Agent Name')
+                    ->state(function ($record) {
                         return $record->change_agent_name ?? 'System';
-                    }
-
-                    return $record->user->name ?? 'System';
-                }),
+                    }),
+            ] : []),
             ExportColumn::make('user_agent'),
             ExportColumn::make('tags'),
             ExportColumn::make('created_at'),

--- a/app-modules/audit/src/Filament/Exports/AuditExporter.php
+++ b/app-modules/audit/src/Filament/Exports/AuditExporter.php
@@ -62,7 +62,8 @@ class AuditExporter extends Exporter
             ExportColumn::make('ip_address')
                 ->label('IP address'),
             ExportColumn::make('change_agent_id')
-                ->label('Change Agent ID'),
+                ->label('Change Agent ID')
+                ->default('N/A'),
             ExportColumn::make('change_agent_name')
                 ->label('Change Agent Name')
                 ->state(function ($record) {

--- a/app-modules/audit/src/Filament/Resources/AuditResource.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource.php
@@ -46,13 +46,17 @@ class AuditResource extends Resource
 {
     protected static ?string $model = Audit::class;
 
-    protected static ?string $navigationLabel = 'Other Records';
+    protected static ?string $navigationLabel = 'System Administration';
 
     protected static ?string $navigationIcon = 'heroicon-o-shield-check';
 
     protected static ?int $navigationSort = 40;
 
     protected static ?string $cluster = UsageAuditing::class;
+
+    protected static ?string $breadcrumb = 'System Administration';
+
+    protected static ?string $slug = 'system-administration';
 
     public static function getPages(): array
     {

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
@@ -38,7 +38,10 @@ namespace AdvisingApp\Audit\Filament\Resources\AuditResource\Pages;
 
 use App\Models\User;
 use Filament\Tables\Table;
+use Laravel\Pennant\Feature;
 use Filament\Actions\ExportAction;
+use Filament\Tables\Filters\Filter;
+use Filament\Forms\Components\Checkbox;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use App\Filament\Tables\Columns\IdColumn;
@@ -55,6 +58,8 @@ class ListAudits extends ListRecords
 {
     protected static string $resource = AuditResource::class;
 
+    protected static ?string $title = 'System Administration';
+
     public function table(Table $table): Table
     {
         return $table
@@ -63,14 +68,30 @@ class ListAudits extends ListRecords
                 TextColumn::make('auditable_type')
                     ->label('Auditable')
                     ->sortable(),
-                TextColumn::make('user.name')
+                TextColumn::make('change_agent_name')
                     ->label('Change Agent (User)')
-                    ->sortable(),
+                    ->sortable()
+                    ->default('System')
+                    ->visible(Feature::active('change-agent-name')),
                 TextColumn::make('event')
                     ->label('Event')
                     ->sortable(),
             ])
             ->filters([
+                Filter::make('exclude_system_user')
+                    ->label('Exclude System User')
+                    ->query(function (Builder $query, array $data): Builder {
+                        if (isset($data['isActive']) && $data['isActive']) {
+                            $query->whereHas('user');
+                        }
+
+                        return $query;
+                    })
+                    ->form([
+                        Checkbox::make('isActive')
+                            ->label('Exclude System User')
+                            ->default(true),
+                    ]),
                 SelectFilter::make('change_agent_user')
                     ->label('Change Agent (User)')
                     ->options(fn (): array => User::query()->pluck('name', 'id')->all())
@@ -87,7 +108,8 @@ class ListAudits extends ListRecords
             ->bulkActions([
                 BulkActionGroup::make([
                     ExportBulkAction::make()
-                        ->exporter(AuditExporter::class),
+                        ->exporter(AuditExporter::class)
+                        ->label('Export Records'),
                 ]),
             ]);
     }
@@ -96,7 +118,8 @@ class ListAudits extends ListRecords
     {
         return [
             ExportAction::make()
-                ->exporter(AuditExporter::class),
+                ->exporter(AuditExporter::class)
+                ->label('Export Records'),
         ];
     }
 }

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
@@ -68,6 +68,10 @@ class ListAudits extends ListRecords
                 TextColumn::make('auditable_type')
                     ->label('Auditable')
                     ->sortable(),
+                TextColumn::make('user.name')
+                    ->label('Change Agent (User)')
+                    ->sortable()
+                    ->visible(! Feature::active('change-agent-name')),
                 TextColumn::make('change_agent_name')
                     ->label('Change Agent (User)')
                     ->sortable()
@@ -80,13 +84,9 @@ class ListAudits extends ListRecords
             ->filters([
                 Filter::make('exclude_system_user')
                     ->label('Exclude System User')
-                    ->query(function (Builder $query, array $data): Builder {
-                        if (isset($data['isActive']) && $data['isActive']) {
-                            $query->whereHas('user');
-                        }
-
-                        return $query;
-                    })
+                    ->query(
+                        fn (Builder $query, array $data): Builder => $query->when($data['isActive'], fn (Builder $query) => $query->whereHas('user'))
+                    )
                     ->form([
                         Checkbox::make('isActive')
                             ->label('Exclude System User')

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Audit\Filament\Resources\AuditResource\Pages;
 
+use Laravel\Pennant\Feature;
 use Filament\Infolists\Infolist;
 use AdvisingApp\Audit\Models\Audit;
 use Filament\Resources\Pages\ViewRecord;
@@ -47,6 +48,8 @@ class ViewAudit extends ViewRecord
 {
     protected static string $resource = AuditResource::class;
 
+    protected static ?string $title = 'View System Administration';
+
     public function infolist(Infolist $infolist): Infolist
     {
         return $infolist
@@ -55,9 +58,10 @@ class ViewAudit extends ViewRecord
                     ->schema([
                         TextEntry::make('auditable_type')
                             ->label('Auditable'),
-                        TextEntry::make('user.name')
+                        TextEntry::make('change_agent_name')
                             ->label('Change Agent (User)')
-                            ->placeholder('N/A'),
+                            ->placeholder('System')
+                            ->visible(Feature::active('change-agent-name')),
                         TextEntry::make('event')
                             ->label('Event'),
                         TextEntry::make('url')

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
@@ -58,6 +58,10 @@ class ViewAudit extends ViewRecord
                     ->schema([
                         TextEntry::make('auditable_type')
                             ->label('Auditable'),
+                        TextEntry::make('user.name')
+                            ->label('Change Agent (User)')
+                            ->placeholder('N/A')
+                            ->visible(! Feature::active('change-agent-name')),
                         TextEntry::make('change_agent_name')
                             ->label('Change Agent (User)')
                             ->placeholder('System')

--- a/app/AuditResolvers/ChangeAgentNameResolver.php
+++ b/app/AuditResolvers/ChangeAgentNameResolver.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\AuditResolvers;
 
 use OwenIt\Auditing\Contracts\Resolver;

--- a/app/AuditResolvers/ChangeAgentNameResolver.php
+++ b/app/AuditResolvers/ChangeAgentNameResolver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\AuditResolvers;
+
+use OwenIt\Auditing\Contracts\Resolver;
+use OwenIt\Auditing\Contracts\Auditable;
+
+class ChangeAgentNameResolver implements Resolver
+{
+    public static function resolve(Auditable $auditable)
+    {
+        return $auditable->preloadedResolverData['change_agent_name'] ?? call_user_func([config('audit.user.resolver'), 'resolve'])?->name;
+    }
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-751

### Technical Description

> Change the label for audit categories from "Personal Assistant" to "Assistant Utilization" and from "Other Records" to "System Administration."
> In the View System Administration section, set "System" in the Change Agent (User) field if it is empty.
> Two new columns, Change Agent (User) and Change Agent (ID), have been added for file exports in System Administration.
> A filter to exclude system users has been added.
> The export button label has been updated from "Export audits" to "Export Records" and from "Export legacy AI message logs" to "Export Records."

### Any deployment steps required?

> We developed a custom resolver called ChangeAgentNameResolver. Therefore, it may be necessary to restart the queue on the server using the command: php artisan queue:restart.

### Are any Feature Flags Added?

> Yes. The name of the newly added Feature Flag is "change-agent-name".

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
