### PR TITLE
[ADVAPP-988]: Indicate student or prospect's name when that task is related to a student or prospect in the resulting notification.

### DIFF
--- a/app-modules/task/src/Notifications/TaskAssignedToUserNotification.php
+++ b/app-modules/task/src/Notifications/TaskAssignedToUserNotification.php
@@ -79,24 +79,21 @@ class TaskAssignedToUserNotification extends BaseNotification implements Databas
     {
         $url = EditTask::getUrl(['record' => $this->task]);
 
-        $studentProspectUrl = match (true) {
-            ! empty($this->task->concern) && $this->task->concern instanceof Student => ViewStudent::getUrl(['record' => $this->task->concern]),
-            ! empty($this->task->concern) && $this->task->concern instanceof Prospect => ViewProspect::getUrl(['record' => $this->task->concern]),
-            default => null,
-        };
-
         $title = str($this->task->title)->limit();
 
-        $link = new HtmlString("<a href='{$url}' target='_blank' class='underline'>{$title}</a>");
-
-        $studentProspectLink = match (true) {
-            ! empty($this->task->concern) => new HtmlString("<a href='{$studentProspectUrl}' target='_blank' class='underline'>{$this->task->concern->full_name}</a>"),
-            default => null,
-        };
-
         $message = match (true) {
-            ! empty($this->task->concern) && ($this->task->concern instanceof Student || $this->task->concern instanceof Prospect) => "You have been assigned a new Task: {$link} related to {$this->task->concern_type} {$studentProspectLink}",
-            default => "You have been assigned a new Task: {$link}",
+            $this->task->concern instanceof Student => 'You have been assigned a new Task: ' .
+                new HtmlString("<a href='{$url}' target='_blank' class='underline'>{$title}</a>") .
+                ' related to Student ' .
+                new HtmlString("<a href='" . ViewStudent::getUrl(['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern->full_name}</a>"),
+
+            $this->task->concern instanceof Prospect => 'You have been assigned a new Task: ' .
+                new HtmlString("<a href='{$url}' target='_blank' class='underline'>{$title}</a>") .
+                ' related to Prospect ' .
+                new HtmlString("<a href='" . ViewProspect::getUrl(['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern->full_name}</a>"),
+
+            default => 'You have been assigned a new Task: ' .
+                new HtmlString("<a href='{$url}' target='_blank' class='underline'>{$title}</a>"),
         };
 
         return FilamentNotification::make()

--- a/app-modules/task/src/Notifications/TaskAssignedToUserNotification.php
+++ b/app-modules/task/src/Notifications/TaskAssignedToUserNotification.php
@@ -81,18 +81,11 @@ class TaskAssignedToUserNotification extends BaseNotification implements Databas
         $title = str($this->task->title)->limit();
 
         $message = match (true) {
-            $this->task->concern instanceof Student => 'You have been assigned a new Task: ' .
-                "<a href='{$url}' target='_blank' class='underline'>{$title}</a>" .
-                ' related to Student ' .
-                "<a href='" . ViewStudent::getUrl(['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern->full_name}</a>",
+            $this->task->concern instanceof Student => "You have been assigned a new Task: <a href='{$url}' target='_blank' class='underline'>{$title}</a> related to Student <a href='" . ViewStudent::getUrl(['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern->full_name}</a>",
 
-            $this->task->concern instanceof Prospect => 'You have been assigned a new Task: ' .
-                "<a href='{$url}' target='_blank' class='underline'>{$title}</a>" .
-                ' related to Prospect ' .
-                "<a href='" . ViewProspect::getUrl(['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern->full_name}</a>",
+            $this->task->concern instanceof Prospect => "You have been assigned a new Task: <a href='{$url}' target='_blank' class='underline'>{$title}</a> related to Prospect <a href='" . ViewProspect::getUrl(['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern->full_name}</a>",
 
-            default => 'You have been assigned a new Task: ' .
-                "<a href='{$url}' target='_blank' class='underline'>{$title}</a>",
+            default => "You have been assigned a new Task: <a href='{$url}' target='_blank' class='underline'>{$title}</a>",
         };
 
         return FilamentNotification::make()

--- a/app-modules/task/src/Notifications/TaskAssignedToUserNotification.php
+++ b/app-modules/task/src/Notifications/TaskAssignedToUserNotification.php
@@ -38,7 +38,6 @@ namespace AdvisingApp\Task\Notifications;
 
 use App\Models\User;
 use AdvisingApp\Task\Models\Task;
-use Illuminate\Support\HtmlString;
 use App\Models\NotificationSetting;
 use Illuminate\Queue\SerializesModels;
 use AdvisingApp\Prospect\Models\Prospect;
@@ -83,17 +82,17 @@ class TaskAssignedToUserNotification extends BaseNotification implements Databas
 
         $message = match (true) {
             $this->task->concern instanceof Student => 'You have been assigned a new Task: ' .
-                new HtmlString("<a href='{$url}' target='_blank' class='underline'>{$title}</a>") .
+                "<a href='{$url}' target='_blank' class='underline'>{$title}</a>" .
                 ' related to Student ' .
-                new HtmlString("<a href='" . ViewStudent::getUrl(['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern->full_name}</a>"),
+                "<a href='" . ViewStudent::getUrl(['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern->full_name}</a>",
 
             $this->task->concern instanceof Prospect => 'You have been assigned a new Task: ' .
-                new HtmlString("<a href='{$url}' target='_blank' class='underline'>{$title}</a>") .
+                "<a href='{$url}' target='_blank' class='underline'>{$title}</a>" .
                 ' related to Prospect ' .
-                new HtmlString("<a href='" . ViewProspect::getUrl(['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern->full_name}</a>"),
+                "<a href='" . ViewProspect::getUrl(['record' => $this->task->concern]) . "' target='_blank' class='underline'>{$this->task->concern->full_name}</a>",
 
             default => 'You have been assigned a new Task: ' .
-                new HtmlString("<a href='{$url}' target='_blank' class='underline'>{$title}</a>"),
+                "<a href='{$url}' target='_blank' class='underline'>{$title}</a>",
         };
 
         return FilamentNotification::make()


### PR DESCRIPTION

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-988

### Technical Description

Indicate student or prospect's name when that task is related to a student or prospect in the resulting notification.

### Any deployment steps required?

Need to restart queue. 

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
