### PR TITLE
[ADVAPP-840]: Modify local configuration to allow containers to reach each other via subdomain

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -42,7 +42,10 @@ services:
     volumes:
       - '.:/var/www/html'
     networks:
-      - cgbs-development
+      cgbs-development:
+        ipv4_address: 172.16.1.3
+    dns:
+      - 172.16.1.1
     depends_on:
       - advisingapp-redis
       - advisingapp-mailpit


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-840

### Technical Description

Adds needed configuration to work with changes to the `traefik` repo, allowing the app containers to communicate via subdomain.

### Any deployment steps required?

No

### Are any Feature Flags Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
