### PR TITLE
[ADVAPP-803]: Old flowbite svg is still referenced in Landlord page

### DIFF
--- a/resources/views/landlord.blade.php
+++ b/resources/views/landlord.blade.php
@@ -39,7 +39,7 @@
             <div class="mx-auto text-center">
                 <img
                     class="mx-auto mb-3 max-w-md"
-                    src="{{ Vite::asset('resources/svg/flowbite-500.svg') }}"
+                    src="{{ Vite::asset('resources/svg/canyongbs-500.svg') }}"
                     alt="Internal Server Error"
                 >
                 <h1 class="mb-3 text-5xl font-extrabold text-primary-600 dark:text-primary-500">


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-803

### Technical Description

> Replace reference to resources/svg/flowbite-500.svg with resources/svg/canyongbs-500.svg in resources/views/landlord.blade.php

### Any deployment steps required?

> No

### Are any Feature Flags Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
