### PR TITLE
[ADVAPP-925]: Update changelog path for login to point to the Advising App website changelog instead of GitHub

### DIFF
--- a/app-modules/authorization/src/Filament/Pages/Auth/Login.php
+++ b/app-modules/authorization/src/Filament/Pages/Auth/Login.php
@@ -80,7 +80,7 @@ class Login extends FilamentLogin
     {
         $themeSettings = app(ThemeSettings::class);
 
-        $this->themeChangelogUrl = ! empty($themeSettings->changelog_url) ? $themeSettings->changelog_url : 'https://github.com/canyongbs/advisingapp/releases';
+        $this->themeChangelogUrl = ! empty($themeSettings->changelog_url) ? $themeSettings->changelog_url : 'https://advising.app/changelog/';
 
         $this->productKnowledgebaseUrl = ! empty($themeSettings->product_knowledge_base_url) ? $themeSettings->product_knowledge_base_url : 'https://canyongbs.aiding.app/portal/categories/9bcc47d1-05be-40d2-bf95-9bd719209b06';
     }


### PR DESCRIPTION
…changelog instead of GitHub

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-925

### Technical Description

Update changelog path for login to point to the Advising App website changelog instead of GitHub

### Any deployment steps required?

No 

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
