### PR TITLE
[ADVAPP-827]: After a prospect is converted to a student, place them in a converted status

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1,39 +1,5 @@
 <?php
 
-/*
-<COPYRIGHT>
-
-    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
-
-    Advising App™ is licensed under the Elastic License 2.0. For more details,
-    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
-
-    Notice:
-
-    - You may not provide the software to third parties as a hosted or managed
-      service, where the service provides users with access to any substantial set of
-      the features or functionality of the software.
-    - You may not move, change, disable, or circumvent the license key functionality
-      in the software, and you may not remove or obscure any functionality in the
-      software that is protected by the license key.
-    - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
-      to applicable law.
-    - Canyon GBS LLC respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
-      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
-      vigorously.
-    - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS LLC.
-    - Use of this software implies agreement to the license terms and conditions as stated
-      in the Elastic License 2.0.
-
-    For more information or inquiries please visit our website at
-    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
-
-</COPYRIGHT>
-*/
-
 // @formatter:off
 // phpcs:ignoreFile
 /**
@@ -2503,6 +2469,7 @@ namespace AdvisingApp\Interaction\Models{
  * @property-read \AdvisingApp\Interaction\Models\InteractionOutcome|null $outcome
  * @property-read \AdvisingApp\Interaction\Models\InteractionRelation|null $relation
  * @property-read \AdvisingApp\Interaction\Models\InteractionStatus|null $status
+ * @property-read \AdvisingApp\Timeline\Models\Timeline|null $timelineRecord
  * @property-read \AdvisingApp\Interaction\Models\InteractionType|null $type
  * @property-read \App\Models\User|null $user
  * @method static \AdvisingApp\Interaction\Database\Factories\InteractionFactory factory($count = null, $state = [])
@@ -3776,6 +3743,8 @@ namespace AdvisingApp\Prospect\Models{
  * @property-read int|null $ordered_engagement_responses_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\Engagement\Models\Engagement> $orderedEngagements
  * @property-read int|null $ordered_engagements_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\Interaction\Models\Interaction> $orderedInteractions
+ * @property-read int|null $ordered_interactions_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\ServiceManagement\Models\ServiceRequest> $serviceRequests
  * @property-read int|null $service_requests_count
  * @property-read \AdvisingApp\Prospect\Models\ProspectSource $source
@@ -3877,6 +3846,7 @@ namespace AdvisingApp\Prospect\Models{
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
  * @property int $sort
+ * @property bool $is_system_protected
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\Audit\Models\Audit> $audits
  * @property-read int|null $audits_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\Prospect\Models\Prospect> $prospects
@@ -3891,6 +3861,7 @@ namespace AdvisingApp\Prospect\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|ProspectStatus whereCreatedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|ProspectStatus whereDeletedAt($value)
  * @method static \Illuminate\Database\Eloquent\Builder|ProspectStatus whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ProspectStatus whereIsSystemProtected($value)
  * @method static \Illuminate\Database\Eloquent\Builder|ProspectStatus whereName($value)
  * @method static \Illuminate\Database\Eloquent\Builder|ProspectStatus whereSort($value)
  * @method static \Illuminate\Database\Eloquent\Builder|ProspectStatus whereUpdatedAt($value)
@@ -4252,6 +4223,8 @@ namespace AdvisingApp\ServiceManagement\Models{
  * @property-read int|null $interactions_count
  * @property-read \AdvisingApp\ServiceManagement\Models\ServiceRequestUpdate|null $latestInboundServiceRequestUpdate
  * @property-read \AdvisingApp\ServiceManagement\Models\ServiceRequestUpdate|null $latestOutboundServiceRequestUpdate
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\Interaction\Models\Interaction> $orderedInteractions
+ * @property-read int|null $ordered_interactions_count
  * @property-read \AdvisingApp\ServiceManagement\Models\ServiceRequestPriority|null $priority
  * @property-read \AdvisingApp\ServiceManagement\Models\ServiceRequestFormSubmission|null $serviceRequestFormSubmission
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\ServiceManagement\Models\ServiceRequestUpdate> $serviceRequestUpdates
@@ -4758,19 +4731,12 @@ namespace AdvisingApp\StudentDataModel\Models{
  * AdvisingApp\StudentDataModel\Models\Enrollment
  *
  * @property string $sisid
- * @property string $acad_career
- * @property string $division
- * @property string $semester
- * @property string $class_nbr
- * @property string $subject
- * @property string $catalog_nbr
- * @property string $enrl_status_reason
- * @property string $enrl_add_dt
- * @property string $enrl_drop_dt
- * @property string $crse_grade_off
- * @property int $unt_taken
- * @property int $unt_earned
- * @property \Illuminate\Support\Carbon $last_upd_dt_stmp
+ * @property string|null $division
+ * @property string|null $class_nbr
+ * @property string|null $crse_grade_off
+ * @property int|null $unt_taken
+ * @property int|null $unt_earned
+ * @property \Illuminate\Support\Carbon|null $last_upd_dt_stmp
  * @property string|null $section
  * @property string|null $name
  * @property string|null $department
@@ -4785,66 +4751,26 @@ namespace AdvisingApp\StudentDataModel\Models{
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment query()
- * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereAcadCareer($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereCatalogNbr($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereClassNbr($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereCrseGradeOff($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereDepartment($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereDivision($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereEndDate($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereEnrlAddDt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereEnrlDropDt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereEnrlStatusReason($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereFacultyEmail($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereFacultyName($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereLastUpdDtStmp($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereName($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereSection($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereSemester($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereSemesterCode($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereSemesterName($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereSisid($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereStartDate($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereSubject($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereUntEarned($value)
  * @method static \Illuminate\Database\Eloquent\Builder|Enrollment whereUntTaken($value)
  * @mixin \Eloquent
  */
 	#[\AllowDynamicProperties]
 	class IdeHelperEnrollment {}
