### PR TITLE
[ADVAPP-955]: Some campaign actions are generating an exception

### DIFF
--- a/app-modules/engagement/src/Actions/EngagementSmsChannelDelivery.php
+++ b/app-modules/engagement/src/Actions/EngagementSmsChannelDelivery.php
@@ -36,16 +36,25 @@
 
 namespace AdvisingApp\Engagement\Actions;
 
+use AdvisingApp\Engagement\Enums\EngagementDeliveryStatus;
 use AdvisingApp\Engagement\Notifications\EngagementSmsNotification;
 
 class EngagementSmsChannelDelivery extends QueuedEngagementDelivery
 {
     public function deliver(): void
     {
-        $this
-            ->deliverable
-            ->engagement
-            ->recipient
-            ->notifyNow(new EngagementSmsNotification($this->deliverable));
+        $recipient = $this->deliverable->engagement->recipient;
+
+        if (! $recipient->canRecieveSms()) {
+            $this->deliverable->update([
+                'delivery_status' => EngagementDeliveryStatus::DispatchFailed,
+                'last_delivery_attempt' => now(),
+                'delivery_response' => 'System determined recipient cannot receive SMS messages.',
+            ]);
+
+            return;
+        }
+
+        $recipient->notifyNow(new EngagementSmsNotification($this->deliverable));
     }
 }

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -40,12 +40,13 @@ use Illuminate\Database\Eloquent\Collection;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use AdvisingApp\Notification\Models\Contracts\NotifiableInterface;
 
 /**
  * @property-read Collection $careTeam
  * @property string $email
  */
-interface Educatable extends Identifiable
+interface Educatable extends Identifiable, NotifiableInterface
 {
     public static function getLabel(): string;
 
@@ -58,4 +59,6 @@ interface Educatable extends Identifiable
     public static function getLicenseType(): LicenseType;
 
     public function eventAttendeeRecords(): HasMany;
+
+    public function canRecieveSms(): bool;
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-955

### Technical Description

Fixes issues caused by the system trying to send text messages to Educatables that do not have mobile number set. Will mark the delivery as dispatch failed.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
