### PR TITLE
[ADVAPP-910]: Fix path in FeatureFlag stub

### DIFF
--- a/stubs/feature.stub
+++ b/stubs/feature.stub
@@ -2,7 +2,7 @@
 
 namespace {{ namespace }};
 
-use App\Features\AbstractFeatureFlag;
+use App\Support\AbstractFeatureFlag;
 
 class {{ class }} extends AbstractFeatureFlag
 {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-910

### Technical Description

Fix path defined in stub for Feature Flags.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
