### PR TITLE
[ADVAPP-1047]: API documentation fails to generate after introducing flexible statuses on alerts

### DIFF
--- a/app-modules/alert/graphql/alert-status.graphql
+++ b/app-modules/alert/graphql/alert-status.graphql
@@ -1,0 +1,106 @@
+type AlertStatus @model(class: "AdvisingApp\\Alert\\Models\\AlertStatus") {
+    "Unique primary key."
+    id: UUID!
+
+    "The Classification of the alert status."
+    classification: SystemAlertStatusClassification!
+
+    "The name of the alert status."
+    name: String!
+
+    "The order of the alert status."
+    order: Int!
+
+    "Whether or not the alert status is the default."
+    is_default: Boolean!
+
+    "The created datetime of the alert."
+    created_at: DateTime
+
+    "The updated datetime of the alert."
+    updated_at: DateTime
+
+    "The deleted datetime of the alert."
+    deleted_at: DateTime
+}
+
+input AlertStatusesQuery {
+    id: UUID
+    classification: SystemAlertStatusClassification
+    name: String
+    order: Int
+    is_default: Boolean
+    created_at: DateTime
+    updated_at: DateTime
+    deleted_at: DateTime
+}
+
+type AlertStatusQueries {
+    "Find a single alert status by an identifying attribute."
+    find(
+        "The value of the attribute to match."
+        id: UUID!
+            @whereKey
+            @rules(apply: ["required", "uuid", "exists:alert_statuses"])
+    ): AlertStatus @find @softDeletes @canResolved(ability: "view")
+
+    "List multiple alert statuses."
+    list(where: AlertStatusesQuery @searchBy): [AlertStatus!]!
+        @paginate
+        @softDeletes
+        @canModel(ability: "viewAny")
+}
+
+extend type Query {
+    alertStatus: AlertStatusQueries! @namespaced
+}
+
+input CreateAlertStatusInput {
+    "The name of the alert status."
+    name: String! @rules(apply: ["required", "string", "max:255"])
+
+    "The classification of the alert status."
+    classification: SystemAlertStatusClassification!
+
+    # Add the ability to set default later
+}
+
+input UpdateAlertStatusInput {
+    "The name of the alert status."
+    name: String! @rules(apply: ["required", "string", "max:255"])
+
+    "The classification of the alert status."
+    classification: SystemAlertStatusClassification!
+
+    # Add the ability to set default later
+}
+
+type AlertStatusMutations {
+    "Create an alert status."
+    create(input: CreateAlertStatusInput! @spread): AlertStatus!
+        @create
+        @canModel(ability: "create")
+
+    "Update an existing alert status."
+    update(
+        "The identifier of the alert status you would like to update."
+        id: UUID!
+            @whereKey
+            @rules(apply: ["required", "uuid", "exists:alert_statuses"])
+
+        "The fields you would like to update."
+        input: UpdateAlertStatusInput! @spread
+    ): AlertStatus! @canFind(ability: "update", find: "id") @update
+
+    "Delete an existing alert status."
+    delete(
+        "The identifier of the alert status you would like to delete."
+        id: UUID!
+            @whereKey
+            @rules(apply: ["required", "uuid", "exists:alert_statuses"])
+    ): AlertStatus @canFind(ability: "delete", find: "id") @delete
+}
+
+extend type Mutation {
+    alertStatus: AlertStatusMutations! @namespaced
+}

--- a/app-modules/alert/graphql/alert.graphql
+++ b/app-modules/alert/graphql/alert.graphql
@@ -12,7 +12,7 @@ type Alert @model(class: "AdvisingApp\\Alert\\Models\\Alert") {
     severity: AlertSeverity!
 
     "The status of the alert."
-    status: AlertStatus!
+    status: AlertStatus! @belongsTo
 
     "The suggested intervention for the alert."
     suggested_intervention: String!
@@ -39,7 +39,7 @@ input AlertsQuery {
     concern_type: EducatableType
     description: String
     severity: AlertSeverity
-    status: AlertStatus
+    status: AlertStatusesQuery
     suggested_intervention: String
     created_at: DateTime
     updated_at: DateTime
@@ -85,7 +85,7 @@ input CreateAlertInput {
     severity: AlertSeverity! @rules(apply: ["required"])
 
     "The status of the alert."
-    status: AlertStatus! @rules(apply: ["required"])
+    status_id: UUID! @rules(apply: ["required", "string", "in:alert_statuses"])
 
     "The suggested intervention for the alert."
     suggested_intervention: String! @rules(apply: ["required", "string"])
@@ -99,7 +99,7 @@ input UpdateAlertInput {
     severity: AlertSeverity @rules(apply: ["filled"])
 
     "The status of the alert."
-    status: AlertStatus @rules(apply: ["filled"])
+    status_id: UUID @rules(apply: ["filled", "string", "in:alert_statuses"])
 
     "The suggested intervention for the alert."
     suggested_intervention: String @rules(apply: ["filled", "string"])

--- a/app-modules/alert/src/Providers/AlertServiceProvider.php
+++ b/app-modules/alert/src/Providers/AlertServiceProvider.php
@@ -93,7 +93,7 @@ class AlertServiceProvider extends ServiceProvider
 
     protected function registerGraphQL(): void
     {
-        $this->discoverSchema(__DIR__ . '/../../graphql/alert.graphql');
+        $this->discoverSchema(__DIR__ . '/../../graphql/*');
 
         $this->registerEnum(AlertSeverity::class);
         $this->registerEnum(SystemAlertStatusClassification::class);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1047

### Technical Description

Fixes an issue in API docs generation caused by changing Alert Status to a Model.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
