### PR TITLE
[OLYMPUS-88]: Ensure Olympus connect to other products works locally

### DIFF
--- a/app/Console/Commands/ConnectOlympus.php
+++ b/app/Console/Commands/ConnectOlympus.php
@@ -36,7 +36,6 @@
 
 namespace App\Console\Commands;
 
-use App\Settings\BrandSettings;
 use Illuminate\Console\Command;
 use App\Settings\OlympusSettings;
 use Illuminate\Support\Facades\Http;
@@ -69,10 +68,6 @@ class ConnectOlympus extends Command
         $olympusSettings = app(OlympusSettings::class);
         $olympusSettings->fill($response->json('olympus'));
         $olympusSettings->save();
-
-        $brandSettings = app(BrandSettings::class);
-        $brandSettings->fill($response->json('brand'));
-        $brandSettings->save();
 
         $this->info('The app has been connected to Olympus.');
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/OLYMPUS-88

### Technical Description

Support for [OLYMPUS-88]. Because Brand settings will now no longer be tied to an Application we should not and cannot sync Brand info during the first connection to Olympus.

### Any deployment steps required?

No.

### Are any Feature Flags Added?

No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).


[OLYMPUS-88]: https://canyongbs.atlassian.net/browse/OLYMPUS-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