-}
-
-namespace AdvisingApp\StudentDataModel\Models{
-/**
- * AdvisingApp\StudentDataModel\Models\Performance
- *
- * @property string $sisid
- * @property string $acad_career
- * @property string $division
- * @property bool $first_gen
- * @property int $cum_att
- * @property int $cum_ern
- * @property int $pct_ern
- * @property float $cum_gpa
- * @property \Illuminate\Support\Carbon $max_dt
- * @property-read \AdvisingApp\StudentDataModel\Models\Student|null $student
- * @method static \AdvisingApp\StudentDataModel\Database\Factories\PerformanceFactory factory($count = null, $state = [])
- * @method static \Illuminate\Database\Eloquent\Builder|Performance newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|Performance newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder|Performance query()
- * @method static \Illuminate\Database\Eloquent\Builder|Performance whereAcadCareer($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Performance whereCumAtt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Performance whereCumErn($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Performance whereCumGpa($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Performance whereDivision($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Performance whereFirstGen($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Performance whereMaxDt($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Performance wherePctErn($value)
- * @method static \Illuminate\Database\Eloquent\Builder|Performance whereSisid($value)
- * @mixin \Eloquent
- */
-	#[\AllowDynamicProperties]
-	class IdeHelperPerformance {}
 }
 
 namespace AdvisingApp\StudentDataModel\Models{
@@ -4959,8 +4885,8 @@ namespace AdvisingApp\StudentDataModel\Models{
  * @property-read int|null $ordered_engagement_responses_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\Engagement\Models\Engagement> $orderedEngagements
  * @property-read int|null $ordered_engagements_count
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\StudentDataModel\Models\Performance> $performances
- * @property-read int|null $performances_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\Interaction\Models\Interaction> $orderedInteractions
+ * @property-read int|null $ordered_interactions_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\StudentDataModel\Models\Program> $programs
  * @property-read int|null $programs_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \AdvisingApp\Prospect\Models\Prospect> $prospects

--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 // @formatter:off
 // phpcs:ignoreFile
 /**

--- a/app-modules/prospect/database/factories/ProspectStatusFactory.php
+++ b/app-modules/prospect/database/factories/ProspectStatusFactory.php
@@ -36,10 +36,11 @@
 
 namespace AdvisingApp\Prospect\Database\Factories;
 
-use AdvisingApp\Prospect\Models\ProspectStatus;
-use Illuminate\Database\Eloquent\Factories\Factory;
 use AdvisingApp\Prospect\Enums\ProspectStatusColorOptions;
 use AdvisingApp\Prospect\Enums\SystemProspectClassification;
+use AdvisingApp\Prospect\Models\ProspectStatus;
+use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
  * @extends Factory<ProspectStatus>
@@ -52,7 +53,9 @@ class ProspectStatusFactory extends Factory
             'classification' => $this->faker->randomElement(SystemProspectClassification::cases()),
             'name' => $this->faker->word,
             'color' => $this->faker->randomElement(ProspectStatusColorOptions::cases()),
-            'is_system_protected' => false,
+            ... ProspectStatusSystemProtectionAndAutoAssignment::active() ? [
+                'is_system_protected' => false,
+            ] : [],
         ];
     }
 }

--- a/app-modules/prospect/database/factories/ProspectStatusFactory.php
+++ b/app-modules/prospect/database/factories/ProspectStatusFactory.php
@@ -36,11 +36,11 @@
 
 namespace AdvisingApp\Prospect\Database\Factories;
 
+use AdvisingApp\Prospect\Models\ProspectStatus;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use AdvisingApp\Prospect\Enums\ProspectStatusColorOptions;
 use AdvisingApp\Prospect\Enums\SystemProspectClassification;
-use AdvisingApp\Prospect\Models\ProspectStatus;
 use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
-use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
  * @extends Factory<ProspectStatus>
@@ -53,7 +53,7 @@ class ProspectStatusFactory extends Factory
             'classification' => $this->faker->randomElement(SystemProspectClassification::cases()),
             'name' => $this->faker->word,
             'color' => $this->faker->randomElement(ProspectStatusColorOptions::cases()),
-            ... ProspectStatusSystemProtectionAndAutoAssignment::active() ? [
+            ...ProspectStatusSystemProtectionAndAutoAssignment::active() ? [
                 'is_system_protected' => false,
             ] : [],
         ];

--- a/app-modules/prospect/database/factories/ProspectStatusFactory.php
+++ b/app-modules/prospect/database/factories/ProspectStatusFactory.php
@@ -52,6 +52,7 @@ class ProspectStatusFactory extends Factory
             'classification' => $this->faker->randomElement(SystemProspectClassification::cases()),
             'name' => $this->faker->word,
             'color' => $this->faker->randomElement(ProspectStatusColorOptions::cases()),
+            'is_system_protected' => false,
         ];
     }
 }

--- a/app-modules/prospect/database/migrations/2024_10_08_153706_add_is_system_protected_column_to_prospect_statuses_table.php
+++ b/app-modules/prospect/database/migrations/2024_10_08_153706_add_is_system_protected_column_to_prospect_statuses_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;

--- a/app-modules/prospect/database/migrations/2024_10_08_153706_add_is_system_protected_column_to_prospect_statuses_table.php
+++ b/app-modules/prospect/database/migrations/2024_10_08_153706_add_is_system_protected_column_to_prospect_statuses_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('prospect_statuses', function (Blueprint $table) {
+            $table->boolean('is_system_protected')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('prospect_statuses', function (Blueprint $table) {
+            $table->dropColumn('is_system_protected');
+        });
+    }
+};

--- a/app-modules/prospect/database/migrations/2024_10_08_161832_data_ensure_system_default_prospect_statuses_exist.php
+++ b/app-modules/prospect/database/migrations/2024_10_08_161832_data_ensure_system_default_prospect_statuses_exist.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Migrations\Migration;

--- a/app-modules/prospect/database/migrations/2024_10_08_161832_data_ensure_system_default_prospect_statuses_exist.php
+++ b/app-modules/prospect/database/migrations/2024_10_08_161832_data_ensure_system_default_prospect_statuses_exist.php
@@ -1,0 +1,79 @@
+<?php
+
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        $newStatus = DB::table('prospect_statuses')
+            ->where('classification', 'new')
+            ->where('name', 'New')
+            ->first();
+
+        if ($newStatus === null) {
+            if (! app()->runningUnitTests()) {
+                DB::table('prospect_statuses')->insert([
+                    'id' => (string) Str::orderedUuid(),
+                    'classification' => 'new',
+                    'name' => 'New',
+                    'color' => 'info',
+                    'created_at' => now(),
+                    'sort' => DB::raw('(SELECT MAX(sort) + 1 FROM prospect_statuses)'),
+                ]);
+            }
+        } else {
+            if ($newStatus->is_system_protected !== true) {
+                DB::table('prospect_statuses')
+                    ->where('id', $newStatus->id)
+                    ->update([
+                        'is_system_protected' => true,
+                    ]);
+            }
+        }
+
+        $convertedStatus = DB::table('prospect_statuses')
+            ->where('classification', 'converted')
+            ->where('name', 'Converted')
+            ->first();
+
+        if ($convertedStatus === null) {
+            if (! app()->runningUnitTests()) {
+                DB::table('prospect_statuses')->insert([
+                    'id' => (string) Str::orderedUuid(),
+                    'classification' => 'converted',
+                    'name' => 'Converted',
+                    'color' => 'success',
+                    'created_at' => now(),
+                    'sort' => DB::raw('(SELECT MAX(sort) + 1 FROM prospect_statuses)'),
+                ]);
+            }
+        } else {
+            if ($convertedStatus->is_system_protected !== true) {
+                DB::table('prospect_statuses')
+                    ->where('id', $convertedStatus->id)
+                    ->update([
+                        'is_system_protected' => true,
+                    ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('prospect_statuses')
+            ->where('classification', 'new')
+            ->where('name', 'New')
+            ->update([
+                'is_system_protected' => false,
+            ]);
+
+        DB::table('prospect_statuses')
+            ->where('classification', 'converted')
+            ->where('name', 'Converted')
+            ->update([
+                'is_system_protected' => false,
+            ]);
+    }
+};

--- a/app-modules/prospect/database/migrations/2024_10_08_173948_create_trigger_to_apply_modification_prevention_for_system_protected_prospect_statuses.php
+++ b/app-modules/prospect/database/migrations/2024_10_08_173948_create_trigger_to_apply_modification_prevention_for_system_protected_prospect_statuses.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;

--- a/app-modules/prospect/database/migrations/2024_10_08_173948_create_trigger_to_apply_modification_prevention_for_system_protected_prospect_statuses.php
+++ b/app-modules/prospect/database/migrations/2024_10_08_173948_create_trigger_to_apply_modification_prevention_for_system_protected_prospect_statuses.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('prospect_statuses', function (Blueprint $table) {
+            $table->trigger(
+                name: 'prevent_modification_of_system_protected_rows',
+                action: 'prevent_modification_of_system_protected_rows()',
+                fire: 'BEFORE UPDATE OR DELETE',
+            )
+                ->forEachRow()
+                ->replace(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('prospect_statuses', function (Blueprint $table) {
+            $table->dropTriggerIfExists('prevent_modification_of_system_protected_rows');
+        });
+    }
+};

--- a/app-modules/prospect/database/migrations/2024_10_08_174319_data_activate_feature_flag_prospect_status_system_protection_and_auto_assignment.php
+++ b/app-modules/prospect/database/migrations/2024_10_08_174319_data_activate_feature_flag_prospect_status_system_protection_and_auto_assignment.php
@@ -1,12 +1,9 @@
 <?php
 
-use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
+use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         ProspectStatusSystemProtectionAndAutoAssignment::activate();

--- a/app-modules/prospect/database/migrations/2024_10_08_174319_data_activate_feature_flag_prospect_status_system_protection_and_auto_assignment.php
+++ b/app-modules/prospect/database/migrations/2024_10_08_174319_data_activate_feature_flag_prospect_status_system_protection_and_auto_assignment.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
 

--- a/app-modules/prospect/database/migrations/2024_10_08_174319_data_activate_feature_flag_prospect_status_system_protection_and_auto_assignment.php
+++ b/app-modules/prospect/database/migrations/2024_10_08_174319_data_activate_feature_flag_prospect_status_system_protection_and_auto_assignment.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        ProspectStatusSystemProtectionAndAutoAssignment::activate();
+    }
+
+    public function down(): void
+    {
+        ProspectStatusSystemProtectionAndAutoAssignment::deactivate();
+    }
+};

--- a/app-modules/prospect/database/seeders/ProspectStatusSeeder.php
+++ b/app-modules/prospect/database/seeders/ProspectStatusSeeder.php
@@ -36,11 +36,11 @@
 
 namespace AdvisingApp\Prospect\Database\Seeders;
 
+use Illuminate\Database\Seeder;
+use AdvisingApp\Prospect\Models\ProspectStatus;
 use AdvisingApp\Prospect\Enums\ProspectStatusColorOptions;
 use AdvisingApp\Prospect\Enums\SystemProspectClassification;
-use AdvisingApp\Prospect\Models\ProspectStatus;
 use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
-use Illuminate\Database\Seeder;
 
 class ProspectStatusSeeder extends Seeder
 {
@@ -53,7 +53,7 @@ class ProspectStatusSeeder extends Seeder
                         'classification' => SystemProspectClassification::New,
                         'name' => 'New',
                         'color' => ProspectStatusColorOptions::Info->value,
-                        ... ProspectStatusSystemProtectionAndAutoAssignment::active() ? [
+                        ...ProspectStatusSystemProtectionAndAutoAssignment::active() ? [
                             'is_system_protected' => true,
                         ] : [],
                     ],
@@ -71,7 +71,7 @@ class ProspectStatusSeeder extends Seeder
                         'classification' => SystemProspectClassification::Converted,
                         'name' => 'Converted',
                         'color' => ProspectStatusColorOptions::Success->value,
-                        ... ProspectStatusSystemProtectionAndAutoAssignment::active() ? [
+                        ...ProspectStatusSystemProtectionAndAutoAssignment::active() ? [
                             'is_system_protected' => true,
                         ] : [],
                     ],

--- a/app-modules/prospect/database/seeders/ProspectStatusSeeder.php
+++ b/app-modules/prospect/database/seeders/ProspectStatusSeeder.php
@@ -52,6 +52,7 @@ class ProspectStatusSeeder extends Seeder
                         'classification' => SystemProspectClassification::New,
                         'name' => 'New',
                         'color' => ProspectStatusColorOptions::Info->value,
+                        'is_system_protected' => true,
                     ],
                     [
                         'classification' => SystemProspectClassification::Assigned,
@@ -67,6 +68,7 @@ class ProspectStatusSeeder extends Seeder
                         'classification' => SystemProspectClassification::Converted,
                         'name' => 'Converted',
                         'color' => ProspectStatusColorOptions::Success->value,
+                        'is_system_protected' => true,
                     ],
                     [
                         'classification' => SystemProspectClassification::Recycled,

--- a/app-modules/prospect/database/seeders/ProspectStatusSeeder.php
+++ b/app-modules/prospect/database/seeders/ProspectStatusSeeder.php
@@ -36,10 +36,11 @@
 
 namespace AdvisingApp\Prospect\Database\Seeders;
 
-use Illuminate\Database\Seeder;
-use AdvisingApp\Prospect\Models\ProspectStatus;
 use AdvisingApp\Prospect\Enums\ProspectStatusColorOptions;
 use AdvisingApp\Prospect\Enums\SystemProspectClassification;
+use AdvisingApp\Prospect\Models\ProspectStatus;
+use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
+use Illuminate\Database\Seeder;
 
 class ProspectStatusSeeder extends Seeder
 {
@@ -52,7 +53,9 @@ class ProspectStatusSeeder extends Seeder
                         'classification' => SystemProspectClassification::New,
                         'name' => 'New',
                         'color' => ProspectStatusColorOptions::Info->value,
-                        'is_system_protected' => true,
+                        ... ProspectStatusSystemProtectionAndAutoAssignment::active() ? [
+                            'is_system_protected' => true,
+                        ] : [],
                     ],
                     [
                         'classification' => SystemProspectClassification::Assigned,
@@ -68,7 +71,9 @@ class ProspectStatusSeeder extends Seeder
                         'classification' => SystemProspectClassification::Converted,
                         'name' => 'Converted',
                         'color' => ProspectStatusColorOptions::Success->value,
-                        'is_system_protected' => true,
+                        ... ProspectStatusSystemProtectionAndAutoAssignment::active() ? [
+                            'is_system_protected' => true,
+                        ] : [],
                     ],
                     [
                         'classification' => SystemProspectClassification::Recycled,

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Actions/DisassociateStudent.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Actions/DisassociateStudent.php
@@ -38,6 +38,9 @@ namespace AdvisingApp\Prospect\Filament\Resources\ProspectResource\Actions;
 
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
+use AdvisingApp\Prospect\Models\ProspectStatus;
+use AdvisingApp\Prospect\Enums\SystemProspectClassification;
+use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
 
 class DisassociateStudent extends Action
 {
@@ -53,6 +56,17 @@ class DisassociateStudent extends Action
             ->action(function ($record) {
                 /** @var Prospect $record */
                 $record->student()->dissociate();
+
+                if (ProspectStatusSystemProtectionAndAutoAssignment::active()) {
+                    $record->status()->associate(
+                        ProspectStatus::query()
+                            ->where('classification', SystemProspectClassification::New)
+                            ->where('name', 'New')
+                            ->where('is_system_protected', true)
+                            ->firstOrFail()
+                    );
+                }
+
                 $record->save();
 
                 $this->dispatch('reload-prospect');

--- a/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/EditProspectStatus.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/EditProspectStatus.php
@@ -36,8 +36,9 @@
 
 namespace AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource\Pages;
 
-use Filament\Actions;
 use Filament\Forms\Form;
+use Filament\Actions\ViewAction;
+use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
@@ -80,8 +81,8 @@ class EditProspectStatus extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\ViewAction::make(),
-            Actions\DeleteAction::make(),
+            ViewAction::make(),
+            DeleteAction::make(),
         ];
     }
 }

