### PR TITLE
[ADVAPP-935]: Add the ability to filter the list of Message Center engagement by constituents where you are a member of their care team

### DIFF
--- a/app-modules/engagement/resources/views/components/filters.blade.php
+++ b/app-modules/engagement/resources/views/components/filters.blade.php
@@ -80,6 +80,13 @@
     </div>
 
     <label class="flex items-center">
+        <x-filament::input.checkbox wire:model.live="filterMemberOfCareTeam" />
+        <span class="ml-2">
+            Member of Care team
+        </span>
+    </label>
+
+    <label class="flex items-center">
         <x-filament::input.checkbox wire:model.live="filterSubscribed" />
 
         <span class="ml-2">
@@ -101,10 +108,5 @@
         </span>
     </label>
 
-    <label class="flex items-center">
-        <x-filament::input.checkbox wire:model.live="filterMemberOfCareTeam" />
-        <span class="ml-2">
-            Member of Care team
-        </span>
-    </label>
+    
 </div>

--- a/app-modules/engagement/resources/views/components/filters.blade.php
+++ b/app-modules/engagement/resources/views/components/filters.blade.php
@@ -108,5 +108,4 @@
         </span>
     </label>
 
-    
 </div>

--- a/app-modules/engagement/resources/views/components/filters.blade.php
+++ b/app-modules/engagement/resources/views/components/filters.blade.php
@@ -100,4 +100,11 @@
             Open Service Requests
         </span>
     </label>
+
+    <label class="flex items-center">
+        <x-filament::input.checkbox wire:model.live="filterMemberOfCareTeam" />
+        <span class="ml-2">
+            Member of Care team
+        </span>
+    </label>
 </div>

--- a/app-modules/engagement/src/Filament/Pages/MessageCenter.php
+++ b/app-modules/engagement/src/Filament/Pages/MessageCenter.php
@@ -53,6 +53,7 @@ use AdvisingApp\Prospect\Models\Prospect;
 use App\Actions\GetRecordFromMorphAndKey;
 use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\CareTeam\Models\CareTeam;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Timeline\Actions\SyncTimelineData;
 use Illuminate\Contracts\Database\Eloquent\Builder;
@@ -117,6 +118,9 @@ class MessageCenter extends Page
     #[Url(as: 'endDate')]
     public ?string $filterEndDate = null;
 
+    #[Url(as: 'hasMemberOfCareTeam')]
+    public bool $filterMemberOfCareTeam = false;
+
     public int $inboxPerPage = 10;
 
     public static function canAccess(): bool
@@ -154,6 +158,7 @@ class MessageCenter extends Page
             'filterOpenServiceRequests',
             'filterStartDate',
             'filterEndDate',
+            'filterMemberOfCareTeam',
         ];
 
         if (in_array($property, $filters)) {
@@ -299,6 +304,12 @@ class MessageCenter extends Page
                     ServiceRequest::query()
                         ->open()
                         ->pluck('respondent_id')
+                );
+            })
+            ->when($this->filterMemberOfCareTeam === true, function (Builder $query) use ($idColumn) {
+                $query->whereIn(
+                    $idColumn,
+                    CareTeam::query()->pluck('educatable_id')
                 );
             });
     }

--- a/app-modules/engagement/src/Filament/Pages/MessageCenter.php
+++ b/app-modules/engagement/src/Filament/Pages/MessageCenter.php
@@ -53,7 +53,6 @@ use AdvisingApp\Prospect\Models\Prospect;
 use App\Actions\GetRecordFromMorphAndKey;
 use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\Authorization\Enums\LicenseType;
-use AdvisingApp\CareTeam\Models\CareTeam;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Timeline\Actions\SyncTimelineData;
 use Illuminate\Contracts\Database\Eloquent\Builder;

--- a/app-modules/engagement/src/Filament/Pages/MessageCenter.php
+++ b/app-modules/engagement/src/Filament/Pages/MessageCenter.php
@@ -309,7 +309,7 @@ class MessageCenter extends Page
             ->when($this->filterMemberOfCareTeam === true, function (Builder $query) use ($idColumn) {
                 $query->whereIn(
                     $idColumn,
-                    CareTeam::query()->pluck('educatable_id')
+                    $this->user->careTeams()->pluck('educatable_id')
                 );
             });
     }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-935

### Technical Description

> Add the ability to filter the list of Message Center engagement by constituents where you are a member of their care team

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
