### PR TITLE
[ADVAPP-859]: Trying to update the Portal copyright statement throws an error

### DIFF
--- a/app-modules/portal/src/Settings/PortalSettings.php
+++ b/app-modules/portal/src/Settings/PortalSettings.php
@@ -74,7 +74,7 @@ class PortalSettings extends SettingsWithMedia
 
     public ?string $footer_color = null;
 
-    public ?string $footer_copyright_statement = null;
+    public ?array $footer_copyright_statement = null;
 
     /**
     * Knowledge Base Portal


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-859

### Technical Description

Fixes typing error with `PortalSettings` `$footer_copyright_statement`.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
