### PR TITLE
[ADVAPP-1051]: Add event date to user auditing list view and detail view

### DIFF
--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
@@ -52,6 +52,7 @@ use Filament\Tables\Actions\ExportBulkAction;
 use AdvisingApp\Audit\Filament\Exports\AuditExporter;
 use AdvisingApp\Audit\Actions\Finders\AuditableModels;
 use AdvisingApp\Audit\Filament\Resources\AuditResource;
+use Carbon\Carbon;
 
 class ListAudits extends ListRecords
 {
@@ -74,6 +75,9 @@ class ListAudits extends ListRecords
                 TextColumn::make('event')
                     ->label('Event')
                     ->sortable(),
+                TextColumn::make('created_at')
+                    ->label('Occurred At')
+                    ->formatStateUsing(fn (string $state) => Carbon::parse($state)->format('d-m-Y h:i A')),
             ])
             ->defaultSort('id', 'desc')
             ->filters([

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Audit\Filament\Resources\AuditResource\Pages;
 
+use Carbon\Carbon;
 use App\Models\User;
 use Filament\Tables\Table;
 use Filament\Actions\ExportAction;
@@ -52,7 +53,6 @@ use Filament\Tables\Actions\ExportBulkAction;
 use AdvisingApp\Audit\Filament\Exports\AuditExporter;
 use AdvisingApp\Audit\Actions\Finders\AuditableModels;
 use AdvisingApp\Audit\Filament\Resources\AuditResource;
-use Carbon\Carbon;
 
 class ListAudits extends ListRecords
 {

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ListAudits.php
@@ -77,7 +77,7 @@ class ListAudits extends ListRecords
                     ->sortable(),
                 TextColumn::make('created_at')
                     ->label('Occurred At')
-                    ->formatStateUsing(fn (string $state) => Carbon::parse($state)->format('d-m-Y h:i A')),
+                    ->formatStateUsing(fn (string $state) => Carbon::parse($state)->format('m-d-Y h:i A')),
             ])
             ->defaultSort('id', 'desc')
             ->filters([

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
@@ -42,6 +42,7 @@ use Filament\Resources\Pages\ViewRecord;
 use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\TextEntry;
 use AdvisingApp\Audit\Filament\Resources\AuditResource;
+use Carbon\Carbon;
 
 class ViewAudit extends ViewRecord
 {
@@ -68,6 +69,9 @@ class ViewAudit extends ViewRecord
                             ->label('IP Address'),
                         TextEntry::make('user_agent')
                             ->label('User Agent'),
+                        TextEntry::make('created_at')
+                            ->label('Occurred At')
+                            ->formatStateUsing(fn (string $state) => Carbon::parse($state)->format('d-m-Y h:i A')),
                         TextEntry::make('getModified')
                             ->label('Changes')
                             ->columnSpanFull()

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
@@ -36,13 +36,13 @@
 
 namespace AdvisingApp\Audit\Filament\Resources\AuditResource\Pages;
 
+use Carbon\Carbon;
 use Filament\Infolists\Infolist;
 use AdvisingApp\Audit\Models\Audit;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\TextEntry;
 use AdvisingApp\Audit\Filament\Resources\AuditResource;
-use Carbon\Carbon;
 
 class ViewAudit extends ViewRecord
 {

--- a/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
+++ b/app-modules/audit/src/Filament/Resources/AuditResource/Pages/ViewAudit.php
@@ -71,7 +71,7 @@ class ViewAudit extends ViewRecord
                             ->label('User Agent'),
                         TextEntry::make('created_at')
                             ->label('Occurred At')
-                            ->formatStateUsing(fn (string $state) => Carbon::parse($state)->format('d-m-Y h:i A')),
+                            ->formatStateUsing(fn (string $state) => Carbon::parse($state)->format('m-d-Y h:i A')),
                         TextEntry::make('getModified')
                             ->label('Changes')
                             ->columnSpanFull()


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1051

### Technical Description

> Add event date to user auditing list view and detail view

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
