### PR TITLE
[ADVAPP-797]: Introduce "demo mode" for email and text messaging

### DIFF
--- a/app-modules/integration-twilio/src/Filament/Pages/ManageTwilioSettings.php
+++ b/app-modules/integration-twilio/src/Filament/Pages/ManageTwilioSettings.php
@@ -78,6 +78,9 @@ class ManageTwilioSettings extends SettingsPage
                 Toggle::make('is_enabled')
                     ->label('Enabled')
                     ->live(),
+                Toggle::make('is_demo_mode_enabled')
+                    ->label('Demo Mode')
+                    ->live(),
                 Section::make()
                     ->schema([
                         TextInput::make('account_sid')
@@ -94,7 +97,8 @@ class ManageTwilioSettings extends SettingsPage
                         TextInput::make('from_number')
                             ->string()
                             ->required(),
-                    ])->visible(fn (Get $get) => $get('is_enabled')),
+                    ])
+                    ->visible(fn (Get $get) => $get('is_enabled') && ! $get('is_demo_mode_enabled')),
             ]);
     }
 }

--- a/app-modules/integration-twilio/src/Filament/Pages/ManageTwilioSettings.php
+++ b/app-modules/integration-twilio/src/Filament/Pages/ManageTwilioSettings.php
@@ -79,7 +79,8 @@ class ManageTwilioSettings extends SettingsPage
                     ->label('Enabled')
                     ->live(),
                 Toggle::make('is_demo_mode_enabled')