--- a/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
@@ -36,7 +36,6 @@
 
 namespace AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource\Pages;
 
-use Actions\EditAction;
 use Filament\Infolists\Infolist;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Contracts\View\View;
@@ -47,6 +46,7 @@ use Filament\Infolists\Components\TextEntry;
 use AdvisingApp\Prospect\Models\ProspectStatus;
 use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
 use AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource;
+use Filament\Actions\EditAction;
 
 class ViewProspectStatus extends ViewRecord
 {

--- a/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource\Pages;
 
+use Filament\Actions\EditAction;
 use Filament\Infolists\Infolist;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Contracts\View\View;
@@ -46,7 +47,6 @@ use Filament\Infolists\Components\TextEntry;
 use AdvisingApp\Prospect\Models\ProspectStatus;
 use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
 use AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource;
-use Filament\Actions\EditAction;
 
 class ViewProspectStatus extends ViewRecord
 {

--- a/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
@@ -38,15 +38,34 @@ namespace AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource\Pages;
 
 use Filament\Actions;
 use Filament\Infolists\Infolist;
+use Filament\View\PanelsRenderHook;
+use Illuminate\Contracts\View\View;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Infolists\Components\Section;
+use Filament\Support\Facades\FilamentView;
 use Filament\Infolists\Components\TextEntry;
 use AdvisingApp\Prospect\Models\ProspectStatus;
+use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
 use AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource;
 
 class ViewProspectStatus extends ViewRecord
 {
     protected static string $resource = ProspectStatusResource::class;
+
+    public function boot(): void
+    {
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::PAGE_HEADER_ACTIONS_AFTER,
+            fn (): View => view('components.page-header-action-lock-icon', [
+                'condition' => function () {
+                    return ProspectStatusSystemProtectionAndAutoAssignment::active() && $this->getRecord()?->is_system_protected;
+                },
+                'identifier' => 'prospect_status_system_protected',
+                'tooltip' => 'This record is protected as it is a system status.',
+            ]),
+            scopes: static::class,
+        );
+    }
 
     public function infolist(Infolist $infolist): Infolist
     {

--- a/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectStatusResource/Pages/ViewProspectStatus.php
@@ -36,7 +36,7 @@
 
 namespace AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource\Pages;
 
-use Filament\Actions;
+use Actions\EditAction;
 use Filament\Infolists\Infolist;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Contracts\View\View;
@@ -91,7 +91,7 @@ class ViewProspectStatus extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
-            Actions\EditAction::make(),
+            EditAction::make(),
         ];
     }
 }

