### PR TITLE
[ADVAPP-899]: When attempting to set a hyperlink via the GDPR configuration, the path to the link is incorrectly constructed when attempting to follow it

### DIFF
--- a/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
+++ b/app-modules/portal/src/Filament/Pages/ManagePortalSettings.php
@@ -257,4 +257,35 @@ class ManagePortalSettings extends SettingsPage
                     ->visible(fn (Get $get) => $get('knowledge_management_portal_enabled')),
             ]);
     }
+
+    public function updateLinks(array $array): array
+    {
+        foreach ($array['content'] as &$paragraph) {
+            foreach ($paragraph['content'] as &$text) {
+                if (isset($text['marks'])) {
+                    foreach ($text['marks'] as &$mark) {
+                        if ($mark['type'] === 'link' && isset($mark['attrs']['href'])) {
+                            if (strpos($mark['attrs']['href'], 'www.') === 0) {
+                                $mark['attrs']['href'] = 'https://' . $mark['attrs']['href'];
+                            } elseif (strpos($mark['attrs']['href'], 'http') !== 0) {
+                                $mark['attrs']['href'] = 'https://' . $mark['attrs']['href'];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $array;
+    }
+
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $tiptapContent = $data['gdpr_banner_text'];
+        $tiptapContent = $this->updateLinks($tiptapContent);
+
+        $data['gdpr_banner_text'] = $tiptapContent;
+
+        return $data;
+    }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-899

### Technical Description

> Fixed GDPR hyperlink issue.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
