### PR TITLE
[ADVAPP-915]: After uploading a file for the AI Assistants using Canyon's GPT 4o and GPT 4o Mini models, the AI assistants are unable to retrieve information.

### DIFF
--- a/app-modules/integration-open-ai/src/Jobs/UploadFilesToAssistant.php
+++ b/app-modules/integration-open-ai/src/Jobs/UploadFilesToAssistant.php
@@ -88,7 +88,6 @@ class UploadFilesToAssistant
             );
         } else {
             $service->createVectorStoreFilesBatch(
-                service: $this->service,
                 vectorStoreId: $vectorStoreId,
                 fileIds: $assistantFiles->pluck('file_id')->toArray()
             );
@@ -99,7 +98,6 @@ class UploadFilesToAssistant
         }
 
         $service->awaitVectorStoreProcessing(
-            service: $this->service,
             vectorStore: $vectorStore,
         );
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-915

### Technical Description

Fixes issues with assistant file upload.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