--- a/app-modules/prospect/src/Models/ProspectStatus.php
+++ b/app-modules/prospect/src/Models/ProspectStatus.php
@@ -64,6 +64,7 @@ class ProspectStatus extends BaseModel implements Auditable
         'classification' => SystemProspectClassification::class,
         'color' => ProspectStatusColorOptions::class,
         'sort' => 'integer',
+        'is_system_protected' => 'boolean',
     ];
 
     public function prospects(): HasMany

--- a/app-modules/prospect/src/Policies/ProspectStatusPolicy.php
+++ b/app-modules/prospect/src/Policies/ProspectStatusPolicy.php
@@ -40,6 +40,7 @@ use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\Prospect\Models\ProspectStatus;
+use App\Features\ProspectStatusSystemProtectionAndAutoAssignment;
 
 class ProspectStatusPolicy
 {
@@ -78,6 +79,10 @@ class ProspectStatusPolicy
 
     public function update(Authenticatable $authenticatable, ProspectStatus $prospectStatus): Response
     {
+        if (ProspectStatusSystemProtectionAndAutoAssignment::active() && $prospectStatus->is_system_protected) {
+            return Response::deny('You cannot update this prospect status because it is system protected.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["prospect_status.{$prospectStatus->id}.update"],
             denyResponse: 'You do not have permission to update prospect statuses.'
@@ -86,6 +91,10 @@ class ProspectStatusPolicy
 
     public function delete(Authenticatable $authenticatable, ProspectStatus $prospectStatus): Response
     {
+        if (ProspectStatusSystemProtectionAndAutoAssignment::active() && $prospectStatus->is_system_protected) {
+            return Response::deny('You cannot delete this prospect status because it is system protected.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["prospect_status.{$prospectStatus->id}.delete"],
             denyResponse: 'You do not have permission to delete prospect statuses.'
@@ -102,6 +111,10 @@ class ProspectStatusPolicy
 
     public function forceDelete(Authenticatable $authenticatable, ProspectStatus $prospectStatus): Response
     {
+        if (ProspectStatusSystemProtectionAndAutoAssignment::active() && $prospectStatus->is_system_protected) {
+            return Response::deny('You cannot delete this prospect status because it is system protected.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["prospect_status.{$prospectStatus->id}.force-delete"],
             denyResponse: 'You do not have permission to force delete prospect statuses.'

--- a/app-modules/prospect/tests/Prospect/EditProspectTest.php
+++ b/app-modules/prospect/tests/Prospect/EditProspectTest.php
@@ -36,14 +36,17 @@
 
 use App\Models\User;
 
+use function Pest\Laravel\seed;
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 use AdvisingApp\Prospect\Models\Prospect;
 use Filament\Tables\Actions\AttachAction;
+use AdvisingApp\Prospect\Models\ProspectStatus;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\BasicNeeds\Models\BasicNeedsProgram;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource;
+use AdvisingApp\Prospect\Database\Seeders\ProspectStatusSeeder;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource\Pages\EditProspect;
 use AdvisingApp\Prospect\Tests\Prospect\RequestFactories\EditProspectRequestFactory;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource\Actions\ConvertToStudent;
@@ -197,6 +200,10 @@ test('convert prospect to student', function () {
 
     actingAs($user);
 
+    seed([
+        ProspectStatusSeeder::class,
+    ]);
+
     $prospect = Prospect::factory()
         ->create();
 
@@ -212,6 +219,15 @@ test('convert prospect to student', function () {
         )->assertSuccessful();
 
     $prospect->refresh();
+
+    $status = ProspectStatus::query()
+        ->where('classification', 'converted')
+        ->where('name', 'Converted')
+        ->where('is_system_protected', true)
+        ->firstOrFail();
+
+    expect($prospect)
+        ->status->toEqual($status);
 
     expect($prospect->student)
         ->sisid->toBe($student->sisid)

--- a/app-modules/prospect/tests/Prospect/ViewProspectTest.php
+++ b/app-modules/prospect/tests/Prospect/ViewProspectTest.php
@@ -36,12 +36,15 @@
 
 use App\Models\User;
 
+use function Pest\Laravel\seed;
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\Prospect\Models\ProspectStatus;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource;
+use AdvisingApp\Prospect\Database\Seeders\ProspectStatusSeeder;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource\Pages\ViewProspect;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource\Actions\ConvertToStudent;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource\Pages\ManageProspectFiles;
@@ -133,6 +136,10 @@ test('convert prospect to student', function () {
 
     actingAs($user);
 
+    seed([
+        ProspectStatusSeeder::class,
+    ]);
+
     $prospect = Prospect::factory()
         ->create();
 
@@ -149,6 +156,15 @@ test('convert prospect to student', function () {
 
     $prospect->refresh();
 
+    $status = ProspectStatus::query()
+        ->where('classification', 'converted')
+        ->where('name', 'Converted')
+        ->where('is_system_protected', true)
+        ->firstOrFail();
+
+    expect($prospect)
+        ->status->toEqual($status);
+
     expect($prospect->student)
         ->sisid->toBe($student->sisid)
         ->full_name->toBe($student->full_name)
@@ -163,6 +179,10 @@ test('disassociate student from prospect', function () {
 
     actingAs($user);
 
+    seed([
+        ProspectStatusSeeder::class,
+    ]);
+
     $prospect = Prospect::factory()
         ->for(Student::factory(), 'student')
         ->create();
@@ -175,6 +195,15 @@ test('disassociate student from prospect', function () {
         )->assertSuccessful();
 
     $prospect->refresh();
+
+    $status = ProspectStatus::query()
+        ->where('classification', 'new')
+        ->where('name', 'New')
+        ->where('is_system_protected', true)
+        ->firstOrFail();
+
+    expect($prospect)
+        ->status->toEqual($status);
 
     expect($prospect->student()->exists())->toBeFalse();
 });

--- a/app-modules/prospect/tests/ProspectStatus/EditProspectStatusTest.php
+++ b/app-modules/prospect/tests/ProspectStatus/EditProspectStatusTest.php
@@ -48,6 +48,7 @@ use function PHPUnit\Framework\assertEquals;
 
 use AdvisingApp\Prospect\Models\ProspectStatus;
 use AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource;
+use AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource\Pages\EditProspectStatus;
 use AdvisingApp\Prospect\Tests\ProspectStatus\RequestFactories\EditProspectStatusRequestFactory;
 
 test('A successful action on the EditProspectStatus page', function () {
@@ -63,7 +64,7 @@ test('A successful action on the EditProspectStatus page', function () {
 
     $editRequest = EditProspectStatusRequestFactory::new()->create();
 
-    livewire(ProspectStatusResource\Pages\EditProspectStatus::class, [
+    livewire(EditProspectStatus::class, [
         'record' => $prospectStatus->getRouteKey(),
     ])
         ->assertFormSet([
@@ -85,7 +86,7 @@ test('EditProspectStatus requires valid data', function ($data, $errors) {
 
     $prospectStatus = ProspectStatus::factory()->create();
 
-    livewire(ProspectStatusResource\Pages\EditProspectStatus::class, [
+    livewire(EditProspectStatus::class, [
         'record' => $prospectStatus->getRouteKey(),
     ])
         ->assertFormSet([
@@ -121,7 +122,7 @@ test('EditProspectStatus is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    livewire(ProspectStatusResource\Pages\EditProspectStatus::class, [
+    livewire(EditProspectStatus::class, [
         'record' => $prospectStatus->getRouteKey(),
     ])
         ->assertForbidden();
@@ -138,7 +139,7 @@ test('EditProspectStatus is gated with proper access control', function () {
 
     $request = collect(EditProspectStatusRequestFactory::new()->create());
 
-    livewire(ProspectStatusResource\Pages\EditProspectStatus::class, [
+    livewire(EditProspectStatus::class, [
         'record' => $prospectStatus->getRouteKey(),
     ])
         ->fillForm($request->toArray())
@@ -159,7 +160,7 @@ test('EditProspectStatus is gated with proper system protection access control',
             ])
         )->assertForbidden();
 
-    livewire(ProspectStatusResource\Pages\EditProspectStatus::class, [
+    livewire(EditProspectStatus::class, [
         'record' => $prospectStatus->getRouteKey(),
     ])
         ->assertForbidden();
@@ -175,7 +176,7 @@ test('EditProspectStatus is gated with proper system protection access control',
 
     $request = collect(EditProspectStatusRequestFactory::new()->create());
 
-    livewire(ProspectStatusResource\Pages\EditProspectStatus::class, [
+    livewire(EditProspectStatus::class, [
         'record' => $prospectStatus->getRouteKey(),
     ])
         ->fillForm($request->toArray())

--- a/app-modules/prospect/tests/ProspectStatus/EditProspectStatusTest.php
+++ b/app-modules/prospect/tests/ProspectStatus/EditProspectStatusTest.php
@@ -148,3 +148,40 @@ test('EditProspectStatus is gated with proper access control', function () {
     assertEquals($request['name'], $prospectStatus->fresh()->name);
     assertEquals($request['color'], $prospectStatus->fresh()->color);
 });
+
+test('EditProspectStatus is gated with proper system protection access control', function () {
+    $prospectStatus = ProspectStatus::factory()->create(['is_system_protected' => true]);
+
+    asSuperAdmin()
+        ->get(
+            ProspectStatusResource::getUrl('edit', [
+                'record' => $prospectStatus,
+            ])
+        )->assertForbidden();
+
+    livewire(ProspectStatusResource\Pages\EditProspectStatus::class, [
+        'record' => $prospectStatus->getRouteKey(),
+    ])
+        ->assertForbidden();
+
+    $prospectStatus = ProspectStatus::factory()->create();
+
+    asSuperAdmin()
+        ->get(
+            ProspectStatusResource::getUrl('edit', [
+                'record' => $prospectStatus,
+            ])
+        )->assertSuccessful();
+
+    $request = collect(EditProspectStatusRequestFactory::new()->create());
+
+    livewire(ProspectStatusResource\Pages\EditProspectStatus::class, [
+        'record' => $prospectStatus->getRouteKey(),
+    ])
+        ->fillForm($request->toArray())
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    assertEquals($request['name'], $prospectStatus->fresh()->name);
+    assertEquals($request['color'], $prospectStatus->fresh()->color);
+});

--- a/app-modules/prospect/tests/ProspectStatus/ViewProspectStatusTest.php
+++ b/app-modules/prospect/tests/ProspectStatus/ViewProspectStatusTest.php
@@ -38,10 +38,12 @@ use App\Models\User;
 
 use function Tests\asSuperAdmin;
 use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\Prospect\Models\ProspectStatus;
 use AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource;
+use AdvisingApp\Prospect\Filament\Resources\ProspectStatusResource\Pages\ViewProspectStatus;
 
 test('The correct details are displayed on the ViewProspectStatus page', function () {
     $prospectStatus = ProspectStatus::factory()->create();
@@ -88,4 +90,32 @@ test('ViewProspectStatus is gated with proper access control', function () {
                 'record' => $prospectStatus,
             ])
         )->assertSuccessful();
+});
+
+it('displays the edit action and not the lock when the prospect status is not system protected', function () {
+    $prospectStatus = ProspectStatus::factory()->create();
+
+    asSuperAdmin();
+
+    livewire(ViewProspectStatus::class, [
+        'record' => $prospectStatus->getRouteKey(),
+    ])
+        ->assertDontSeeHtml('data-identifier="prospect_status_system_protected"')
+        ->assertActionVisible('edit')
+        ->assertActionEnabled('edit');
+});
+
+it('displays the lock icon rather than the edit action when the prospect status is system protected', function () {
+    $prospectStatus = ProspectStatus::factory()->create([
+        'is_system_protected' => true,
+    ]);
+
+    asSuperAdmin();
+
+    livewire(ViewProspectStatus::class, [
+        'record' => $prospectStatus->getRouteKey(),
+    ])
+        ->assertSeeHtml('data-identifier="prospect_status_system_protected"')
+        ->assertActionHidden('edit')
+        ->assertActionDisabled('edit');
 });

--- a/app/Features/ProspectStatusSystemProtectionAndAutoAssignment.php
+++ b/app/Features/ProspectStatusSystemProtectionAndAutoAssignment.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class ProspectStatusSystemProtectionAndAutoAssignment extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Features/ProspectStatusSystemProtectionAndAutoAssignment.php
+++ b/app/Features/ProspectStatusSystemProtectionAndAutoAssignment.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/database/migrations/2024_10_08_173120_create_function_to_prevent_modification_of_system_protected_rows.php
+++ b/database/migrations/2024_10_08_173120_create_function_to_prevent_modification_of_system_protected_rows.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::createFunctionOrReplace(
+            name: 'prevent_modification_of_system_protected_rows',
+            parameters: [],
+            return: 'TRIGGER',
+            language: 'plpgsql',
+            body: <<<SQL
+                BEGIN
+                    IF OLD.is_system_protected THEN
+                        RAISE EXCEPTION 'Cannot modify system protected rows';
+                    END IF;
+                    RETURN NEW;
+                END;
+            SQL,
+            options: [
+                'security' => 'invoker',
+                'volatility' => 'immutable',
+                'parallel' => 'safe',
+            ]
+        );
+    }
+
+    public function down(): void
+    {
+        Schema::dropFunctionIfExists('prevent_modification_of_system_protected_rows');
+    }
+};

--- a/database/migrations/2024_10_08_173120_create_function_to_prevent_modification_of_system_protected_rows.php
+++ b/database/migrations/2024_10_08_173120_create_function_to_prevent_modification_of_system_protected_rows.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 

--- a/resources/views/components/page-header-action-lock-icon.blade.php
+++ b/resources/views/components/page-header-action-lock-icon.blade.php
@@ -1,0 +1,45 @@
+{{--
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+--}}
+
+@props(['condition', 'identifier', 'tooltip'])
+
+@if ($condition())
+    <x-filament::icon-button
+        data-identifier="{{ $identifier }}"
+        icon="heroicon-m-lock-closed"
+        color="gray"
+        size="lg"
+        tooltip="{{ $tooltip }}"
+    />
+@endif


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-827

### Technical Description

Enforces the concept of system protected rows and places that on particular Prospect Statuses.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

Feature Flags:
- `ProspectStatusSystemProtectionAndAutoAssignment`

Data Migrations:
- `app-modules/prospect/database/migrations/2024_10_08_174319_data_activate_feature_flag_prospect_status_system_protection_and_auto_assignment.php`
- `app-modules/prospect/database/migrations/2024_10_08_161832_data_ensure_system_default_prospect_statuses_exist.php`

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
