### PR TITLE
[ADVAPP-854]: Prevent sending SMS messages to Prospects or Students with no Mobile number set

### DIFF
--- a/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
@@ -165,7 +165,7 @@ class BulkEngagementAction
                 CreateEngagementBatch::dispatch(EngagementBatchCreationData::from([
                     'user' => auth()->user(),
                     'records' => $records->filter(function ($record) {
-                        return ! empty($record->mobile);
+                        return $record->canRecieveSms();
                     }),
                     'deliveryMethod' => $data['delivery_method'],
                     'subject' => $data['subject'] ?? null,

--- a/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
@@ -164,7 +164,9 @@ class BulkEngagementAction
             ->action(function (Collection $records, array $data, Form $form) {
                 CreateEngagementBatch::dispatch(EngagementBatchCreationData::from([
                     'user' => auth()->user(),
-                    'records' => $records,
+                    'records' => $records->filter(function ($record) {
+                        return ! empty($record->mobile);
+                    }),
                     'deliveryMethod' => $data['delivery_method'],
                     'subject' => $data['subject'] ?? null,
                     'body' => $data['body'] ?? null,

--- a/app-modules/engagement/src/Filament/Actions/SendEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/SendEngagementAction.php
@@ -74,7 +74,7 @@ class SendEngagementAction extends Action
                     ->label('What would you like to send?')
                     ->options(EngagementDeliveryMethod::getOptions())
                     ->default(EngagementDeliveryMethod::Email->value)
-                    ->disableOptionWhen(fn (string $value): bool => (($value == (EngagementDeliveryMethod::Sms->value) && ! $this->getEducatable()->mobile)) || EngagementDeliveryMethod::tryFrom($value)?->getCaseDisabled())
+                    ->disableOptionWhen(fn (string $value): bool => (($value == (EngagementDeliveryMethod::Sms->value) && ! $this->getEducatable()->canRecieveSms())) || EngagementDeliveryMethod::tryFrom($value)?->getCaseDisabled())
                     ->selectablePlaceholder(false)
                     ->live(),
                 Fieldset::make('Content')
@@ -159,7 +159,7 @@ class SendEngagementAction extends Action
                     ]),
             ])
             ->action(function (array $data, Form $form) {
-                if ($data['delivery_method'] == EngagementDeliveryMethod::Sms->value && ! $this->getEducatable()->mobile) {
+                if ($data['delivery_method'] == EngagementDeliveryMethod::Sms->value && ! $this->getEducatable()->canRecieveSms()) {
                     Notification::make()
                         ->title(ucfirst($this->getEducatable()->getLabel()) . ' does not have mobile number.')
                         ->danger()

--- a/app-modules/engagement/src/Filament/Actions/SendEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/SendEngagementAction.php
@@ -47,6 +47,7 @@ use FilamentTiptapEditor\TiptapEditor;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use AdvisingApp\Engagement\Models\Engagement;
@@ -73,7 +74,7 @@ class SendEngagementAction extends Action
                     ->label('What would you like to send?')
                     ->options(EngagementDeliveryMethod::getOptions())
                     ->default(EngagementDeliveryMethod::Email->value)
-                    ->disableOptionWhen(fn (string $value): bool => EngagementDeliveryMethod::tryFrom($value)?->getCaseDisabled())
+                    ->disableOptionWhen(fn (string $value): bool => (($value == (EngagementDeliveryMethod::Sms->value) && ! $this->getEducatable()->mobile)) || EngagementDeliveryMethod::tryFrom($value)?->getCaseDisabled())
                     ->selectablePlaceholder(false)
                     ->live(),
                 Fieldset::make('Content')
@@ -158,6 +159,15 @@ class SendEngagementAction extends Action
                     ]),
             ])
             ->action(function (array $data, Form $form) {
+                if ($data['delivery_method'] == EngagementDeliveryMethod::Sms->value && ! $this->getEducatable()->mobile) {
+                    Notification::make()
+                        ->title(ucfirst($this->getEducatable()->getLabel()) . ' does not have mobile number.')
+                        ->danger()
+                        ->send();
+
+                    $this->halt();
+                }
+
                 $createOnDemandEngagement = resolve(CreateOnDemandEngagement::class);
 
                 $createOnDemandEngagement(

--- a/app-modules/engagement/src/Filament/ManageRelatedRecords/ManageRelatedEngagementRecords.php
+++ b/app-modules/engagement/src/Filament/ManageRelatedRecords/ManageRelatedEngagementRecords.php
@@ -146,7 +146,7 @@ class ManageRelatedEngagementRecords extends ManageRelatedRecords
                 ->label('What would you like to send?')
                 ->options(EngagementDeliveryMethod::getOptions())
                 ->default(EngagementDeliveryMethod::Email->value)
-                ->disableOptionWhen(fn (string $value): bool => (($value == (EngagementDeliveryMethod::Sms->value) && ! $this->getOwnerRecord()->mobile)) || EngagementDeliveryMethod::tryFrom($value)?->getCaseDisabled())
+                ->disableOptionWhen(fn (string $value): bool => (($value == (EngagementDeliveryMethod::Sms->value) && ! $this->getOwnerRecord()->canRecieveSms())) || EngagementDeliveryMethod::tryFrom($value)?->getCaseDisabled())
                 ->selectablePlaceholder(false)
                 ->live(),
             Fieldset::make('Content')
@@ -284,7 +284,7 @@ class ManageRelatedEngagementRecords extends ManageRelatedRecords
                     })
                     ->createAnother(false)
                     ->action(function (array $data, Form $form) {
-                        if ($data['delivery_method'] == EngagementDeliveryMethod::Sms->value && ! $this->getOwnerRecord()->mobile) {
+                        if ($data['delivery_method'] == EngagementDeliveryMethod::Sms->value && ! $this->getOwnerRecord()->canRecieveSms()) {
                             Notification::make()
                                 ->title('Prospect does not have mobile number.')
                                 ->danger()

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
@@ -182,7 +182,7 @@ class CreateEngagement extends CreateRecord
             $record = Student::find($data['recipient_id']);
         }
 
-        if ($record && ! $record->mobile) {
+        if ($record && ! $record->canRecieveSms()) {
             Notification::make()
                 ->title(ucfirst($data['recipient_type']) . ' does not have mobile number.')
                 ->danger()

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/CreateEngagement.php
@@ -172,6 +172,8 @@ class CreateEngagement extends CreateRecord
 
     public function beforeCreate(): void
     {
+        $record = null;
+
         $data = $this->form->getState();
 
         if ($data['recipient_type'] == app(Prospect::class)->getMorphClass()) {

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
@@ -169,7 +169,7 @@ class EditEngagement extends EditRecord
             $record = Student::find($data['recipient_id']);
         }
 
-        if ($record && ! $record->mobile) {
+        if ($record && ! $record->canRecieveSms()) {
             Notification::make()
                 ->title(ucfirst($data['recipient_type']) . ' does not have mobile number.')
                 ->danger()

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
@@ -48,13 +48,16 @@ use FilamentTiptapEditor\TiptapEditor;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
+use AdvisingApp\Prospect\Models\Prospect;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use AdvisingApp\Engagement\Models\Engagement;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\DateTimePicker;
 use AdvisingApp\Engagement\Models\EmailTemplate;
+use AdvisingApp\StudentDataModel\Models\Student;
 use App\Filament\Forms\Components\EducatableSelect;
 use AdvisingApp\Engagement\Enums\EngagementDeliveryMethod;
 use AdvisingApp\Engagement\Filament\Resources\EngagementResource;
@@ -152,6 +155,26 @@ class EditEngagement extends EditRecord
                             ->visible(fn (callable $get) => $get('send_later')),
                     ]),
             ]);
+    }
+
+    protected function beforeSave(): void
+    {
+        $data = $this->form->getState();
+
+        if ($data['recipient_type'] == app(Prospect::class)->getMorphClass()) {
+            $record = Prospect::find($data['recipient_id']);
+        } elseif ($data['recipient_type'] == app(Student::class)->getMorphClass()) {
+            $record = Student::find($data['recipient_id']);
+        }
+
+        if ($record && ! $record->mobile) {
+            Notification::make()
+                ->title(ucfirst($data['recipient_type']) . ' does not have mobile number.')
+                ->danger()
+                ->send();
+
+            $this->halt();
+        }
     }
 
     protected function getHeaderActions(): array

--- a/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementResource/Pages/EditEngagement.php
@@ -159,6 +159,8 @@ class EditEngagement extends EditRecord
 
     protected function beforeSave(): void
     {
+        $record = null;
+
         $data = $this->form->getState();
 
         if ($data['recipient_type'] == app(Prospect::class)->getMorphClass()) {

--- a/app-modules/engagement/src/Models/EngagementBatch.php
+++ b/app-modules/engagement/src/Models/EngagementBatch.php
@@ -72,7 +72,9 @@ class EngagementBatch extends BaseModel implements ExecutableFromACampaignAction
         try {
             CreateEngagementBatch::dispatch(EngagementBatchCreationData::from([
                 'user' => $action->campaign->user,
-                'records' => $action->campaign->segment->retrieveRecords(),
+                'records' => $action->campaign->segment->retrieveRecords()->filter(function ($record) {
+                    return ! empty($record->mobile);
+                }),
                 'deliveryMethod' => $action->data['delivery_method'],
                 'subject' => $action->data['subject'] ?? null,
                 'body' => $action->data['body'] ?? null,

--- a/app-modules/engagement/src/Models/EngagementBatch.php
+++ b/app-modules/engagement/src/Models/EngagementBatch.php
@@ -73,7 +73,7 @@ class EngagementBatch extends BaseModel implements ExecutableFromACampaignAction
             CreateEngagementBatch::dispatch(EngagementBatchCreationData::from([
                 'user' => $action->campaign->user,
                 'records' => $action->campaign->segment->retrieveRecords()->filter(function ($record) {
-                    return ! empty($record->mobile);
+                    return $record->canRecieveSms();
                 }),
                 'deliveryMethod' => $action->data['delivery_method'],
                 'subject' => $action->data['subject'] ?? null,

--- a/app-modules/prospect/src/Models/Prospect.php
+++ b/app-modules/prospect/src/Models/Prospect.php
@@ -348,6 +348,11 @@ class Prospect extends BaseAuthenticatable implements Auditable, Subscribable, E
             ->withTimestamps();
     }
 
+    public static function mobile(): string
+    {
+        return 'mobile';
+    }
+
     protected static function booted(): void
     {
         static::addGlobalScope('licensed', function (Builder $builder) {

--- a/app-modules/prospect/src/Models/Prospect.php
+++ b/app-modules/prospect/src/Models/Prospect.php
@@ -348,9 +348,9 @@ class Prospect extends BaseAuthenticatable implements Auditable, Subscribable, E
             ->withTimestamps();
     }
 
-    public static function mobile(): string
+    public function canRecieveSms(): bool
     {
-        return 'mobile';
+        return filled($this->mobile);
     }
 
     protected static function booted(): void

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/StudentEngagementRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/StudentEngagementRelationManager.php
@@ -146,7 +146,7 @@ class StudentEngagementRelationManager extends RelationManager
                 ->label('What would you like to send?')
                 ->options(EngagementDeliveryMethod::getOptions())
                 ->default(EngagementDeliveryMethod::Email->value)
-                ->disableOptionWhen(fn (string $value): bool => (($value == (EngagementDeliveryMethod::Sms->value) && ! $this->getOwnerRecord()->mobile)) || EngagementDeliveryMethod::tryFrom($value)?->getCaseDisabled())
+                ->disableOptionWhen(fn (string $value): bool => (($value == (EngagementDeliveryMethod::Sms->value) && ! $this->getOwnerRecord()->canRecieveSms())) || EngagementDeliveryMethod::tryFrom($value)?->getCaseDisabled())
                 ->selectablePlaceholder(false)
                 ->live(),
             Fieldset::make('Content')
@@ -284,7 +284,7 @@ class StudentEngagementRelationManager extends RelationManager
                     })
                     ->createAnother(false)
                     ->action(function (CreateAction $action, array $data, Form $form) {
-                        if ($data['delivery_method'] == EngagementDeliveryMethod::Sms->value && ! $this->getOwnerRecord()->mobile) {
+                        if ($data['delivery_method'] == EngagementDeliveryMethod::Sms->value && ! $this->getOwnerRecord()->canRecieveSms()) {
                             Notification::make()
                                 ->title('Student does not have mobile number.')
                                 ->danger()

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -58,4 +58,6 @@ interface Educatable extends Identifiable
     public static function getLicenseType(): LicenseType;
 
     public function eventAttendeeRecords(): HasMany;
+
+    public static function mobile(): string;
 }

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -58,6 +58,4 @@ interface Educatable extends Identifiable
     public static function getLicenseType(): LicenseType;
 
     public function eventAttendeeRecords(): HasMany;
-
-    public static function mobile(): string;
 }

--- a/app-modules/student-data-model/src/Models/Student.php
+++ b/app-modules/student-data-model/src/Models/Student.php
@@ -350,9 +350,9 @@ class Student extends BaseAuthenticatable implements Auditable, Subscribable, Ed
         return 'student';
     }
 
-    public static function mobile(): string
+    public function canRecieveSms(): bool
     {
-        return 'mobile';
+        return filled($this->mobile);
     }
 
     protected static function booted(): void

--- a/app-modules/student-data-model/src/Models/Student.php
+++ b/app-modules/student-data-model/src/Models/Student.php
@@ -350,6 +350,11 @@ class Student extends BaseAuthenticatable implements Auditable, Subscribable, Ed
         return 'student';
     }
 
+    public static function mobile(): string
+    {
+        return 'mobile';
+    }
+
     protected static function booted(): void
     {
         static::addGlobalScope('licensed', function (Builder $builder) {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-854

### Technical Description

> Prevent sending SMS messages to Prospects or Students with no Mobile number set

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
