### PR TITLE
[ADVAPP-835]: When attempting to login via SSO and the directory information case does not match the in product user email case, it generates a user not found error instead of logging the user in

### DIFF
--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -45,6 +45,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
 use Filament\Notifications\Notification;
 use AdvisingApp\Authorization\Enums\SocialiteProvider;
+use Illuminate\Database\Query\Expression;
 
 class SocialiteController extends Controller
 {
@@ -76,7 +77,7 @@ class SocialiteController extends Controller
 
         /** @var User $user */
         $user = User::query()
-            ->where('email', $socialiteUser->getEmail())
+            ->where(new Expression('lower(email)'), strtolower($socialiteUser->getEmail()))
             ->first();
 
         if (! $user?->is_external) {

--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -44,8 +44,8 @@ use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
 use Filament\Notifications\Notification;
-use AdvisingApp\Authorization\Enums\SocialiteProvider;
 use Illuminate\Database\Query\Expression;
+use AdvisingApp\Authorization\Enums\SocialiteProvider;
 
 class SocialiteController extends Controller
 {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-835

### Technical Description

> Solve the issue where attempting to login via SSO , the directory information case does not match the product user email case.

### Any deployment steps required?

> No.

### Are any Feature Flags Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
