### PR TITLE
[ADVAPP-779]: Sorting Tasks by Due Date on My Dashboard in the Recruitment CRM does not appropriately reorder the list

### DIFF
--- a/app-modules/task/src/Filament/Widgets/TasksWidget.php
+++ b/app-modules/task/src/Filament/Widgets/TasksWidget.php
@@ -67,8 +67,7 @@ abstract class TasksWidget extends BaseWidget
                 return $user
                     ->assignedTasks()
                     ->whereMorphedTo('concern', $this->concern())
-                    ->getQuery()
-                    ->byNextDue();
+                    ->getQuery();
             })
             ->columns([
                 IdColumn::make(),
@@ -91,6 +90,7 @@ abstract class TasksWidget extends BaseWidget
                         default => null,
                     }),
             ])
+            ->defaultSort('due')
             ->filters([
                 SelectFilter::make('status')
                     ->options(TaskStatus::class)


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-779

### Technical Description

Sorting Tasks by Due Date on My Dashboard in the Recruitment CRM does not appropriately reorder the list

### Any deployment steps required?

No

### Are any Feature Flags Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