-                    ->label('Demo Mode')
+                    ->label('SMS Demo Mode')
+                    ->helperText('When enabled, no messages will be sent.')
                     ->live(),
                 Section::make()
                     ->schema([

--- a/app-modules/integration-twilio/src/Providers/IntegrationTwilioServiceProvider.php
+++ b/app-modules/integration-twilio/src/Providers/IntegrationTwilioServiceProvider.php
@@ -59,7 +59,7 @@ class IntegrationTwilioServiceProvider extends ServiceProvider
     {
         Panel::configureUsing(fn (Panel $panel) => ($panel->getId() !== 'admin') || $panel->plugin(new IntegrationTwilioPlugin()));
 
-        $this->app->bind(EngagementResponseSenderFinder::class, function () {
+        $this->app->scoped(EngagementResponseSenderFinder::class, function () {
             if (config('local_development.twilio.enable_test_sender') === true) {
                 return new PlaygroundFindEngagementResponseSender();
             }
@@ -69,7 +69,7 @@ class IntegrationTwilioServiceProvider extends ServiceProvider
 
         $settings = $this->app->make(TwilioSettings::class);
 
-        $this->app->bind(
+        $this->app->scoped(
             Client::class,
             fn () => Integration::Twilio->isOn()
                 ? new Client($settings->account_sid, $settings->auth_token)

--- a/app-modules/integration-twilio/src/Settings/TwilioSettings.php
+++ b/app-modules/integration-twilio/src/Settings/TwilioSettings.php
@@ -37,10 +37,15 @@
 namespace AdvisingApp\IntegrationTwilio\Settings;
 
 use App\Settings\IntegrationSettings;
+use App\Settings\Contracts\HasDefaultSettings;
 use AdvisingApp\IntegrationTwilio\DataTransferObjects\TwilioApiKey;
 
-class TwilioSettings extends IntegrationSettings
+class TwilioSettings extends IntegrationSettings implements HasDefaultSettings
 {
+    public bool $is_enabled = false;
+
+    public bool $is_demo_mode_enabled = false;
+
     public ?TwilioApiKey $api_key;
 
     public ?string $account_sid;
@@ -67,5 +72,17 @@ class TwilioSettings extends IntegrationSettings
     public function isConfigured(): bool
     {
         return $this->account_sid && $this->auth_token && $this->from_number;
+    }
+
+    public static function defaults(): array
+    {
+        return [
+            'is_enabled' => false,
+            'is_demo_mode_enabled' => false,
+            'api_key' => null,
+            'account_sid' => null,
+            'auth_token' => null,
+            'from_number' => null,
+        ];
     }
 }

--- a/app-modules/integration-twilio/src/Settings/TwilioSettings.php
+++ b/app-modules/integration-twilio/src/Settings/TwilioSettings.php
@@ -71,7 +71,7 @@ class TwilioSettings extends IntegrationSettings implements HasDefaultSettings
 
     public function isConfigured(): bool
     {
-        return $this->account_sid && $this->auth_token && $this->from_number || $this->is_demo_mode_enabled;
+        return $this->account_sid && $this->auth_token && $this->from_number || $this->is_demo_mode_enabled ?? false;
     }
 
     public static function defaults(): array

--- a/app-modules/integration-twilio/src/Settings/TwilioSettings.php
+++ b/app-modules/integration-twilio/src/Settings/TwilioSettings.php
@@ -71,7 +71,7 @@ class TwilioSettings extends IntegrationSettings implements HasDefaultSettings
 
     public function isConfigured(): bool
     {
-        return $this->account_sid && $this->auth_token && $this->from_number;
+        return $this->account_sid && $this->auth_token && $this->from_number || $this->is_demo_mode_enabled;
     }
 
     public static function defaults(): array

--- a/app-modules/notification/src/Notifications/Channels/EmailChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/EmailChannel.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Notification\Notifications\Channels;
 
 use Exception;
 use App\Models\User;
+use App\Models\Tenant;
 use App\Settings\LicenseSettings;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Notifications\Notification;
@@ -50,10 +51,8 @@ use AdvisingApp\Notification\Notifications\EmailNotification;
 use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
 use AdvisingApp\Notification\Exceptions\NotificationQuotaExceeded;
 use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
-use AdvisingApp\IntegrationAwsSesEventHandling\Settings\SesSettings;
 use AdvisingApp\Notification\DataTransferObjects\EmailChannelResultData;
 use AdvisingApp\Notification\DataTransferObjects\NotificationResultData;
-use App\Models\Tenant;
 
 class EmailChannel extends MailChannel
 {
@@ -123,7 +122,7 @@ class EmailChannel extends MailChannel
         if ($result->success) {
             $deliverable->update([
                 'delivery_status' => ! $demoMode ? NotificationDeliveryStatus::Dispatched : NotificationDeliveryStatus::Successful,
-                'quota_usage' => !$demoMode ? self::determineQuotaUsage($result->recipients) : 0,
+                'quota_usage' => ! $demoMode ? self::determineQuotaUsage($result->recipients) : 0,
             ]);
         } else {
             $deliverable->update([

--- a/app-modules/notification/src/Notifications/Channels/SmsChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/SmsChannel.php
@@ -99,7 +99,7 @@ class SmsChannel
 
         $twilioSettings = app(TwilioSettings::class);
 
-        if ($twilioSettings->is_demo_mode_enabled) {
+        if ($twilioSettings->is_demo_mode_enabled ?? false) {
             return SmsChannelResultData::from([
                 'success' => true,
                 'message' => new MessageInstance(

--- a/app-modules/notification/src/Notifications/Channels/SmsChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/SmsChannel.php
@@ -39,13 +39,18 @@ namespace AdvisingApp\Notification\Notifications\Channels;
 use Exception;
 use App\Models\User;
 use Twilio\Rest\Client;
+use Twilio\Rest\Api\V2010;
+use Illuminate\Support\Str;
+use Twilio\Rest\MessagingBase;
 use App\Settings\LicenseSettings;
 use Illuminate\Support\Facades\DB;
 use Twilio\Exceptions\TwilioException;
+use Twilio\Rest\Api\V2010\Account\MessageInstance;
 use AdvisingApp\Notification\Enums\NotificationChannel;
 use AdvisingApp\Engagement\Models\EngagementDeliverable;
 use AdvisingApp\Notification\Models\OutboundDeliverable;
 use Talkroute\MessageSegmentCalculator\SegmentCalculator;
+use AdvisingApp\IntegrationTwilio\Settings\TwilioSettings;
 use AdvisingApp\Notification\Notifications\SmsNotification;
 use AdvisingApp\Notification\Notifications\BaseNotification;
 use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
@@ -92,6 +97,26 @@ class SmsChannel
     {
         $twilioMessage = $notification->toSms($notifiable);
 
+        $twilioSettings = app(TwilioSettings::class);
+
+        if ($twilioSettings->is_demo_mode_enabled) {
+            return SmsChannelResultData::from([
+                'success' => true,
+                'message' => new MessageInstance(
+                    new V2010(new MessagingBase(new Client(username: 'abc123', password: 'abc123'))),
+                    [
+                        'sid' => Str::random(),
+                        'status' => 'delivered',
+                        'from' => $twilioMessage->getFrom(),
+                        'to' => $twilioMessage->getRecipientPhoneNumber(),
+                        'body' => $twilioMessage->getContent(),
+                        'num_segments' => 1,
+                    ],
+                    'abc123'
+                ),
+            ]);
+        }
+
         $client = app(Client::class);
 
         $messageContent = [
@@ -124,12 +149,14 @@ class SmsChannel
 
     public static function afterSending(object $notifiable, OutboundDeliverable $deliverable, SmsChannelResultData $result): void
     {
+        $twilioSettings = app(TwilioSettings::class);
+
         if ($result->success) {
             $deliverable->update([
                 'external_reference_id' => $result->message->sid,
                 'external_status' => $result->message->status,
-                'delivery_status' => NotificationDeliveryStatus::Dispatched,
-                'quota_usage' => self::determineQuotaUsage($result),
+                'delivery_status' => ! $twilioSettings->is_demo_mode_enabled ? NotificationDeliveryStatus::Dispatched : NotificationDeliveryStatus::Successful,
+                'quota_usage' => ! $twilioSettings->is_demo_mode_enabled ? self::determineQuotaUsage($result) : 0,
             ]);
         } else {
             $deliverable->update([

--- a/app-modules/notification/src/Notifications/Channels/SmsChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/SmsChannel.php
@@ -151,12 +151,14 @@ class SmsChannel
     {
         $twilioSettings = app(TwilioSettings::class);
 
+        $demoMode = $twilioSettings->is_demo_mode_enabled ?? false;
+
         if ($result->success) {
             $deliverable->update([
                 'external_reference_id' => $result->message->sid,
                 'external_status' => $result->message->status,
-                'delivery_status' => ! $twilioSettings->is_demo_mode_enabled ? NotificationDeliveryStatus::Dispatched : NotificationDeliveryStatus::Successful,
-                'quota_usage' => ! $twilioSettings->is_demo_mode_enabled ? self::determineQuotaUsage($result) : 0,
+                'delivery_status' => ! $demoMode ? NotificationDeliveryStatus::Dispatched : NotificationDeliveryStatus::Successful,
+                'quota_usage' => ! $demoMode ? self::determineQuotaUsage($result) : 0,
             ]);
         } else {
             $deliverable->update([

--- a/app/Console/Commands/CreateTenant.php
+++ b/app/Console/Commands/CreateTenant.php
@@ -114,6 +114,7 @@ class CreateTenant extends Command
                     root: config('filesystems.disks.s3-public.root') ?? $rootName . '/PUBLIC',
                 ),
                 mail: new TenantMailConfig(
+                    isDemoModeEnabled: false,
                     mailers: new TenantMailersConfig(
                         smtp: new TenantSmtpMailerConfig(
                             host: config('mail.mailers.smtp.host'),

--- a/app/Http/Controllers/Tenants/CreateTenantController.php
+++ b/app/Http/Controllers/Tenants/CreateTenantController.php
@@ -95,6 +95,7 @@ class CreateTenantController
                     root: $rootName . '/PUBLIC',
                 ),
                 mail: new TenantMailConfig(
+                    isDemoModeEnabled: false,
                     mailers: new TenantMailersConfig(
                         smtp: new TenantSmtpMailerConfig(
                             host: config('mail.mailers.smtp.host'),

--- a/app/Multitenancy/DataTransferObjects/TenantMailConfig.php
+++ b/app/Multitenancy/DataTransferObjects/TenantMailConfig.php
@@ -41,8 +41,8 @@ use Spatie\LaravelData\Data;
 class TenantMailConfig extends Data
 {
     public function __construct(
-        public bool $isDemoModeEnabled = false,
         public TenantMailersConfig $mailers,
+        public bool $isDemoModeEnabled = false,
         public string $mailer = 'smtp',
         public string $fromAddress = 'no-reply@advising.app',
         public string $fromName = 'Advising App™',

--- a/app/Multitenancy/DataTransferObjects/TenantMailConfig.php
+++ b/app/Multitenancy/DataTransferObjects/TenantMailConfig.php
@@ -41,6 +41,7 @@ use Spatie\LaravelData\Data;
 class TenantMailConfig extends Data
 {
     public function __construct(
+        public bool $isDemoModeEnabled = false,
         public TenantMailersConfig $mailers,
         public string $mailer = 'smtp',
         public string $fromAddress = 'no-reply@advising.app',

--- a/app/Multitenancy/Tasks/SwitchMailTask.php
+++ b/app/Multitenancy/Tasks/SwitchMailTask.php
@@ -40,6 +40,7 @@ use Spatie\Multitenancy\Models\Tenant;
 use Illuminate\Notifications\ChannelManager;
 use Spatie\Multitenancy\Tasks\SwitchTenantTask;
 use Illuminate\Notifications\Channels\MailChannel;
+use App\Multitenancy\DataTransferObjects\TenantMailConfig;
 
 class SwitchMailTask implements SwitchTenantTask
 {
@@ -69,19 +70,37 @@ class SwitchMailTask implements SwitchTenantTask
 
     public function makeCurrent(Tenant $tenant): void
     {
-        $config = $tenant->config;
+        /** @var TenantMailConfig $config */
+        $config = $tenant->config->mail;
+
+        if ($config->isDemoModeEnabled ?? false) {
+            $this->setMailConfig(
+                mailer: 'array',
+                fromAddress: $this->originalFromAddress,
+                fromName: $this->originalFromName,
+                smtpHost: null,
+                smtpPort: null,
+                smtpEncryption: null,
+                smtpUsername: null,
+                smtpPassword: null,
+                smtpTimeout: null,
+                smtpLocalDomain: null,
+            );
+
+            return;
+        }
 
         $this->setMailConfig(
-            mailer: $config->mail->mailer,
-            fromAddress: $config->mail->fromAddress,
-            fromName: $config->mail->fromName,
-            smtpHost: $config->mail->mailers->smtp->host,
-            smtpPort: $config->mail->mailers->smtp->port,
-            smtpEncryption: $config->mail->mailers->smtp->encryption,
-            smtpUsername: $config->mail->mailers->smtp->username,
-            smtpPassword: $config->mail->mailers->smtp->password,
-            smtpTimeout: $config->mail->mailers->smtp->timeout,
-            smtpLocalDomain: $config->mail->mailers->smtp->localDomain,
+            mailer: $config->mailer,
+            fromAddress: $config->fromAddress,
+            fromName: $config->fromName,
+            smtpHost: $config->mailers->smtp->host,
+            smtpPort: $config->mailers->smtp->port,
+            smtpEncryption: $config->mailers->smtp->encryption,
+            smtpUsername: $config->mailers->smtp->username,
+            smtpPassword: $config->mailers->smtp->password,
+            smtpTimeout: $config->mailers->smtp->timeout,
+            smtpLocalDomain: $config->mailers->smtp->localDomain,
         );
     }
 

--- a/database/factories/TenantFactory.php
+++ b/database/factories/TenantFactory.php
@@ -95,6 +95,7 @@ class TenantFactory extends Factory
                 root: config('filesystems.disks.s3-public.root'),
             ),
             mail: new TenantMailConfig(
+                isDemoModeEnabled: false,
                 mailers: new TenantMailersConfig(
                     smtp: new TenantSmtpMailerConfig(
                         host: config('mail.mailers.smtp.host'),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -221,6 +221,7 @@ abstract class TestCase extends BaseTestCase
                     root: config('filesystems.disks.s3-public.root'),
                 ),
                 mail: new TenantMailConfig(
+                    isDemoModeEnabled: false,
                     mailers: new TenantMailersConfig(
                         smtp: new TenantSmtpMailerConfig(
                             host: config('mail.mailers.smtp.host'),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-797

### Technical Description

It adds new settings for SES and Twilio demo mode that prevent email or text from actually being sent but mark engagements as having been delivered.

### Any deployment steps required?

No

### Are any Feature Flags Added?

No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
