### PR TITLE
[ADVAPP-1041]: Prevent the removal of a population segment that is associated with an active campaign

### DIFF
--- a/app-modules/segment/src/Filament/Resources/SegmentResource/Pages/ListSegments.php
+++ b/app-modules/segment/src/Filament/Resources/SegmentResource/Pages/ListSegments.php
@@ -39,17 +39,16 @@ namespace AdvisingApp\Segment\Filament\Resources\SegmentResource\Pages;
 use Filament\Tables\Table;
 use Filament\Actions\CreateAction;
 use Filament\Tables\Filters\Filter;
+use AdvisingApp\Segment\Models\Segment;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
-use Filament\Notifications\Notification;
 use AdvisingApp\Prospect\Models\Prospect;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Actions\DeleteAction;
 use AdvisingApp\StudentDataModel\Models\Student;
-use AdvisingApp\Segment\Filament\Resources\SegmentResource;
-use AdvisingApp\Segment\Models\Segment;
 use Illuminate\Auth\Access\AuthorizationException;
+use AdvisingApp\Segment\Filament\Resources\SegmentResource;
 
 class ListSegments extends ListRecords
 {

--- a/app-modules/segment/src/Filament/Resources/SegmentResource/Pages/ListSegments.php
+++ b/app-modules/segment/src/Filament/Resources/SegmentResource/Pages/ListSegments.php
@@ -47,6 +47,7 @@ use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Actions\DeleteAction;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Segment\Filament\Resources\SegmentResource;
+use Filament\Notifications\Notification;
 
 class ListSegments extends ListRecords
 {
@@ -76,7 +77,25 @@ class ListSegments extends ListRecords
             ])
             ->actions([
                 EditAction::make(),
-                DeleteAction::make(),
+                DeleteAction::make()
+                    ->action(function (DeleteAction $action) {
+                        if ($action->getRecord()->campaigns()->exists()) {
+                            
+                            Notification::make()
+                                        ->title('This population segment is associated with a campaign. Please remove the campaign before attempting to remove the segment.')
+                                        ->warning()
+                                        ->send();
+
+                            $action->cancel();
+                        }
+
+                        $action->getRecord()->delete();
+
+                        Notification::make()
+                                        ->title('Deleted.')
+                                        ->success()
+                                        ->send();   
+                    }),
             ])
             ->filters([
                 Filter::make('my_segments')

--- a/app-modules/segment/src/Filament/Resources/SegmentResource/Pages/ListSegments.php
+++ b/app-modules/segment/src/Filament/Resources/SegmentResource/Pages/ListSegments.php
@@ -41,13 +41,13 @@ use Filament\Actions\CreateAction;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Notifications\Notification;
 use AdvisingApp\Prospect\Models\Prospect;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Actions\DeleteAction;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Segment\Filament\Resources\SegmentResource;
-use Filament\Notifications\Notification;
 
 class ListSegments extends ListRecords
 {
@@ -77,25 +77,7 @@ class ListSegments extends ListRecords
             ])
             ->actions([
                 EditAction::make(),
-                DeleteAction::make()
-                    ->action(function (DeleteAction $action) {
-                        if ($action->getRecord()->campaigns()->exists()) {
-                            
-                            Notification::make()
-                                        ->title('This population segment is associated with a campaign. Please remove the campaign before attempting to remove the segment.')
-                                        ->warning()
-                                        ->send();
-
-                            $action->cancel();
-                        }
-
-                        $action->getRecord()->delete();
-
-                        Notification::make()
-                                        ->title('Deleted.')
-                                        ->success()
-                                        ->send();   
-                    }),
+                DeleteAction::make(),
             ])
             ->filters([
                 Filter::make('my_segments')

--- a/app-modules/segment/src/Policies/SegmentPolicy.php
+++ b/app-modules/segment/src/Policies/SegmentPolicy.php
@@ -102,6 +102,10 @@ class SegmentPolicy implements PerformsChecksBeforeAuthorization
             return Response::deny('You do not have permission to delete this segment.');
         }
 
+        if ($segment->campaigns()->exists()) {
+            return Response::deny('This population segment is associated with a campaign. Please remove the campaign before attempting to remove the segment.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["segment.{$segment->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this segment.'
@@ -124,6 +128,10 @@ class SegmentPolicy implements PerformsChecksBeforeAuthorization
     {
         if (! $authenticatable->hasLicense($segment->model?->class()::getLicenseType())) {
             return Response::deny('You do not have permission to permanently delete this segment.');
+        }
+
+        if ($segment->campaigns()->exists()) {
+            return Response::deny('This population segment is associated with a campaign. Please remove the campaign before attempting to remove the segment.');
         }
 
         return $authenticatable->canOrElse(


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1041

### Technical Description

> Prevent the removal of a population segment that is associated with an active campaign.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
