### PR TITLE
[ADVAPP-80]: Remove usage of translateLabel()

### DIFF
--- a/app-modules/engagement/src/Filament/Concerns/EngagementResponseInfolist.php
+++ b/app-modules/engagement/src/Filament/Concerns/EngagementResponseInfolist.php
@@ -44,8 +44,7 @@ trait EngagementResponseInfolist
     public function engagementResponseInfolist(): array
     {
         return [
-            TextEntry::make('content')
-                ->translateLabel(),
+            TextEntry::make('content'),
             TextEntry::make('sent_at')
                 ->dateTime('Y-m-d H:i:s'),
         ];

--- a/app-modules/engagement/src/Filament/ManageRelatedRecords/ManageRelatedEngagementRecords.php
+++ b/app-modules/engagement/src/Filament/ManageRelatedRecords/ManageRelatedEngagementRecords.php
@@ -130,8 +130,7 @@ class ManageRelatedEngagementRecords extends ManageRelatedRecords
                     ->columns(),
             ],
             EngagementResponse::class => [
-                TextEntry::make('content')
-                    ->translateLabel(),
+                TextEntry::make('content'),
                 TextEntry::make('sent_at')
                     ->dateTime('Y-m-d H:i:s'),
             ],

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/ViewEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/ViewEngagement.php
@@ -63,13 +63,11 @@ class ViewEngagement extends ViewRecord
                     ->schema([
                         TextEntry::make('user.name')
                             ->label('Created By')
-                            ->translateLabel()
                             ->color('primary')
                             ->url(function (Engagement $record) {
                                 return UserResource::getUrl('view', ['record' => $record->user->id]);
                             }),
                         TextEntry::make('recipient')
-                            ->translateLabel()
                             ->color('primary')
                             ->state(function (Engagement $record): string {
                                 /** @var Student|Prospect $recipient */

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/RelationManagers/EngagementDeliverablesRelationManager.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/RelationManagers/EngagementDeliverablesRelationManager.php
@@ -62,7 +62,6 @@ class EngagementDeliverablesRelationManager extends RelationManager
             ->schema([
                 Select::make('channel')
                     ->label('How would you like to send this engagement?')
-                    ->translateLabel()
                     ->options(EngagementDeliveryMethod::class)
                     ->disableOptionWhen(fn (string $value) => $this->ownerRecord->deliverable->channel === EngagementDeliveryMethod::from($value))
                     ->validationAttribute('Delivery Method')

--- a/app-modules/engagement/src/Filament/Resources/EngagementResponseResource/Pages/ListEngagementResponses.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResponseResource/Pages/ListEngagementResponses.php
@@ -52,8 +52,7 @@ class ListEngagementResponses extends ListRecords
         return $table
             ->columns([
                 IdColumn::make(),
-                TextColumn::make('content')
-                    ->translateLabel(),
+                TextColumn::make('content'),
             ])
             ->actions([
                 ViewAction::make(),

--- a/app-modules/engagement/src/Filament/Resources/EngagementResponseResource/Pages/ViewEngagementResponse.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResponseResource/Pages/ViewEngagementResponse.php
@@ -59,7 +59,6 @@ class ViewEngagementResponse extends ViewRecord
                     ->schema([
                         TextEntry::make('sender')
                             ->label('Sent By')
-                            ->translateLabel()
                             ->color('primary')
                             ->state(function (EngagementResponse $record): string {
                                 /** @var Student|Prospect $sender */
@@ -79,8 +78,7 @@ class ViewEngagementResponse extends ViewRecord
                                     Prospect::class => ProspectResource::getUrl('view', ['record' => $sender->id]),
                                 };
                             }),
-                        TextEntry::make('content')
-                            ->translateLabel(),
+                        TextEntry::make('content'),
                     ])
                     ->columns(),
             ]);

--- a/app-modules/interaction/src/Filament/Resources/InteractionResource/Pages/CreateInteraction.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionResource/Pages/CreateInteraction.php
@@ -97,7 +97,6 @@ class CreateInteraction extends CreateRecord
             ->schema([
                 MorphToSelect::make('interactable')
                     ->label('Related To')
-                    ->translateLabel()
                     ->searchable()
                     ->required()
                     ->types([

--- a/app-modules/interaction/src/Filament/Resources/InteractionResource/Pages/EditInteraction.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionResource/Pages/EditInteraction.php
@@ -67,7 +67,6 @@ class EditInteraction extends EditRecord
             ->schema([
                 MorphToSelect::make('interactable')
                     ->label('Related To')
-                    ->translateLabel()
                     ->searchable()
                     ->required()
                     ->types([

--- a/app-modules/interaction/src/Filament/Resources/InteractionStatusResource.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionStatusResource.php
@@ -71,7 +71,6 @@ class InteractionStatusResource extends Resource
                     ->placeholder('Interaction Status Name'),
                 Select::make('color')
                     ->label('Color')
-                    ->translateLabel()
                     ->searchable()
                     ->options(InteractionStatusColorOptions::class)
                     ->required()

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseArticleResource/Pages/ListKnowledgeBaseArticles.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseArticleResource/Pages/ListKnowledgeBaseArticles.php
@@ -74,25 +74,20 @@ class ListKnowledgeBaseArticles extends ListRecords
                 IdColumn::make(),
                 TextColumn::make('title')
                     ->label('Title')
-                    ->translateLabel()
                     ->searchable()
                     ->sortable(),
                 TextColumn::make('quality.name')
                     ->label('Quality')
-                    ->translateLabel()
                     ->sortable(),
                 TextColumn::make('status.name')
                     ->label('Status')
-                    ->translateLabel()
                     ->sortable(),
                 TextColumn::make('public')
                     ->label('Public')
-                    ->translateLabel()
                     ->sortable()
                     ->formatStateUsing(fn (bool $state): string => $state ? 'Yes' : 'No'),
                 TextColumn::make('category.name')
                     ->label('Category')
-                    ->translateLabel()
                     ->sortable(),
                 TextColumn::make('views_count')
                     ->label('Views')

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseQualityResource/Pages/ViewKnowledgeBaseQuality.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseQualityResource/Pages/ViewKnowledgeBaseQuality.php
@@ -54,8 +54,7 @@ class ViewKnowledgeBaseQuality extends ViewRecord
                 Section::make()
                     ->schema([
                         TextEntry::make('name')
-                            ->label('Name')
-                            ->translateLabel(),
+                            ->label('Name'),
                     ])
                     ->columns(),
             ]);

--- a/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseStatusResource/Pages/ViewKnowledgeBaseStatus.php
+++ b/app-modules/knowledge-base/src/Filament/Resources/KnowledgeBaseStatusResource/Pages/ViewKnowledgeBaseStatus.php
@@ -54,8 +54,7 @@ class ViewKnowledgeBaseStatus extends ViewRecord
                 Section::make()
                     ->schema([
                         TextEntry::make('name')
-                            ->label('Name')
-                            ->translateLabel(),
+                            ->label('Name'),
                     ])
                     ->columns(),
             ]);

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
@@ -89,23 +89,19 @@ class ListProspects extends ListRecords implements HasBulkEngagementAction
                     ->sortable(),
                 TextColumn::make('email')
                     ->label('Email')
-                    ->translateLabel()
                     ->searchable()
                     ->sortable(),
                 TextColumn::make('mobile')
                     ->label('Mobile')
-                    ->translateLabel()
                     ->searchable()
                     ->sortable(),
                 TextColumn::make('status.name')
                     ->badge()
-                    ->translateLabel()
                     ->color(fn (Prospect $record) => $record->status->color->value)
                     ->toggleable()
                     ->sortable(['sort']),
                 TextColumn::make('source.name')
                     ->label('Source')
-                    ->translateLabel()
                     ->toggleable()
                     ->sortable(),
                 TextColumn::make('created_at')

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectApplicationSubmissions.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectApplicationSubmissions.php
@@ -87,7 +87,6 @@ class ManageProspectApplicationSubmissions extends ManageRelatedRecords
                     ->url(fn (ApplicationSubmission $record): string => FormResource::getUrl('edit', ['record' => $record->submissible])),
                 TextColumn::make('state')
                     ->badge()
-                    ->translateLabel()
                     ->state(function (ApplicationSubmission $record) {
                         return $record->state->name;
                     })

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ViewProspect.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ViewProspect.php
@@ -66,45 +66,33 @@ class ViewProspect extends ViewRecord
                 Section::make('Demographics')
                     ->schema([
                         TextEntry::make('first_name')
-                            ->label('First Name')
-                            ->translateLabel(),
+                            ->label('First Name'),
                         TextEntry::make('last_name')
-                            ->label('Last Name')
-                            ->translateLabel(),
+                            ->label('Last Name'),
                         TextEntry::make(Prospect::displayNameKey())
-                            ->label('Full Name')
-                            ->translateLabel(),
+                            ->label('Full Name'),
                         TextEntry::make('preferred')
-                            ->label('Preferred Name')
-                            ->translateLabel(),
+                            ->label('Preferred Name'),
                         TextEntry::make('birthdate')
-                            ->label('Birthdate')
-                            ->translateLabel(),
+                            ->label('Birthdate'),
                         TextEntry::make('hsgrad')
-                            ->label('High School Grad')
-                            ->translateLabel(),
+                            ->label('High School Grad'),
                     ])
                     ->columns(2),
                 Section::make('Contact Information')
                     ->schema([
                         TextEntry::make('email')
-                            ->label('Email')
-                            ->translateLabel(),
+                            ->label('Email'),
                         TextEntry::make('email_2')
-                            ->label('Alternate Email')
-                            ->translateLabel(),
+                            ->label('Alternate Email'),
                         TextEntry::make('mobile')
-                            ->label('Mobile')
-                            ->translateLabel(),
+                            ->label('Mobile'),
                         TextEntry::make('phone')
-                            ->label('Phone')
-                            ->translateLabel(),
+                            ->label('Phone'),
                         TextEntry::make('address')
-                            ->label('Address')
-                            ->translateLabel(),
+                            ->label('Address'),
                         TextEntry::make('address_2')
-                            ->label('Address 2')
-                            ->translateLabel(),
+                            ->label('Address 2'),
                         TextEntry::make('address_3')
                             ->label('Address 3'),
                         TextEntry::make('city')
@@ -118,14 +106,11 @@ class ViewProspect extends ViewRecord
                 Section::make('Classification')
                     ->schema([
                         TextEntry::make('status.name')
-                            ->label('Status')
-                            ->translateLabel(),
+                            ->label('Status'),
                         TextEntry::make('source.name')
-                            ->label('Source')
-                            ->translateLabel(),
+                            ->label('Source'),
                         TextEntry::make('description')
                             ->label('Description')
-                            ->translateLabel()
                             ->columnSpanFull(),
                     ])
                     ->columns(2),
@@ -142,8 +127,7 @@ class ViewProspect extends ViewRecord
                 Section::make('Record Details')
                     ->schema([
                         TextEntry::make('createdBy.name')
-                            ->label('Created By')
-                            ->translateLabel(),
+                            ->label('Created By'),
                     ])
                     ->columns(2),
             ]);

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementResponsesRelationManager.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/RelationManagers/EngagementResponsesRelationManager.php
@@ -58,8 +58,7 @@ class EngagementResponsesRelationManager extends RelationManager
     {
         return $infolist
             ->schema([
-                TextEntry::make('content')
-                    ->translateLabel(),
+                TextEntry::make('content'),
                 TextEntry::make('sent_at')
                     ->dateTime('Y-m-d H:i:s'),
             ]);

--- a/app-modules/prospect/src/Filament/Resources/ProspectSourceResource/Pages/CreateProspectSource.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectSourceResource/Pages/CreateProspectSource.php
@@ -51,7 +51,6 @@ class CreateProspectSource extends CreateRecord
             ->schema([
                 TextInput::make('name')
                     ->label('Name')
-                    ->translateLabel()
                     ->required()
                     ->string(),
             ]);

--- a/app-modules/prospect/src/Filament/Resources/ProspectSourceResource/Pages/EditProspectSource.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectSourceResource/Pages/EditProspectSource.php
@@ -52,7 +52,6 @@ class EditProspectSource extends EditRecord
             ->schema([
                 TextInput::make('name')
                     ->label('Name')
-                    ->translateLabel()
                     ->required()
                     ->string(),
             ]);

--- a/app-modules/prospect/src/Filament/Resources/ProspectSourceResource/Pages/ViewProspectSource.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectSourceResource/Pages/ViewProspectSource.php
@@ -54,8 +54,7 @@ class ViewProspectSource extends ViewRecord
                 Section::make()
                     ->schema([
                         TextEntry::make('name')
-                            ->label('Name')
-                            ->translateLabel(),
+                            ->label('Name'),
                     ])
                     ->columns(),
             ]);

--- a/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
@@ -55,14 +55,11 @@ class ViewProspectStatus extends ViewRecord
                 Section::make()
                     ->schema([
                         TextEntry::make('name')
-                            ->label('Name')
-                            ->translateLabel(),
+                            ->label('Name'),
                         TextEntry::make('classification')
-                            ->label('Classification')
-                            ->translateLabel(),
+                            ->label('Classification'),
                         TextEntry::make('color')
                             ->label('Color')
-                            ->translateLabel()
                             ->badge()
                             ->color(fn (ProspectStatus $prospectStatus) => $prospectStatus->color->value),
                         TextEntry::make('sort')

--- a/app-modules/service-management/src/Filament/Concerns/ServiceRequestAssignmentInfolist.php
+++ b/app-modules/service-management/src/Filament/Concerns/ServiceRequestAssignmentInfolist.php
@@ -49,7 +49,6 @@ trait ServiceRequestAssignmentInfolist
         return [
             TextEntry::make('serviceRequest.service_request_number')
                 ->label('Service Request')
-                ->translateLabel()
                 ->url(fn (ServiceRequestAssignment $serviceRequestAssignment): string => ServiceRequestResource::getUrl('view', ['record' => $serviceRequestAssignment->serviceRequest]))
                 ->color('primary'),
             TextEntry::make('user.name')

--- a/app-modules/service-management/src/Filament/Concerns/ServiceRequestHistoryInfolist.php
+++ b/app-modules/service-management/src/Filament/Concerns/ServiceRequestHistoryInfolist.php
@@ -48,7 +48,6 @@ trait ServiceRequestHistoryInfolist
         return [
             TextEntry::make('serviceRequest.service_request_number')
                 ->label('Service Request')
-                ->translateLabel()
                 ->url(fn (ServiceRequestHistory $serviceRequestHistory): string => ServiceRequestResource::getUrl('view', ['record' => $serviceRequestHistory->serviceRequest]))
                 ->color('primary'),
             TextEntry::make('getUpdates')

--- a/app-modules/service-management/src/Filament/Concerns/ServiceRequestUpdateInfolist.php
+++ b/app-modules/service-management/src/Filament/Concerns/ServiceRequestUpdateInfolist.php
@@ -50,7 +50,6 @@ trait ServiceRequestUpdateInfolist
         return [
             TextEntry::make('serviceRequest.service_request_number')
                 ->label('Service Request')
-                ->translateLabel()
                 ->url(fn (ServiceRequestUpdate $serviceRequestUpdate): string => ServiceRequestResource::getUrl('view', ['record' => $serviceRequestUpdate->serviceRequest]))
                 ->color('primary'),
             IconEntry::make('internal')

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestResource/RelationManagers/ServiceRequestUpdatesRelationManager.php
@@ -85,7 +85,6 @@ class ServiceRequestUpdatesRelationManager extends RelationManager
                 IdColumn::make(),
                 TextColumn::make('update')
                     ->label('Update')
-                    ->translateLabel()
                     ->words(6),
                 IconColumn::make('internal')
                     ->boolean(),

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestStatusResource/Pages/ViewServiceRequestStatus.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestStatusResource/Pages/ViewServiceRequestStatus.php
@@ -55,14 +55,11 @@ class ViewServiceRequestStatus extends ViewRecord
                 Section::make()
                     ->schema([
                         TextEntry::make('name')
-                            ->label('Name')
-                            ->translateLabel(),
+                            ->label('Name'),
                         TextEntry::make('classification')
-                            ->label('Classification')
-                            ->translateLabel(),
+                            ->label('Classification'),
                         TextEntry::make('color')
                             ->label('Color')
-                            ->translateLabel()
                             ->badge()
                             ->color(fn (ServiceRequestStatus $serviceRequestStatus) => $serviceRequestStatus->color->value),
                     ])

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource.php
@@ -69,7 +69,6 @@ class ServiceRequestUpdateResource extends Resource
                     ->relationship('serviceRequest', 'id')
                     ->preload()
                     ->label('Service Request')
-                    ->translateLabel()
                     ->required()
                     ->exists(
                         table: (new ServiceRequest())->getTable(),
@@ -148,11 +147,9 @@ class ServiceRequestUpdateResource extends Resource
             ])
             ->filters([
                 Tables\Filters\TernaryFilter::make('internal')
-                    ->label('Internal')
-                    ->translateLabel(),
+                    ->label('Internal'),
                 Tables\Filters\SelectFilter::make('direction')
                     ->label('Direction')
-                    ->translateLabel()
                     ->options(ServiceRequestUpdateDirection::class),
             ])
             ->actions([

--- a/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource/Pages/ViewServiceRequestUpdate.php
+++ b/app-modules/service-management/src/Filament/Resources/ServiceRequestUpdateResource/Pages/ViewServiceRequestUpdate.php
@@ -59,7 +59,6 @@ class ViewServiceRequestUpdate extends ViewRecord
                     ->schema([
                         TextEntry::make('serviceRequest.service_request_number')
                             ->label('Service Request')
-                            ->translateLabel()
                             ->url(fn (ServiceRequestUpdate $serviceRequestUpdate): string => ServiceRequestResource::getUrl('view', ['record' => $serviceRequestUpdate->serviceRequest]))
                             ->color('primary'),
                         IconEntry::make('internal')

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentApplicationSubmissions.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/ManageStudentApplicationSubmissions.php
@@ -84,7 +84,6 @@ class ManageStudentApplicationSubmissions extends ManageRelatedRecords
                     ->url(fn (ApplicationSubmission $record): string => ApplicationResource::getUrl('edit', ['record' => $record->submissible])),
                 TextColumn::make('state')
                     ->badge()
-                    ->translateLabel()
                     ->state(function (ApplicationSubmission $record) {
                         return $record->state->name;
                     })

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementResponsesRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementResponsesRelationManager.php
@@ -58,8 +58,7 @@ class EngagementResponsesRelationManager extends RelationManager
     {
         return $infolist
             ->schema([
-                TextEntry::make('content')
-                    ->translateLabel(),
+                TextEntry::make('content'),
                 TextEntry::make('sent_at')
                     ->dateTime('Y-m-d H:i:s'),
             ]);

--- a/app-modules/webhook/src/Filament/Resources/InboundWebhookResource/Pages/ViewInboundWebhook.php
+++ b/app-modules/webhook/src/Filament/Resources/InboundWebhookResource/Pages/ViewInboundWebhook.php
@@ -52,14 +52,10 @@ class ViewInboundWebhook extends ViewRecord
             ->schema([
                 Section::make()
                     ->schema([
-                        TextEntry::make('source')
-                            ->translateLabel(),
-                        TextEntry::make('event')
-                            ->translateLabel(),
-                        TextEntry::make('url')
-                            ->translateLabel(),
+                        TextEntry::make('source'),
+                        TextEntry::make('event'),
+                        TextEntry::make('url'),
                         TextEntry::make('payload')
-                            ->translateLabel()
                             ->limit(100),
                     ])
                     ->columns(),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-80

### Technical Description

> Removed the translateLabel() from the app except AdminPanelProvider.php.

### Any deployment steps required?

> No.

### Are any Feature Flags Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
