### PR TITLE
[ADVAPP-603]: Unable to receive engagement updates on delivered emails as expected

### DIFF
--- a/app-modules/integration-aws-ses-event-handling/routes/landlord.php
+++ b/app-modules/integration-aws-ses-event-handling/routes/landlord.php
@@ -39,11 +39,21 @@ use AdvisingApp\Webhook\Http\Middleware\HandleAwsSnsRequest;
 use AdvisingApp\Webhook\Http\Middleware\VerifyAwsSnsRequest;
 use AdvisingApp\IntegrationAwsSesEventHandling\Http\Controllers\AwsSesInboundWebhookController;
 
-Route::post('/inbound/webhook/awsses', AwsSesInboundWebhookController::class)
-    ->middleware(
-        [
-            VerifyAwsSnsRequest::class,
-            HandleAwsSnsRequest::class,
-        ]
+Route::prefix('landlord/api')
+    ->as('landlord.api.')
+    ->domain(
+        (string) str(config('app.landlord_url'))
+            ->after('http://')
+            ->after('https://')
+            ->rtrim('/'),
     )
-    ->name('inbound.webhook.awsses');
+    ->group(function () {
+        Route::post('/inbound/webhook/awsses', AwsSesInboundWebhookController::class)
+            ->middleware(
+                [
+                    VerifyAwsSnsRequest::class,
+                    HandleAwsSnsRequest::class,
+                ]
+            )
+            ->name('inbound.webhook.awsses');
+    });

--- a/app-modules/integration-aws-ses-event-handling/src/Http/Controllers/AwsSesInboundWebhookController.php
+++ b/app-modules/integration-aws-ses-event-handling/src/Http/Controllers/AwsSesInboundWebhookController.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\IntegrationAwsSesEventHandling\Http\Controllers;
 
 use Exception;
+use App\Models\Tenant;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use AdvisingApp\IntegrationAwsSesEventHandling\Events\SesOpenEvent;
@@ -57,21 +58,26 @@ class AwsSesInboundWebhookController extends Controller
     {
         $data = SesEventData::fromRequest($request);
 
-        // We are currently not handling the "Click", "Complaint", "Open", "Send", or "Subscription" event types
-        // Since we are only looking to identify whether or not email delivery was successful/failed
-        match ($data->eventType) {
-            'Bounce' => SesBounceEvent::dispatch($data),
-            'Click' => SesClickEvent::dispatch($data),
-            'Complaint' => SesComplaintEvent::dispatch($data),
-            'Delivery' => SesDeliveryEvent::dispatch($data),
-            'DeliveryDelay' => SesDeliveryDelayEvent::dispatch($data),
-            'Open' => SesOpenEvent::dispatch($data),
-            'Reject' => SesRejectEvent::dispatch($data),
-            'RenderingFailure' => SesRenderingFailureEvent::dispatch($data),
-            'Send' => SesSendEvent::dispatch($data),
-            'Subscription' => SesSubscriptionEvent::dispatch($data),
-            default => throw new Exception('Unknown AWS SES event type'),
-        };
+        /** @var Tenant $tenant */
+        $tenant = Tenant::query()->findOrFail(data_get($data->mail->tags, 'tenant_id'))->first();
+
+        $tenant->execute(function () use ($data) {
+            // We are currently not handling the "Click", "Complaint", "Open", "Send", or "Subscription" event types
+            // Since we are only looking to identify whether or not email delivery was successful/failed
+            match ($data->eventType) {
+                'Bounce' => SesBounceEvent::dispatch($data),
+                'Click' => SesClickEvent::dispatch($data),
+                'Complaint' => SesComplaintEvent::dispatch($data),
+                'Delivery' => SesDeliveryEvent::dispatch($data),
+                'DeliveryDelay' => SesDeliveryDelayEvent::dispatch($data),
+                'Open' => SesOpenEvent::dispatch($data),
+                'Reject' => SesRejectEvent::dispatch($data),
+                'RenderingFailure' => SesRenderingFailureEvent::dispatch($data),
+                'Send' => SesSendEvent::dispatch($data),
+                'Subscription' => SesSubscriptionEvent::dispatch($data),
+                default => throw new Exception('Unknown AWS SES event type'),
+            };
+        });
 
         return response(status: 200);
     }

--- a/app-modules/integration-aws-ses-event-handling/tests/Feature/Http/AwsSesInboundWebhookControllerTest.php
+++ b/app-modules/integration-aws-ses-event-handling/tests/Feature/Http/AwsSesInboundWebhookControllerTest.php
@@ -34,6 +34,7 @@
 </COPYRIGHT>
 */
 
+use App\Models\Tenant;
 use Illuminate\Support\Facades\Event;
 
 use function Pest\Laravel\withHeaders;
@@ -61,7 +62,11 @@ beforeEach(function () {
 it('handles a bounce event', function () {
     $snsData = loadFixtureFromModule('integration-aws-ses-event-handling', 'sns-notification');
 
-    $snsData['Message'] = json_encode(loadFixtureFromModule('integration-aws-ses-event-handling', 'Bounce'));
+    $tenant = Tenant::current();
+
+    $messageContent = loadFixtureFromModule('integration-aws-ses-event-handling', 'Bounce');
+    data_set($messageContent, 'mail.tags.tenant_id.0', $tenant->getKey());
+    $snsData['Message'] = json_encode($messageContent);
 
     $response = withHeaders(
         [
@@ -88,7 +93,11 @@ it('handles a bounce event', function () {
 it('handles a complaint event', function () {
     $snsData = loadFixtureFromModule('integration-aws-ses-event-handling', 'sns-notification');
 
-    $snsData['Message'] = json_encode(loadFixtureFromModule('integration-aws-ses-event-handling', 'Complaint'));
+    $tenant = Tenant::current();
+
+    $messageContent = loadFixtureFromModule('integration-aws-ses-event-handling', 'Complaint');
+    data_set($messageContent, 'mail.tags.tenant_id.0', $tenant->getKey());
+    $snsData['Message'] = json_encode($messageContent);
 
     $response = withHeaders(
         [
@@ -115,7 +124,11 @@ it('handles a complaint event', function () {
 it('handles a delivery event', function () {
     $snsData = loadFixtureFromModule('integration-aws-ses-event-handling', 'sns-notification');
 
-    $snsData['Message'] = json_encode(loadFixtureFromModule('integration-aws-ses-event-handling', 'Delivery'));
+    $tenant = Tenant::current();
+
+    $messageContent = loadFixtureFromModule('integration-aws-ses-event-handling', 'Delivery');
+    data_set($messageContent, 'mail.tags.tenant_id.0', $tenant->getKey());
+    $snsData['Message'] = json_encode($messageContent);
 
     $response = withHeaders(
         [
@@ -142,7 +155,11 @@ it('handles a delivery event', function () {
 it('handles a send event', function () {
     $snsData = loadFixtureFromModule('integration-aws-ses-event-handling', 'sns-notification');
 
-    $snsData['Message'] = json_encode(loadFixtureFromModule('integration-aws-ses-event-handling', 'Send'));
+    $tenant = Tenant::current();
+
+    $messageContent = loadFixtureFromModule('integration-aws-ses-event-handling', 'Send');
+    data_set($messageContent, 'mail.tags.tenant_id.0', $tenant->getKey());
+    $snsData['Message'] = json_encode($messageContent);
 
     $response = withHeaders(
         [
@@ -169,7 +186,11 @@ it('handles a send event', function () {
 it('handles a reject event', function () {
     $snsData = loadFixtureFromModule('integration-aws-ses-event-handling', 'sns-notification');
 
-    $snsData['Message'] = json_encode(loadFixtureFromModule('integration-aws-ses-event-handling', 'Reject'));
+    $tenant = Tenant::current();
+
+    $messageContent = loadFixtureFromModule('integration-aws-ses-event-handling', 'Reject');
+    data_set($messageContent, 'mail.tags.tenant_id.0', $tenant->getKey());
+    $snsData['Message'] = json_encode($messageContent);
 
     $response = withHeaders(
         [
@@ -196,7 +217,11 @@ it('handles a reject event', function () {
 it('handles a open event', function () {
     $snsData = loadFixtureFromModule('integration-aws-ses-event-handling', 'sns-notification');
 
-    $snsData['Message'] = json_encode(loadFixtureFromModule('integration-aws-ses-event-handling', 'Open'));
+    $tenant = Tenant::current();
+
+    $messageContent = loadFixtureFromModule('integration-aws-ses-event-handling', 'Open');
+    data_set($messageContent, 'mail.tags.tenant_id.0', $tenant->getKey());
+    $snsData['Message'] = json_encode($messageContent);
 
     $response = withHeaders(
         [
@@ -223,7 +248,11 @@ it('handles a open event', function () {
 it('handles a click event', function () {
     $snsData = loadFixtureFromModule('integration-aws-ses-event-handling', 'sns-notification');
 
-    $snsData['Message'] = json_encode(loadFixtureFromModule('integration-aws-ses-event-handling', 'Click'));
+    $tenant = Tenant::current();
+
+    $messageContent = loadFixtureFromModule('integration-aws-ses-event-handling', 'Click');
+    data_set($messageContent, 'mail.tags.tenant_id.0', $tenant->getKey());
+    $snsData['Message'] = json_encode($messageContent);
 
     $response = withHeaders(
         [
@@ -250,7 +279,11 @@ it('handles a click event', function () {
 it('handles a renderingFailure event', function () {
     $snsData = loadFixtureFromModule('integration-aws-ses-event-handling', 'sns-notification');
 
-    $snsData['Message'] = json_encode(loadFixtureFromModule('integration-aws-ses-event-handling', 'RenderingFailure'));
+    $tenant = Tenant::current();
+
+    $messageContent = loadFixtureFromModule('integration-aws-ses-event-handling', 'RenderingFailure');
+    data_set($messageContent, 'mail.tags.tenant_id.0', $tenant->getKey());
+    $snsData['Message'] = json_encode($messageContent);
 
     $response = withHeaders(
         [
@@ -277,7 +310,11 @@ it('handles a renderingFailure event', function () {
 it('handles a DeliveryDelay event', function () {
     $snsData = loadFixtureFromModule('integration-aws-ses-event-handling', 'sns-notification');
 
-    $snsData['Message'] = json_encode(loadFixtureFromModule('integration-aws-ses-event-handling', 'DeliveryDelay'));
+    $tenant = Tenant::current();
+
+    $messageContent = loadFixtureFromModule('integration-aws-ses-event-handling', 'DeliveryDelay');
+    data_set($messageContent, 'mail.tags.tenant_id.0', $tenant->getKey());
+    $snsData['Message'] = json_encode($messageContent);
 
     $response = withHeaders(
         [
@@ -304,7 +341,11 @@ it('handles a DeliveryDelay event', function () {
 it('handles a Subscription event', function () {
     $snsData = loadFixtureFromModule('integration-aws-ses-event-handling', 'sns-notification');
 
-    $snsData['Message'] = json_encode(loadFixtureFromModule('integration-aws-ses-event-handling', 'Subscription'));
+    $tenant = Tenant::current();
+
+    $messageContent = loadFixtureFromModule('integration-aws-ses-event-handling', 'Subscription');
+    data_set($messageContent, 'mail.tags.tenant_id.0', $tenant->getKey());
+    $snsData['Message'] = json_encode($messageContent);
 
     $response = withHeaders(
         [

--- a/app-modules/integration-aws-ses-event-handling/tests/Feature/Http/AwsSesInboundWebhookControllerTest.php
+++ b/app-modules/integration-aws-ses-event-handling/tests/Feature/Http/AwsSesInboundWebhookControllerTest.php
@@ -76,7 +76,7 @@ it('handles a bounce event', function () {
             'User-Agent' => 'Amazon Simple Notification Service Agent',
         ]
     )->postJson(
-        route('inbound.webhook.awsses'),
+        route('landlord.api.inbound.webhook.awsses'),
         $snsData,
     );
 
@@ -103,7 +103,7 @@ it('handles a complaint event', function () {
             'User-Agent' => 'Amazon Simple Notification Service Agent',
         ]
     )->postJson(
-        route('inbound.webhook.awsses'),
+        route('landlord.api.inbound.webhook.awsses'),
         $snsData,
     );
 
@@ -130,7 +130,7 @@ it('handles a delivery event', function () {
             'User-Agent' => 'Amazon Simple Notification Service Agent',
         ]
     )->postJson(
-        route('inbound.webhook.awsses'),
+        route('landlord.api.inbound.webhook.awsses'),
         $snsData,
     );
 
@@ -157,7 +157,7 @@ it('handles a send event', function () {
             'User-Agent' => 'Amazon Simple Notification Service Agent',
         ]
     )->postJson(
-        route('inbound.webhook.awsses'),
+        route('landlord.api.inbound.webhook.awsses'),
         $snsData,
     );
 
@@ -184,7 +184,7 @@ it('handles a reject event', function () {
             'User-Agent' => 'Amazon Simple Notification Service Agent',
         ]
     )->postJson(
-        route('inbound.webhook.awsses'),
+        route('landlord.api.inbound.webhook.awsses'),
         $snsData,
     );
 
@@ -211,7 +211,7 @@ it('handles a open event', function () {
             'User-Agent' => 'Amazon Simple Notification Service Agent',
         ]
     )->postJson(
-        route('inbound.webhook.awsses'),
+        route('landlord.api.inbound.webhook.awsses'),
         $snsData,
     );
 
@@ -238,7 +238,7 @@ it('handles a click event', function () {
             'User-Agent' => 'Amazon Simple Notification Service Agent',
         ]
     )->postJson(
-        route('inbound.webhook.awsses'),
+        route('landlord.api.inbound.webhook.awsses'),
         $snsData,
     );
 
@@ -265,7 +265,7 @@ it('handles a renderingFailure event', function () {
             'User-Agent' => 'Amazon Simple Notification Service Agent',
         ]
     )->postJson(
-        route('inbound.webhook.awsses'),
+        route('landlord.api.inbound.webhook.awsses'),
         $snsData,
     );
 
@@ -292,7 +292,7 @@ it('handles a DeliveryDelay event', function () {
             'User-Agent' => 'Amazon Simple Notification Service Agent',
         ]
     )->postJson(
-        route('inbound.webhook.awsses'),
+        route('landlord.api.inbound.webhook.awsses'),
         $snsData,
     );
 
@@ -319,7 +319,7 @@ it('handles a Subscription event', function () {
             'User-Agent' => 'Amazon Simple Notification Service Agent',
         ]
     )->postJson(
-        route('inbound.webhook.awsses'),
+        route('landlord.api.inbound.webhook.awsses'),
         $snsData,
     );
 

--- a/app-modules/integration-aws-ses-event-handling/tests/Feature/Listeners/HandleSesEventTest.php
+++ b/app-modules/integration-aws-ses-event-handling/tests/Feature/Listeners/HandleSesEventTest.php
@@ -49,6 +49,8 @@ beforeEach(function () {
 });
 
 it('correctly handles the incoming SES event', function (string $event, NotificationDeliveryStatus $status, ?string $deliveryResponse) {
+    // TODO: Change this test to run in a isolated non-tenantized landlord environment
+
     // Given that we have an outbound deliverable
     $deliverable = OutboundDeliverable::factory()->create();
 
@@ -64,8 +66,6 @@ it('correctly handles the incoming SES event', function (string $event, Notifica
     expect($deliverable->hasBeenDelivered())->toBe(false);
     expect($deliverable->delivery_status)->toBe(NotificationDeliveryStatus::Awaiting);
     expect($deliverable->last_delivery_attempt)->toBeNull();
-
-    // Tenant::forgetCurrent();
 
     $response = withHeaders(
         [
@@ -85,8 +85,6 @@ it('correctly handles the incoming SES event', function (string $event, Notifica
     );
 
     $response->assertOk();
-
-    // $tenant->makeCurrent();
 
     // The outbound deliverable should be appropriately updated based on the event
     $deliverable->refresh();

--- a/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Bounce.json
+++ b/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Bounce.json
@@ -21,7 +21,9 @@
         "sourceArn": "arn:aws:ses:us-east-1:123456789012:identity/sender@example.com",
         "sendingAccountId": "123456789012",
         "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
-        "destination": ["recipient@example.com"],
+        "destination": [
+            "recipient@example.com"
+        ],
         "headersTruncated": false,
         "headers": [
             {
@@ -46,17 +48,34 @@
             }
         ],
         "commonHeaders": {
-            "from": ["Sender Name <sender@example.com>"],
-            "to": ["recipient@example.com"],
+            "from": [
+                "Sender Name <sender@example.com>"
+            ],
+            "to": [
+                "recipient@example.com"
+            ],
             "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
             "subject": "Message sent from Amazon SES"
         },
         "tags": {
-            "ses:configuration-set": ["ConfigSet"],
-            "ses:source-ip": ["192.0.2.0"],
-            "ses:from-domain": ["example.com"],
-            "ses:caller-identity": ["ses_user"],
-            "outbound_deliverable_id": ["xxx"]
+            "ses:configuration-set": [
+                "ConfigSet"
+            ],
+            "ses:source-ip": [
+                "192.0.2.0"
+            ],
+            "ses:from-domain": [
+                "example.com"
+            ],
+            "ses:caller-identity": [
+                "ses_user"
+            ],
+            "outbound_deliverable_id": [
+                "xxx"
+            ],
+            "tenant_id": [
+                "xxx"
+            ]
         }
     }
 }

--- a/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Click.json
+++ b/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Click.json
@@ -4,20 +4,30 @@
         "ipAddress": "192.0.2.1",
         "link": "http://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-smtp.html",
         "linkTags": {
-            "samplekey0": ["samplevalue0"],
-            "samplekey1": ["samplevalue1"]
+            "samplekey0": [
+                "samplevalue0"
+            ],
+            "samplekey1": [
+                "samplevalue1"
+            ]
         },
         "timestamp": "2017-08-09T23:51:25.570Z",
         "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36"
     },
     "mail": {
         "commonHeaders": {
-            "from": ["sender@example.com"],
+            "from": [
+                "sender@example.com"
+            ],
             "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
             "subject": "Message sent from Amazon SES",
-            "to": ["recipient@example.com"]
+            "to": [
+                "recipient@example.com"
+            ]
         },
-        "destination": ["recipient@example.com"],
+        "destination": [
+            "recipient@example.com"
+        ],
         "headers": [
             {
                 "name": "X-SES-CONFIGURATION-SET",
@@ -57,11 +67,24 @@
         "sendingAccountId": "123456789012",
         "source": "sender@example.com",
         "tags": {
-            "ses:caller-identity": ["ses_user"],
-            "ses:configuration-set": ["ConfigSet"],
-            "ses:from-domain": ["example.com"],
-            "ses:source-ip": ["192.0.2.0"],
-            "outbound_deliverable_id": ["xxx"]
+            "ses:caller-identity": [
+                "ses_user"
+            ],
+            "ses:configuration-set": [
+                "ConfigSet"
+            ],
+            "ses:from-domain": [
+                "example.com"
+            ],
+            "ses:source-ip": [
+                "192.0.2.0"
+            ],
+            "outbound_deliverable_id": [
+                "xxx"
+            ],
+            "tenant_id": [
+                "xxx"
+            ]
         },
         "timestamp": "2017-08-09T23:50:05.795Z"
     }

--- a/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Complaint.json
+++ b/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Complaint.json
@@ -18,7 +18,9 @@
         "sourceArn": "arn:aws:ses:us-east-1:123456789012:identity/sender@example.com",
         "sendingAccountId": "123456789012",
         "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
-        "destination": ["recipient@example.com"],
+        "destination": [
+            "recipient@example.com"
+        ],
         "headersTruncated": false,
         "headers": [
             {
@@ -43,17 +45,34 @@
             }
         ],
         "commonHeaders": {
-            "from": ["Sender Name <sender@example.com>"],
-            "to": ["recipient@example.com"],
+            "from": [
+                "Sender Name <sender@example.com>"
+            ],
+            "to": [
+                "recipient@example.com"
+            ],
             "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
             "subject": "Message sent from Amazon SES"
         },
         "tags": {
-            "ses:configuration-set": ["ConfigSet"],
-            "ses:source-ip": ["192.0.2.0"],
-            "ses:from-domain": ["example.com"],
-            "ses:caller-identity": ["ses_user"],
-            "outbound_deliverable_id": ["xxx"]
+            "ses:configuration-set": [
+                "ConfigSet"
+            ],
+            "ses:source-ip": [
+                "192.0.2.0"
+            ],
+            "ses:from-domain": [
+                "example.com"
+            ],
+            "ses:caller-identity": [
+                "ses_user"
+            ],
+            "outbound_deliverable_id": [
+                "xxx"
+            ],
+            "tenant_id": [
+                "xxx"
+            ]
         }
     }
 }

--- a/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Delivery.json
+++ b/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Delivery.json
@@ -6,7 +6,9 @@
         "sourceArn": "arn:aws:ses:us-east-1:123456789012:identity/sender@example.com",
         "sendingAccountId": "123456789012",
         "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
-        "destination": ["recipient@example.com"],
+        "destination": [
+            "recipient@example.com"
+        ],
         "headersTruncated": false,
         "headers": [
             {
@@ -35,24 +37,45 @@
             }
         ],
         "commonHeaders": {
-            "from": ["sender@example.com"],
-            "to": ["recipient@example.com"],
+            "from": [
+                "sender@example.com"
+            ],
+            "to": [
+                "recipient@example.com"
+            ],
             "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
             "subject": "Message sent from Amazon SES"
         },
         "tags": {
-            "ses:configuration-set": ["ConfigSet"],
-            "ses:source-ip": ["192.0.2.0"],
-            "ses:from-domain": ["example.com"],
-            "ses:caller-identity": ["ses_user"],
-            "ses:outgoing-ip": ["192.0.2.0"],
-            "outbound_deliverable_id": ["xxx"]
+            "ses:configuration-set": [
+                "ConfigSet"
+            ],
+            "ses:source-ip": [
+                "192.0.2.0"
+            ],
+            "ses:from-domain": [
+                "example.com"
+            ],
+            "ses:caller-identity": [
+                "ses_user"
+            ],
+            "ses:outgoing-ip": [
+                "192.0.2.0"
+            ],
+            "outbound_deliverable_id": [
+                "xxx"
+            ],
+            "tenant_id": [
+                "xxx"
+            ]
         }
     },
     "delivery": {
         "timestamp": "2016-10-19T23:21:04.133Z",
         "processingTimeMillis": 11893,
-        "recipients": ["recipient@example.com"],
+        "recipients": [
+            "recipient@example.com"
+        ],
         "smtpResponse": "250 2.6.0 Message received",
         "reportingMTA": "mta.example.com"
     }

--- a/app-modules/integration-aws-ses-event-handling/tests/Fixtures/DeliveryDelay.json
+++ b/app-modules/integration-aws-ses-event-handling/tests/Fixtures/DeliveryDelay.json
@@ -6,11 +6,20 @@
         "sourceArn": "arn:aws:ses:us-east-1:123456789012:identity/sender@example.com",
         "sendingAccountId": "123456789012",
         "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
-        "destination": ["recipient@example.com"],
+        "destination": [
+            "recipient@example.com"
+        ],
         "headersTruncated": false,
         "tags": {
-            "ses:configuration-set": ["ConfigSet"],
-            "outbound_deliverable_id": ["xxx"]
+            "ses:configuration-set": [
+                "ConfigSet"
+            ],
+            "outbound_deliverable_id": [
+                "xxx"
+            ],
+            "tenant_id": [
+                "xxx"
+            ]
         }
     },
     "deliveryDelay": {

--- a/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Open.json
+++ b/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Open.json
@@ -2,12 +2,18 @@
     "eventType": "Open",
     "mail": {
         "commonHeaders": {
-            "from": ["sender@example.com"],
+            "from": [
+                "sender@example.com"
+            ],
             "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
             "subject": "Message sent from Amazon SES",
-            "to": ["recipient@example.com"]
+            "to": [
+                "recipient@example.com"
+            ]
         },
-        "destination": ["recipient@example.com"],
+        "destination": [
+            "recipient@example.com"
+        ],
         "headers": [
             {
                 "name": "X-SES-CONFIGURATION-SET",
@@ -43,11 +49,24 @@
         "sendingAccountId": "123456789012",
         "source": "sender@example.com",
         "tags": {
-            "ses:caller-identity": ["IAM_user_or_role_name"],
-            "ses:configuration-set": ["ConfigSet"],
-            "ses:from-domain": ["example.com"],
-            "ses:source-ip": ["192.0.2.0"],
-            "outbound_deliverable_id": ["xxx"]
+            "ses:caller-identity": [
+                "IAM_user_or_role_name"
+            ],
+            "ses:configuration-set": [
+                "ConfigSet"
+            ],
+            "ses:from-domain": [
+                "example.com"
+            ],
+            "ses:source-ip": [
+                "192.0.2.0"
+            ],
+            "outbound_deliverable_id": [
+                "xxx"
+            ],
+            "tenant_id": [
+                "xxx"
+            ]
         },
         "timestamp": "2017-08-09T21:59:49.927Z"
     },

--- a/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Reject.json
+++ b/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Reject.json
@@ -6,7 +6,9 @@
         "sourceArn": "arn:aws:ses:us-east-1:123456789012:identity/sender@example.com",
         "sendingAccountId": "123456789012",
         "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
-        "destination": ["sender@example.com"],
+        "destination": [
+            "sender@example.com"
+        ],
         "headersTruncated": false,
         "headers": [
             {
@@ -35,17 +37,34 @@
             }
         ],
         "commonHeaders": {
-            "from": ["sender@example.com"],
-            "to": ["recipient@example.com"],
+            "from": [
+                "sender@example.com"
+            ],
+            "to": [
+                "recipient@example.com"
+            ],
             "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
             "subject": "Message sent from Amazon SES"
         },
         "tags": {
-            "ses:configuration-set": ["ConfigSet"],
-            "ses:source-ip": ["192.0.2.0"],
-            "ses:from-domain": ["example.com"],
-            "ses:caller-identity": ["ses_user"],
-            "outbound_deliverable_id": ["xxx"]
+            "ses:configuration-set": [
+                "ConfigSet"
+            ],
+            "ses:source-ip": [
+                "192.0.2.0"
+            ],
+            "ses:from-domain": [
+                "example.com"
+            ],
+            "ses:caller-identity": [
+                "ses_user"
+            ],
+            "outbound_deliverable_id": [
+                "xxx"
+            ],
+            "tenant_id": [
+                "xxx"
+            ]
         }
     },
     "reject": {

--- a/app-modules/integration-aws-ses-event-handling/tests/Fixtures/RenderingFailure.json
+++ b/app-modules/integration-aws-ses-event-handling/tests/Fixtures/RenderingFailure.json
@@ -6,11 +6,20 @@
         "sourceArn": "arn:aws:ses:us-east-1:123456789012:identity/sender@example.com",
         "sendingAccountId": "123456789012",
         "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
-        "destination": ["recipient@example.com"],
+        "destination": [
+            "recipient@example.com"
+        ],
         "headersTruncated": false,
         "tags": {
-            "ses:configuration-set": ["ConfigSet"],
-            "outbound_deliverable_id": ["xxx"]
+            "ses:configuration-set": [
+                "ConfigSet"
+            ],
+            "outbound_deliverable_id": [
+                "xxx"
+            ],
+            "tenant_id": [
+                "xxx"
+            ]
         }
     },
     "failure": {

--- a/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Send.json
+++ b/app-modules/integration-aws-ses-event-handling/tests/Fixtures/Send.json
@@ -6,7 +6,9 @@
         "sourceArn": "arn:aws:ses:us-east-1:123456789012:identity/sender@example.com",
         "sendingAccountId": "123456789012",
         "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
-        "destination": ["recipient@example.com"],
+        "destination": [
+            "recipient@example.com"
+        ],
         "headersTruncated": false,
         "headers": [
             {
@@ -35,17 +37,34 @@
             }
         ],
         "commonHeaders": {
-            "from": ["sender@example.com"],
-            "to": ["recipient@example.com"],
+            "from": [
+                "sender@example.com"
+            ],
+            "to": [
+                "recipient@example.com"
+            ],
             "messageId": "EXAMPLE7c191be45-e9aedb9a-02f9-4d12-a87d-dd0099a07f8a-000000",
             "subject": "Message sent from Amazon SES"
         },
         "tags": {
-            "ses:configuration-set": ["ConfigSet"],
-            "ses:source-ip": ["192.0.2.0"],
-            "ses:from-domain": ["example.com"],
-            "ses:caller-identity": ["ses_user"],
-            "outbound_deliverable_id": ["xxx"]
+            "ses:configuration-set": [
+                "ConfigSet"
+            ],
+            "ses:source-ip": [
+                "192.0.2.0"
+            ],
+            "ses:from-domain": [
+                "example.com"
+            ],
+            "ses:caller-identity": [
+                "ses_user"
+            ],
+            "outbound_deliverable_id": [
+                "xxx"
+            ],
+            "tenant_id": [
+                "xxx"
+            ]
         }
     },
     "send": {}

--- a/app-modules/integration-aws-ses-event-handling/tests/Unit/SesConfigurationSetTest.php
+++ b/app-modules/integration-aws-ses-event-handling/tests/Unit/SesConfigurationSetTest.php
@@ -35,6 +35,7 @@
 */
 
 use App\Models\User;
+use App\Models\Tenant;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Mail\Events\MessageSent;
@@ -81,7 +82,7 @@ it('The configuration set headers are present and emails are sent if configurati
 
     Event::assertDispatched(
         fn (MessageSent $event) => $event->message->getHeaders()->get('X-SES-CONFIGURATION-SET')->getBody() === $configurationSet
-            && $event->message->getHeaders()->get('X-SES-MESSAGE-TAGS')->getBody() === 'outbound_deliverable_id=' . OutboundDeliverable::first()->getKey()
+            && $event->message->getHeaders()->get('X-SES-MESSAGE-TAGS')->getBody() === sprintf('outbound_deliverable_id=%s, tenant_id=%s', OutboundDeliverable::first()->getKey(), Tenant::current()->getKey())
     );
 });
 

--- a/app-modules/notification/src/Notifications/BaseNotification.php
+++ b/app-modules/notification/src/Notifications/BaseNotification.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\Notification\Notifications;
 
 use Exception;
+use App\Models\Tenant;
 use Illuminate\Support\Str;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Notification;
@@ -104,6 +105,10 @@ abstract class BaseNotification extends Notification implements ShouldQueue
         $this->metadata = [
             'outbound_deliverable_id' => $deliverable->id,
         ];
+
+        if (Tenant::checkCurrent()) {
+            $this->metadata['tenant_id'] = Tenant::current()->getKey();
+        }
 
         return $deliverable;
     }

--- a/app-modules/notification/src/Notifications/Concerns/EmailChannelTrait.php
+++ b/app-modules/notification/src/Notifications/Concerns/EmailChannelTrait.php
@@ -63,10 +63,23 @@ trait EmailChannelTrait
                     );
                 }
 
-                if (! empty($this->metadata['outbound_deliverable_id'])) {
+                if (
+                    ! empty($this->metadata['outbound_deliverable_id'])
+                    || ! empty($this->metadata['tenant_id'])
+                ) {
+                    $tagString = '';
+
+                    if (! empty($this->metadata['outbound_deliverable_id'])) {
+                        $tagString .= "outbound_deliverable_id={$this->metadata['outbound_deliverable_id']}, ";
+                    }
+
+                    if (! empty($this->metadata['tenant_id'])) {
+                        $tagString .= "tenant_id={$this->metadata['tenant_id']}, ";
+                    }
+
                     $message->getHeaders()->addTextHeader(
                         'X-SES-MESSAGE-TAGS',
-                        "outbound_deliverable_id={$this->metadata['outbound_deliverable_id']}"
+                        rtrim($tagString, ', ')
                     );
                 }
             });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-603

### Technical Description

Fixes the delivery tracking of emails sent out of the system by attaching a `tenant_id` to them and then tracking that on the inbound webhook receiving from SES then directing the job to be executed as that Tenant.

### Any deployment steps required?

No

### Are any Feature Flags Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
