### PR TITLE
[ADVAPP-871]: Prevent the deletion of a prompt-type that has an active relationship to a prompt.

### DIFF
--- a/app-modules/ai/src/Filament/Resources/PromptTypeResource/Pages/ListPromptTypes.php
+++ b/app-modules/ai/src/Filament/Resources/PromptTypeResource/Pages/ListPromptTypes.php
@@ -38,9 +38,11 @@ namespace AdvisingApp\Ai\Filament\Resources\PromptTypeResource\Pages;
 
 use Filament\Tables\Table;
 use Filament\Actions\CreateAction;
+use AdvisingApp\Ai\Models\PromptType;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Notifications\Notification;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Actions\DeleteAction;
@@ -75,7 +77,20 @@ class ListPromptTypes extends ListRecords
             ])
             ->bulkActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->action(function ($records) {
+                            $deletedPromptTypesCount = PromptType::query()
+                                ->whereKey($records)
+                                ->whereDoesntHave('prompts')
+                                ->delete();
+
+                            Notification::make()
+                                ->title('Deleted ' . $deletedPromptTypesCount . ' prompt types')
+                                ->body(($deletedPromptTypesCount < $records->count()) ? ($records->count() - $deletedPromptTypesCount) . ' prompt types were not deleted because they have prompts.' : null)
+                                ->success()
+                                ->send();
+                        })
+                        ->fetchSelectedRecords(false),
                 ]),
             ]);
     }

--- a/app-modules/ai/src/Policies/PromptTypePolicy.php
+++ b/app-modules/ai/src/Policies/PromptTypePolicy.php
@@ -90,6 +90,10 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, PromptType $promptType): Response
     {
+        if ($promptType->prompts()->exists()) {
+            return Response::deny('The prompt type cannot be deleted because it is associated with a prompt.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["prompt_type.{$promptType->id}.delete"],
             denyResponse: 'You do not have permission to delete this prompt type.'
@@ -106,6 +110,10 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, PromptType $promptType): Response
     {
+        if ($promptType->prompts()->exists()) {
+            return Response::deny('The prompt type cannot be deleted because it is associated with a prompt.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["prompt_type.{$promptType->id}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this prompt type.'


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-871

### Technical Description

> Prevent the deletion of a prompt-type that has an active relationship to a prompt.

### Any deployment steps required?

> No

### Are any Feature Flags Added?

> No
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
