### PR TITLE
[ADVAPP-1011]: Add count to filter icon for message center

### DIFF
--- a/app-modules/engagement/resources/views/components/message-center-inbox.blade.php
+++ b/app-modules/engagement/resources/views/components/message-center-inbox.blade.php
@@ -34,6 +34,8 @@
 @php
     use Carbon\Carbon;
     use App\Settings\DisplaySettings;
+
+    $activeFiltersCount = $this->getActiveFiltersCount();
 @endphp
 
 <div
@@ -54,6 +56,8 @@
                 icon="heroicon-m-funnel"
                 x-on:click="showFilters = !showFilters"
                 label="Show Filters and Search"
+                :badge="$activeFiltersCount ?: null"
+                wire:target="filterPeopleType,filterStartDate,filterEndDate,filterSubscribed,filterOpenTasks,filterOpenCases,filterMemberOfCareTeam"
             />
         </div>
 

--- a/app-modules/engagement/src/Filament/Pages/MessageCenter.php
+++ b/app-modules/engagement/src/Filament/Pages/MessageCenter.php
@@ -311,6 +311,44 @@ class MessageCenter extends Page
             });
     }
 
+    public function getActiveFiltersCount(): int
+    {
+        $count = 0;
+
+        if (
+            filled($this->filterPeopleType) &&
+            ($this->filterPeopleType !== 'all')
+        ) {
+            $count++;
+        }
+
+        if ($this->filterStartDate) {
+            $count++;
+        }
+
+        if ($this->filterEndDate) {
+            $count++;
+        }
+
+        if ($this->filterSubscribed) {
+            $count++;
+        }
+
+        if ($this->filterOpenTasks) {
+            $count++;
+        }
+
+        if ($this->filterOpenCases) {
+            $count++;
+        }
+
+        if ($this->filterMemberOfCareTeam) {
+            $count++;
+        }
+
+        return $count;
+    }
+
     public function engage(): void
     {
         $this->mountAction('create');


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1011

### Technical Description

Introduces count of currently active filters. Count method needs to be updated when new filters are added.

Adds loading indicator to the filter button to improve percieved performance of the page. Also needs to be kept up to date when new filters are added.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
