### PR TITLE
[ADVAPP-1032]: Simulate an inbound text message response when demo mode is enabled.

### DIFF
--- a/app-modules/engagement/src/Actions/EngagementSmsChannelDelivery.php
+++ b/app-modules/engagement/src/Actions/EngagementSmsChannelDelivery.php
@@ -36,8 +36,11 @@
 
 namespace AdvisingApp\Engagement\Actions;
 
+use App\Features\TwilioDemoAutoReplyModeFeature;
 use AdvisingApp\Engagement\Enums\EngagementDeliveryStatus;
+use AdvisingApp\IntegrationTwilio\Settings\TwilioSettings;
 use AdvisingApp\Engagement\Notifications\EngagementSmsNotification;
+use AdvisingApp\Engagement\DataTransferObjects\EngagementResponseData;
 
 class EngagementSmsChannelDelivery extends QueuedEngagementDelivery
 {
@@ -56,5 +59,12 @@ class EngagementSmsChannelDelivery extends QueuedEngagementDelivery
         }
 
         $recipient->notifyNow(new EngagementSmsNotification($this->deliverable));
+
+        if (TwilioDemoAutoReplyModeFeature::active() && app(TwilioSettings::class)->is_demo_auto_reply_mode_enabled) {
+            app(CreateEngagementResponse::class)(EngagementResponseData::from([
+                'from' => $this->deliverable->engagement->recipient->routeNotificationForSms(),
+                'body' => 'Just got your message, thanks for sending over these details.',
+            ]));
+        }
     }
 }

--- a/app-modules/engagement/src/Drivers/EngagementSmsDriver.php
+++ b/app-modules/engagement/src/Drivers/EngagementSmsDriver.php
@@ -36,13 +36,9 @@
 
 namespace AdvisingApp\Engagement\Drivers;
 
-use App\Features\TwilioDemoAutoReplyModeFeature;
 use AdvisingApp\Engagement\Models\EngagementDeliverable;
-use AdvisingApp\IntegrationTwilio\Settings\TwilioSettings;
-use AdvisingApp\Engagement\Actions\CreateEngagementResponse;
 use AdvisingApp\Engagement\Actions\QueuedEngagementDelivery;
 use AdvisingApp\Engagement\Actions\EngagementSmsChannelDelivery;
-use AdvisingApp\Engagement\DataTransferObjects\EngagementResponseData;
 use AdvisingApp\Engagement\Drivers\Contracts\EngagementDeliverableDriver;
 use AdvisingApp\Notification\DataTransferObjects\UpdateSmsDeliveryStatusData;
 use AdvisingApp\IntegrationTwilio\DataTransferObjects\TwilioStatusCallbackData;
@@ -78,12 +74,5 @@ class EngagementSmsDriver implements EngagementDeliverableDriver
     public function deliver(): void
     {
         EngagementSmsChannelDelivery::dispatch($this->deliverable);
-
-        if (TwilioDemoAutoReplyModeFeature::active() && app(TwilioSettings::class)->is_demo_auto_reply_mode_enabled) {
-            app(CreateEngagementResponse::class)(EngagementResponseData::from([
-                'from' => $this->deliverable->engagement->recipient->routeNotificationForSms(),
-                'body' => 'Just got your message, thanks for sending over these details.',
-            ]));
-        }
     }
 }

--- a/app-modules/integration-twilio/database/migrations/2024_11_28_151611_add_is_demo_auto_reply_mode_enabled_setting_to_twilio_settings.php
+++ b/app-modules/integration-twilio/database/migrations/2024_11_28_151611_add_is_demo_auto_reply_mode_enabled_setting_to_twilio_settings.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 

--- a/app-modules/integration-twilio/database/migrations/2024_11_28_151611_add_is_demo_auto_reply_mode_enabled_setting_to_twilio_settings.php
+++ b/app-modules/integration-twilio/database/migrations/2024_11_28_151611_add_is_demo_auto_reply_mode_enabled_setting_to_twilio_settings.php
@@ -1,0 +1,20 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        $this->migrator->inGroup('twilio', function (SettingsBlueprint $blueprint): void {
+            $blueprint->add('is_demo_auto_reply_mode_enabled', false);
+        });
+    }
+
+    public function down(): void
+    {
+        $this->migrator->inGroup('twilio', function (SettingsBlueprint $blueprint): void {
+            $blueprint->delete('is_demo_auto_reply_mode_enabled');
+        });
+    }
+};

