### PR TITLE
[ADVAPP-872]: Fix the noWidgetData view which has broken height

### DIFF
--- a/app-modules/report/src/Filament/Widgets/PromptsByCategoryDoughnutChart.php
+++ b/app-modules/report/src/Filament/Widgets/PromptsByCategoryDoughnutChart.php
@@ -60,7 +60,7 @@ class PromptsByCategoryDoughnutChart extends ChartReportWidget
         $data = $data->filter();
 
         if (! count($data)) {
-            return view('livewire.noWidgetData');
+            return view('livewire.no-widget-data');
         }
 
         return view(static::$view, $this->getViewData());

--- a/app-modules/report/src/Filament/Widgets/SpecialActionsDoughnutChart.php
+++ b/app-modules/report/src/Filament/Widgets/SpecialActionsDoughnutChart.php
@@ -58,7 +58,7 @@ class SpecialActionsDoughnutChart extends ChartReportWidget
         [$emailCount, $cloneCount] = $this->getData()['datasets'][0]['data'];
 
         if ($emailCount == 0 && $cloneCount == 0) {
-            return view('livewire.noWidgetData');
+            return view('livewire.no-widget-data');
         }
 
         return view(static::$view, $this->getViewData());

--- a/resources/views/livewire/no-widget-data.blade.php
+++ b/resources/views/livewire/no-widget-data.blade.php
@@ -32,17 +32,15 @@
 </COPYRIGHT>
 --}}
 @php
-    use Filament\Support\Facades\FilamentView;
-
-    $color = $this->getColor();
     $heading = $this->getHeading();
 @endphp
-<x-filament-widgets::widget class="fi-wi-chart">
+
+<x-filament-widgets::widget>
     <x-filament::section
-        class="relative h-full pt-20"
+        class="flex h-full flex-col [&_.fi-section-content-ctn]:flex-1 [&_.fi-section-content]:h-full"
         :heading="$heading"
     >
-        <div class="inset-0 flex items-center justify-center lg:absolute">
+        <div class="flex h-full items-center justify-center pb-3 text-sm text-gray-600 dark:text-gray-500">
             Insufficient Data
         </div>
     </x-filament::section>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-872

### Technical Description

Replaces the CSS classes used to make this section full height, with a centered message of muted styling.

See screenshots in ticket.

### Any deployment steps required?

No

### Are any Feature Flags Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
