### PR TITLE
[ADVAPP-778]: An exception is sometimes thrown during the thread pruning process

### DIFF
--- a/app-modules/ai/src/Listeners/DeleteExternalAiMessageFile.php
+++ b/app-modules/ai/src/Listeners/DeleteExternalAiMessageFile.php
@@ -36,9 +36,9 @@
 
 namespace AdvisingApp\Ai\Listeners;
 
+use Exception;
 use AdvisingApp\Ai\Events\AiMessageFileForceDeleting;
 use AdvisingApp\Ai\Services\Contracts\AiServiceLifecycleHooks;
-use Exception;
 
 class DeleteExternalAiMessageFile
 {

--- a/app-modules/ai/src/Listeners/DeleteExternalAiMessageFile.php
+++ b/app-modules/ai/src/Listeners/DeleteExternalAiMessageFile.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Ai\Listeners;
 
 use AdvisingApp\Ai\Events\AiMessageFileForceDeleting;
 use AdvisingApp\Ai\Services\Contracts\AiServiceLifecycleHooks;
+use Exception;
 
 class DeleteExternalAiMessageFile
 {
@@ -47,7 +48,13 @@ class DeleteExternalAiMessageFile
             return;
         }
 
-        $service = $event->aiMessageFile->message->thread->assistant->model->getService();
+        $service = $event->aiMessageFile?->message?->thread?->assistant?->model?->getService();
+
+        if ($service === null) {
+            report(new Exception('No AI service found for the message file: ' . $event->aiMessageFile->getKey()));
+
+            return;
+        }
 
         if ($service instanceof AiServiceLifecycleHooks) {
             $service->beforeMessageFileForceDeleted($event->aiMessageFile);

--- a/app-modules/ai/src/Listeners/DeleteExternalAiThread.php
+++ b/app-modules/ai/src/Listeners/DeleteExternalAiThread.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Ai\Listeners;
 
+use OpenAI\Exceptions\ErrorException;
 use AdvisingApp\Ai\Events\AiThreadForceDeleting;
 
 class DeleteExternalAiThread
@@ -45,7 +46,17 @@ class DeleteExternalAiThread
         $service = $event->aiThread->assistant->model->getService();
 
         if ($service->isThreadExisting($event->aiThread)) {
-            $service->deleteThread($event->aiThread);
+            try {
+                $service->deleteThread($event->aiThread);
+            } catch (ErrorException $e) {
+                if (str_contains($e->getMessage(), 'No thread found with id')) {
+                    report($e);
+
+                    return;
+                }
+
+                throw $e;
+            }
         }
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-778

### Technical Description

Captures the `No thread found with id` Exception, reports it, and continues on.

### Any deployment steps required?

No

### Are any Feature Flags Added?

No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