--- a/app-modules/integration-twilio/database/migrations/2024_11_28_151611_add_is_demo_auto_reply_mode_enabled_setting_to_twilio_settings.php
+++ b/app-modules/integration-twilio/database/migrations/2024_11_28_151611_add_is_demo_auto_reply_mode_enabled_setting_to_twilio_settings.php
@@ -36,13 +36,17 @@
 
 use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
 
 return new class () extends SettingsMigration {
     public function up(): void
     {
-        $this->migrator->inGroup('twilio', function (SettingsBlueprint $blueprint): void {
-            $blueprint->add('is_demo_auto_reply_mode_enabled', false);
-        });
+        try {
+            $this->migrator->inGroup('twilio', function (SettingsBlueprint $blueprint): void {
+                $blueprint->add('is_demo_auto_reply_mode_enabled', false);
+            });
+        } catch (SettingAlreadyExists) {
+        }
     }
 
     public function down(): void

--- a/app-modules/integration-twilio/database/migrations/2024_11_28_151640_data_activate_twilio_demo_auto_reply_mode_feature.php
+++ b/app-modules/integration-twilio/database/migrations/2024_11_28_151640_data_activate_twilio_demo_auto_reply_mode_feature.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use App\Features\TwilioDemoAutoReplyModeFeature;
 

--- a/app-modules/integration-twilio/database/migrations/2024_11_28_151640_data_activate_twilio_demo_auto_reply_mode_feature.php
+++ b/app-modules/integration-twilio/database/migrations/2024_11_28_151640_data_activate_twilio_demo_auto_reply_mode_feature.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use App\Features\TwilioDemoAutoReplyModeFeature;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        TwilioDemoAutoReplyModeFeature::activate();
+    }
+
+    public function down(): void
+    {
+        TwilioDemoAutoReplyModeFeature::deactivate();
+    }
+};

--- a/app-modules/integration-twilio/src/Filament/Pages/ManageTwilioSettings.php
+++ b/app-modules/integration-twilio/src/Filament/Pages/ManageTwilioSettings.php
@@ -45,6 +45,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\TextInput;
 use App\Filament\Clusters\ProductIntegrations;
+use App\Features\TwilioDemoAutoReplyModeFeature;
 use AdvisingApp\IntegrationTwilio\Settings\TwilioSettings;
 
 class ManageTwilioSettings extends SettingsPage
@@ -81,6 +82,10 @@ class ManageTwilioSettings extends SettingsPage
                     ->label('SMS Demo Mode')
                     ->helperText('When enabled, no messages will be sent.')
                     ->live(),
+                Toggle::make('is_demo_auto_reply_mode_enabled')
+                    ->label('SMS Demo Autoreply')
+                    ->helperText('When enabled, SMS messages will receive an automatic reply.')
+                    ->visible(TwilioDemoAutoReplyModeFeature::active()),
                 Section::make()
                     ->schema([
                         TextInput::make('account_sid')

--- a/app/Features/TwilioDemoAutoReplyModeFeature.php
+++ b/app/Features/TwilioDemoAutoReplyModeFeature.php
@@ -34,44 +34,14 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\IntegrationTwilio\Settings;
+namespace App\Features;
 
-use App\Settings\IntegrationSettings;
-use AdvisingApp\IntegrationTwilio\DataTransferObjects\TwilioApiKey;
+use App\Support\AbstractFeatureFlag;
 
-class TwilioSettings extends IntegrationSettings
+class TwilioDemoAutoReplyModeFeature extends AbstractFeatureFlag
 {
-    public bool $is_enabled = false;
-
-    public bool $is_demo_mode_enabled = false;
-
-    public bool $is_demo_auto_reply_mode_enabled = false;
-
-    public ?TwilioApiKey $api_key = null;
-
-    public ?string $account_sid = null;
-
-    public ?string $auth_token = null;
-
-    public ?string $from_number = null;
-
-    public static function group(): string
+    public function resolve(mixed $scope): mixed
     {
-        return 'twilio';
-    }
-
-    public static function encrypted(): array
-    {
-        return [
-            'api_key',
-            'account_sid',
-            'auth_token',
-            'from_number',
-        ];
-    }
-
-    public function isConfigured(): bool
-    {
-        return $this->account_sid && $this->auth_token && $this->from_number || $this->is_demo_mode_enabled ?? false;
+        return false;
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1032

### Technical Description

If the setting is enabled, a response is created from the SMS driver using the same action that is used by the Twilio web hook controller.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

`TwilioDemoAutoReplyModeFeature`

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
