### PR TITLE
[ADVAPP-798]: When draft with AI is used in campaigns, formatting is not preserved from the AI output

### DIFF
--- a/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
@@ -65,13 +65,13 @@
         @if ($action['body'])
             <div class="flex flex-col pt-3">
                 <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Body</dt>
-                <dd class="prose dark:prose-invert text-sm font-semibold">
+                <dd class="prose text-sm font-semibold dark:prose-invert">
                     {!! EngagementBatch::renderWithMergeTags(
-                    tiptap_converter()->asHTML(
-                        $action['body'],
-                        newImages: $this->componentFileAttachments['data']['actions'][$actionIndex]['data']['body'] ?? [],
-                    ),
-                ) !!}
+                        tiptap_converter()->asHTML(
+                            $action['body'],
+                            newImages: $this->componentFileAttachments['data']['actions'][$actionIndex]['data']['body'] ?? [],
+                        ),
+                    ) !!}
                 </dd>
             </div>
         @endif

--- a/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/bulk-engagement.blade.php
@@ -65,12 +65,14 @@
         @if ($action['body'])
             <div class="flex flex-col pt-3">
                 <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Body</dt>
-                <dd class="text-sm font-semibold">{!! EngagementBatch::renderWithMergeTags(
+                <dd class="prose dark:prose-invert text-sm font-semibold">
+                    {!! EngagementBatch::renderWithMergeTags(
                     tiptap_converter()->asHTML(
                         $action['body'],
                         newImages: $this->componentFileAttachments['data']['actions'][$actionIndex]['data']['body'] ?? [],
                     ),
-                ) !!}</dd>
+                ) !!}
+                </dd>
             </div>
         @endif
         <div class="flex flex-col pt-3">


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-798

### Technical Description

> When an email is created in campaign, the format of the email body was not shown in proper format. Therefore the format of the email body has been solved.

### Any deployment steps required?

> No.

### Are any Feature Flags Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
