### PR TITLE
[ADVAPP-852]: Cleanup GDPR Tiptap editor

### DIFF
--- a/app-modules/portal/src/Settings/PortalSettings.php
+++ b/app-modules/portal/src/Settings/PortalSettings.php
@@ -91,7 +91,23 @@ class PortalSettings extends SettingsWithMedia
 
     public ?string $knowledge_management_portal_authorized_domain = null;
 
-    public string|array $gdpr_banner_text = "We use cookies to personalize content, to provide social media features, and to analyze our traffic. We also share information about your use of our site with our partners who may combine it with other information that you've provided to them or that they've collected from your use of their services.";
+    public array $gdpr_banner_text = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'attrs' => [
+                    'textAlign' => 'start',
+                ],
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'We use cookies to personalize content, to provide social media features, and to analyze our traffic. We also share information about your use of our site with our partners who may combine it with other information that you\'ve provided to them or that they\'ve collected from your use of their services.',
+                    ],
+                ],
+            ],
+        ],
+    ];
 
     public GdprBannerButtonLabel $gdpr_banner_button_label = GdprBannerButtonLabel::AllowCookies;
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-852

### Technical Description

Fixes `gdpr_banner_text` property of the GDPR text settings to match the new data type for being a TipTapEditor.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
