### PR TITLE
[Bugfix]: Update canyongbs/filament-tiptap-editor

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2876,16 +2876,16 @@
         },
         {
             "name": "canyongbs/filament-tiptap-editor",
-            "version": "1.0.3",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/canyongbs/filament-tiptap-editor.git",
-                "reference": "33666bfe929b8cd9ec00831903b5c5cc90785446"
+                "reference": "b8b986187daf0e2f927b8a9bc4f4e90d455692db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/canyongbs/filament-tiptap-editor/zipball/33666bfe929b8cd9ec00831903b5c5cc90785446",
-                "reference": "33666bfe929b8cd9ec00831903b5c5cc90785446",
+                "url": "https://api.github.com/repos/canyongbs/filament-tiptap-editor/zipball/b8b986187daf0e2f927b8a9bc4f4e90d455692db",
+                "reference": "b8b986187daf0e2f927b8a9bc4f4e90d455692db",
                 "shasum": ""
             },
             "require": {
@@ -2948,7 +2948,7 @@
             ],
             "support": {
                 "issues": "https://github.com/canyongbs/filament-tiptap-editor/issues",
-                "source": "https://github.com/canyongbs/filament-tiptap-editor/tree/1.0.3"
+                "source": "https://github.com/canyongbs/filament-tiptap-editor/tree/1.1.0"
             },
             "funding": [
                 {
@@ -2956,7 +2956,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-18T12:41:25+00:00"
+            "time": "2024-12-02T16:14:18+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Updates the package `canyongbs/filament-tiptap-editor` to contain needed updates for the new clear-formatting tool.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
