### PR TITLE
[ADVAPP-982]: When attempting to create a draft with the AI assistant on the student profile page to create a new email or text, an error is generated

### DIFF
--- a/app-modules/engagement/src/Filament/ManageRelatedRecords/ManageRelatedEngagementRecords/Actions/DraftWithAiAction.php
+++ b/app-modules/engagement/src/Filament/ManageRelatedRecords/ManageRelatedEngagementRecords/Actions/DraftWithAiAction.php
@@ -53,6 +53,7 @@ use AdvisingApp\Ai\Exceptions\MessageResponseException;
 use AdvisingApp\Ai\Settings\AiIntegratedAssistantSettings;
 use AdvisingApp\Engagement\Enums\EngagementDeliveryMethod;
 use AdvisingApp\Engagement\Filament\ManageRelatedRecords\ManageRelatedEngagementRecords;
+use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\RelationManagers\StudentEngagementRelationManager;
 
 class DraftWithAiAction extends Action
 {
@@ -66,8 +67,8 @@ class DraftWithAiAction extends Action
             ->label('Draft with AI Assistant')
             ->link()
             ->icon('heroicon-m-pencil')
-            ->modalContent(fn (ManageRelatedEngagementRecords $livewire) => view('engagement::filament.manage-related-records.manage-related-engagement-records.draft-with-ai-modal-content', [
-                'recordTitle' => $livewire->getRecordTitle(),
+            ->modalContent(fn (ManageRelatedEngagementRecords | StudentEngagementRelationManager $livewire) => view('engagement::filament.manage-related-records.manage-related-engagement-records.draft-with-ai-modal-content', [
+                'recordTitle' => $livewire->getOwnerRecord()->getAttribute($livewire->getOwnerRecord()::displayNameKey()),
                 'avatarUrl' => AiAssistant::query()->where('is_default', true)->first()
                     ?->getFirstTemporaryUrl(now()->addHour(), 'avatar', 'avatar-height-250px') ?: Vite::asset('resources/images/canyon-ai-headshot.jpg'),
             ]))
@@ -80,7 +81,7 @@ class DraftWithAiAction extends Action
                     ->placeholder('What do you want to write about?')
                     ->required(),
             ])
-            ->action(function (array $data, Get $get, Set $set, ManageRelatedEngagementRecords $livewire) {
+            ->action(function (array $data, Get $get, Set $set, ManageRelatedEngagementRecords | StudentEngagementRelationManager $livewire) {
                 $model = app(AiIntegratedAssistantSettings::class)->default_model;
 
                 $userName = auth()->user()->name;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-982

### Technical Description

This originated from the student profile refactor, now the action is able to deal with either type of Livewire component that uses it.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
