### PR TITLE
[ADVAPP-911]: When a user attempts to configure a custom assistant or institutional assistant with an assigned Canyon 4o mini model, the option fails to present

### DIFF
--- a/app-modules/ai/src/Enums/AiApplication.php
+++ b/app-modules/ai/src/Enums/AiApplication.php
@@ -67,6 +67,7 @@ enum AiApplication: string implements HasLabel
                 self::PersonalAssistant => [
                     AiModel::OpenAiGpt35,
                     AiModel::OpenAiGpt4o,
+                    AiModel::OpenAiGpt4oMini,
                 ],
                 self::ReportAssistant => [
                     AiModel::OpenAiGpt4,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-911

### Technical Description

Ensures that 4o mini is an option in Institutional Assistant and Custom Assistant Model selection.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
