### PR TITLE
[ADVAPP-813]: If Service Management or Event Management is disabled for a tenant, campaign actions do not respect the feature availability when building journey steps.

### DIFF
--- a/app-modules/campaign/src/Enums/CampaignActionType.php
+++ b/app-modules/campaign/src/Enums/CampaignActionType.php
@@ -82,13 +82,16 @@ enum CampaignActionType: string implements HasLabel
         $blocks = [
             EngagementBatchEmailBlock::make(),
             EngagementBatchSmsBlock::make(),
-            ServiceRequestBlock::make(),
             ProactiveAlertBlock::make(),
             InteractionBlock::make(),
             CareTeamBlock::make(),
             TaskBlock::make(),
             SubscriptionBlock::make(),
         ];
+
+        if (app(LicenseSettings::class)->data->addons->serviceManagement) {
+            $blocks[] = ServiceRequestBlock::make();
+        }
 
         if (app(LicenseSettings::class)->data->addons->eventManagement) {
             $blocks[] = EventBlock::make();

--- a/app-modules/service-management/src/Models/ServiceRequest.php
+++ b/app-modules/service-management/src/Models/ServiceRequest.php
@@ -41,6 +41,7 @@ use App\Models\User;
 use DateTimeInterface;
 use App\Models\BaseModel;
 use Carbon\CarbonInterface;
+use App\Settings\LicenseSettings;
 use Illuminate\Support\Facades\DB;
 use Kirschbaum\PowerJoins\PowerJoins;
 use OwenIt\Auditing\Contracts\Auditable;
@@ -73,7 +74,6 @@ use AdvisingApp\Notification\Models\Contracts\CanTriggerAutoSubscription;
 use AdvisingApp\ServiceManagement\Enums\SystemServiceRequestClassification;
 use AdvisingApp\ServiceManagement\Exceptions\ServiceRequestNumberExceededReRollsException;
 use AdvisingApp\ServiceManagement\Services\ServiceRequestNumber\Contracts\ServiceRequestNumberGenerator;
-use App\Settings\LicenseSettings;
 
 /**
  * @property-read Student|Prospect $respondent

--- a/resources/views/filament/forms/components/campaigns/actions/service-request.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/service-request.blade.php
@@ -60,10 +60,6 @@
             <dd class="text-sm font-semibold">{{ ServiceRequestPriority::find($action['priority_id'])?->name }}</dd>
         </div>
         <div class="flex flex-col pt-3">
-            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Type</dt>
-            <dd class="text-sm font-semibold">{{ ServiceRequestType::find($action['type_id'])?->name }}</dd>
-        </div>
-        <div class="flex flex-col pt-3">
             <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Assigned To</dt>
             <dd class="text-sm font-semibold">{{ User::find($action['assigned_to_id'])?->name ?? 'No one' }}</dd>
         </div>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-813

### Technical Description

> If Service Management or Event Management is not enabled for a tenant, journey steps cannot be created using campaign actions related to those features.

### Any deployment steps required?

> No

### Are any Feature Flags Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
