### PR TITLE
[ADVAPP-809]: Draft with AI for student and prospect interactions generates an exception

### DIFF
--- a/app-modules/interaction/src/Filament/Actions/DraftInteractionWithAiAction.php
+++ b/app-modules/interaction/src/Filament/Actions/DraftInteractionWithAiAction.php
@@ -82,7 +82,7 @@ class DraftInteractionWithAiAction extends Action
                     ->required(),
             ])
             ->action(function (array $data, Get $get, Set $set, Page $livewire) {
-                $model = Feature::active('ai-integrated-assistant-settings')
+                $aiModel = Feature::active('ai-integrated-assistant-settings')
                     ? app(AiIntegratedAssistantSettings::class)->default_model
                     : app(AiSettings::class)->default_model;
 
@@ -113,7 +113,7 @@ class DraftInteractionWithAiAction extends Action
 
                 try {
                     $content = app(CompletePrompt::class)->execute(
-                        aiModel: $model,
+                        aiModel: $aiModel,
                         prompt: <<<EOL
                             My name is {$userName}, and I am a {$userJobTitle} at {$clientName}.
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-809

### Technical Description

Fixes bug with Draft Interaction with AI caused by naming the `$model` variable passed to `CompletePrompt` the same as a variable also used in the prompt for something else.

### Any deployment steps required?

No.

### Are any Feature Flags Added?

No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
