### PR TITLE
[ADVAPP-1014]: Rename the knowledge base addon to Resource Hub in the backend

### DIFF
--- a/app-modules/resource-hub/database/migrations/2024_12_09_174712_data_change_knowledge_management_to_resource_hub_in_license_group_in_settings_table.php
+++ b/app-modules/resource-hub/database/migrations/2024_12_09_174712_data_change_knowledge_management_to_resource_hub_in_license_group_in_settings_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\DataTransferObjects\LicenseManagement\LicenseData;
+use Illuminate\Database\Eloquent\Casts\Json;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $payload = DB::table('settings')->where('group', 'license')
+            ->where('name', 'data')
+            ->value('payload');
+
+        $payload = decrypt(json_decode($payload));
+        $payload['addons']['resource_hub'] = $payload['addons']['knowledge_management'];
+        unset($payload['addons']['knowledge_management']);
+
+        DB::table('settings')->where('group', 'license')
+            ->where('name', 'data')
+            ->update(['payload' => encrypt(json_encode($payload))]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/app-modules/resource-hub/graphql/resource-hub-article.graphql
+++ b/app-modules/resource-hub/graphql/resource-hub-article.graphql
@@ -1,10 +1,10 @@
 type ResourceHubArticle
-    @addon(name: "knowledge-management")
+    @addon(name: "resource-hub")
     @model(class: "AdvisingApp\\ResourceHub\\Models\\ResourceHubArticle") {
     id: UUID!
 }
 
-type ResourceHubArticleQueries @addon(name: "knowledge-management") {
+type ResourceHubArticleQueries @addon(name: "resource-hub") {
     "Find a single resource hub article by an identifying attribute."
     find(
         "The value of the attribute to match."
@@ -17,6 +17,6 @@ type ResourceHubArticleQueries @addon(name: "knowledge-management") {
     list: [ResourceHubArticle!]! @canModel(ability: "viewAny") @paginate
 }
 
-extend type Query @addon(name: "knowledge-management") {
+extend type Query @addon(name: "resource-hub") {
     ResourceHubArticle: ResourceHubArticleQueries! @namespaced
 }

--- a/app-modules/resource-hub/src/Policies/ResourceHubArticlePolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubArticlePolicy.php
@@ -121,6 +121,6 @@ class ResourceHubArticlePolicy implements PerformsChecksBeforeAuthorization
 
     protected function requiredFeatures(): array
     {
-        return [Feature::KnowledgeManagement];
+        return [Feature::ResourceHub];
     }
 }

--- a/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
@@ -121,6 +121,6 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     protected function requiredFeatures(): array
     {
-        return [Feature::KnowledgeManagement];
+        return [Feature::ResourceHub];
     }
 }

--- a/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
@@ -121,6 +121,6 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     protected function requiredFeatures(): array
     {
-        return [Feature::KnowledgeManagement];
+        return [Feature::ResourceHub];
     }
 }

--- a/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
@@ -121,6 +121,6 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     protected function requiredFeatures(): array
     {
-        return [Feature::KnowledgeManagement];
+        return [Feature::ResourceHub];
     }
 }

--- a/app-modules/resource-hub/tests/ResourceHubArticle/CreateResourceHubArticleTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubArticle/CreateResourceHubArticleTest.php
@@ -55,75 +55,75 @@ use AdvisingApp\ResourceHub\Tests\ResourceHubArticle\RequestFactories\CreateReso
 // Permission Tests
 
 test('CreateResourceHubArticle is gated with proper access control', function () {
-    $user = User::factory()->licensed(LicenseType::cases())->create();
+  $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    actingAs($user);
+  actingAs($user);
 
-    $user->givePermissionTo('resource_hub_article.view-any');
+  $user->givePermissionTo('resource_hub_article.view-any');
 
-    livewire(ListResourceHubArticles::class)
-        ->assertSuccessful()
-        ->assertActionDisabled('create');
+  livewire(ListResourceHubArticles::class)
+    ->assertSuccessful()
+    ->assertActionDisabled('create');
 
-    $user->givePermissionTo('resource_hub_article.create');
+  $user->givePermissionTo('resource_hub_article.create');
 
-    livewire(ListResourceHubArticles::class)
-        ->assertActionEnabled('create');
+  livewire(ListResourceHubArticles::class)
+    ->assertActionEnabled('create');
 
-    $request = collect(CreateResourceHubArticleRequestFactory::new()->create());
+  $request = collect(CreateResourceHubArticleRequestFactory::new()->create());
 
-    livewire(ListResourceHubArticles::class)
-        ->callAction('create', $request->toArray())
-        ->assertHasNoActionErrors();
+  livewire(ListResourceHubArticles::class)
+    ->callAction('create', $request->toArray())
+    ->assertHasNoActionErrors();
 
-    assertCount(1, ResourceHubArticle::all());
+  assertCount(1, ResourceHubArticle::all());
 
-    $data = $request->except('division')->toArray();
+  $data = $request->except('division')->toArray();
 
-    assertDatabaseHas(ResourceHubArticle::class, $data);
+  assertDatabaseHas(ResourceHubArticle::class, $data);
 
-    $resourceHubArticle = ResourceHubArticle::first();
+  $resourceHubArticle = ResourceHubArticle::first();
 
-    expect($resourceHubArticle->division->pluck('id')->toArray())->toEqual($request['division']);
+  expect($resourceHubArticle->division->pluck('id')->toArray())->toEqual($request['division']);
 });
 
 test('CreateResourceHubArticle is gated with proper feature access control', function () {
-    $settings = app(LicenseSettings::class);
+  $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+  $settings->data->addons->resourceHub = false;
 
-    $settings->save();
+  $settings->save();
 
-    $user = User::factory()->licensed(LicenseType::cases())->create();
+  $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    actingAs($user);
+  actingAs($user);
 
-    $user->givePermissionTo('resource_hub_article.view-any');
-    $user->givePermissionTo('resource_hub_article.create');
+  $user->givePermissionTo('resource_hub_article.view-any');
+  $user->givePermissionTo('resource_hub_article.create');
 
-    livewire(ListResourceHubArticles::class)
-        ->assertForbidden();
+  livewire(ListResourceHubArticles::class)
+    ->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+  $settings->data->addons->resourceHub = true;
 
-    $settings->save();
+  $settings->save();
 
-    livewire(ListResourceHubArticles::class)
-        ->assertSuccessful();
+  livewire(ListResourceHubArticles::class)
+    ->assertSuccessful();
 
-    $request = collect(CreateResourceHubArticleRequestFactory::new()->create());
+  $request = collect(CreateResourceHubArticleRequestFactory::new()->create());
 
-    livewire(ListResourceHubArticles::class)
-        ->callAction('create', $request->toArray())
-        ->assertHasNoActionErrors();
+  livewire(ListResourceHubArticles::class)
+    ->callAction('create', $request->toArray())
+    ->assertHasNoActionErrors();
 
-    assertCount(1, ResourceHubArticle::all());
+  assertCount(1, ResourceHubArticle::all());
 
-    $data = $request->except('division')->toArray();
+  $data = $request->except('division')->toArray();
 
-    assertDatabaseHas(ResourceHubArticle::class, $data);
+  assertDatabaseHas(ResourceHubArticle::class, $data);
 
-    $resourceHubArticle = ResourceHubArticle::first();
+  $resourceHubArticle = ResourceHubArticle::first();
 
-    expect($resourceHubArticle->division->pluck('id')->toArray())->toEqual($request['division']);
+  expect($resourceHubArticle->division->pluck('id')->toArray())->toEqual($request['division']);
 });

--- a/app-modules/resource-hub/tests/ResourceHubArticle/EditResourceHubArticleTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubArticle/EditResourceHubArticleTest.php
@@ -88,7 +88,7 @@ test('EditResourceHubArticle is gated with proper access control', function () {
 test('EditResourceHubArticle is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -112,7 +112,7 @@ test('EditResourceHubArticle is gated with proper feature access control', funct
     ])
         ->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubArticle/ListResourceHubArticlesTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubArticle/ListResourceHubArticlesTest.php
@@ -56,63 +56,63 @@ use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubArticleResource;
 // Permission Tests
 
 testResourceRequiresPermissionForAccess(
-    resource: ResourceHubArticleResource::class,
-    permissions: 'resource_hub_article.view-any',
-    method: 'index'
+  resource: ResourceHubArticleResource::class,
+  permissions: 'resource_hub_article.view-any',
+  method: 'index'
 );
 
 test('ListResourceHubArticles is gated with proper feature access control', function () {
-    $settings = app(LicenseSettings::class);
+  $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+  $settings->data->addons->resourceHub = false;
 
-    $settings->save();
+  $settings->save();
 
-    $user = User::factory()->licensed(LicenseType::cases())->create();
+  $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('resource_hub_article.view-any');
+  $user->givePermissionTo('resource_hub_article.view-any');
 
-    actingAs($user);
+  actingAs($user);
 
-    get(
-        ResourceHubArticleResource::getUrl('index')
-    )->assertForbidden();
+  get(
+    ResourceHubArticleResource::getUrl('index')
+  )->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+  $settings->data->addons->resourceHub = true;
 
-    $settings->save();
+  $settings->save();
 
-    get(
-        ResourceHubArticleResource::getUrl('index')
-    )->assertSuccessful();
+  get(
+    ResourceHubArticleResource::getUrl('index')
+  )->assertSuccessful();
 });
 
 test('ListResourceHubArticles is gated with proper license access control', function () {
-    $settings = app(LicenseSettings::class);
+  $settings = app(LicenseSettings::class);
 
-    // When the feature is enabled
-    $settings->data->addons->knowledgeManagement = true;
+  // When the feature is enabled
+  $settings->data->addons->resourceHub = true;
 
-    $settings->save();
+  $settings->save();
 
-    $user = User::factory()->create();
+  $user = User::factory()->create();
 
-    // And the authenticatable has the correct permissions
-    // But they do not have the appropriate license
-    $user->givePermissionTo('resource_hub_article.view-any');
+  // And the authenticatable has the correct permissions
+  // But they do not have the appropriate license
+  $user->givePermissionTo('resource_hub_article.view-any');
 
-    // They should not be able to access the resource
-    actingAs($user);
+  // They should not be able to access the resource
+  actingAs($user);
 
-    get(
-        ResourceHubArticleResource::getUrl('index')
-    )->assertForbidden();
+  get(
+    ResourceHubArticleResource::getUrl('index')
+  )->assertForbidden();
 
-    $user->grantLicense(LicenseType::RecruitmentCrm);
+  $user->grantLicense(LicenseType::RecruitmentCrm);
 
-    $user->refresh();
+  $user->refresh();
 
-    get(
-        ResourceHubArticleResource::getUrl('index')
-    )->assertSuccessful();
+  get(
+    ResourceHubArticleResource::getUrl('index')
+  )->assertSuccessful();
 });

--- a/app-modules/resource-hub/tests/ResourceHubArticle/ViewResourceHubArticleTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubArticle/ViewResourceHubArticleTest.php
@@ -52,57 +52,57 @@ use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubArticleResource;
 // Permission Tests
 
 test('ViewResourceHubArticle is gated with proper access control', function () {
-    $user = User::factory()->licensed(LicenseType::cases())->create();
+  $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $resourceHubArticle = ResourceHubArticle::factory()->create();
+  $resourceHubArticle = ResourceHubArticle::factory()->create();
 
-    actingAs($user);
+  actingAs($user);
 
-    get(
-        ResourceHubArticleResource::getUrl('view', [
-            'record' => $resourceHubArticle,
-        ])
-    )->assertForbidden();
+  get(
+    ResourceHubArticleResource::getUrl('view', [
+      'record' => $resourceHubArticle,
+    ])
+  )->assertForbidden();
 
-    $user->givePermissionTo('resource_hub_article.view-any');
-    $user->givePermissionTo('resource_hub_article.*.view');
+  $user->givePermissionTo('resource_hub_article.view-any');
+  $user->givePermissionTo('resource_hub_article.*.view');
 
-    get(
-        ResourceHubArticleResource::getUrl('view', [
-            'record' => $resourceHubArticle,
-        ])
-    )->assertSuccessful();
+  get(
+    ResourceHubArticleResource::getUrl('view', [
+      'record' => $resourceHubArticle,
+    ])
+  )->assertSuccessful();
 });
 
 test('ViewResourceHubArticle is gated with proper feature access control', function () {
-    $settings = app(LicenseSettings::class);
+  $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+  $settings->data->addons->resourceHub = false;
 
-    $settings->save();
+  $settings->save();
 
-    $user = User::factory()->licensed(LicenseType::cases())->create();
+  $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('resource_hub_article.view-any');
-    $user->givePermissionTo('resource_hub_article.*.view');
+  $user->givePermissionTo('resource_hub_article.view-any');
+  $user->givePermissionTo('resource_hub_article.*.view');
 
-    $resourceHubArticle = ResourceHubArticle::factory()->create();
+  $resourceHubArticle = ResourceHubArticle::factory()->create();
 
-    actingAs($user);
+  actingAs($user);
 
-    get(
-        ResourceHubArticleResource::getUrl('view', [
-            'record' => $resourceHubArticle,
-        ])
-    )->assertForbidden();
+  get(
+    ResourceHubArticleResource::getUrl('view', [
+      'record' => $resourceHubArticle,
+    ])
+  )->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+  $settings->data->addons->resourceHub = true;
 
-    $settings->save();
+  $settings->save();
 
-    get(
-        ResourceHubArticleResource::getUrl('view', [
-            'record' => $resourceHubArticle,
-        ])
-    )->assertSuccessful();
+  get(
+    ResourceHubArticleResource::getUrl('view', [
+      'record' => $resourceHubArticle,
+    ])
+  )->assertSuccessful();
 });

--- a/app-modules/resource-hub/tests/ResourceHubCategory/CreateResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubCategory/CreateResourceHubCategoryTest.php
@@ -89,7 +89,7 @@ test('CreateResourceHubCategory is gated with proper access control', function (
 test('CreateResourceHubCategory is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -106,7 +106,7 @@ test('CreateResourceHubCategory is gated with proper feature access control', fu
     livewire(CreateResourceHubCategory::class)
         ->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubCategory/EditResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubCategory/EditResourceHubCategoryTest.php
@@ -96,7 +96,7 @@ test('EditResourceHubCategory is gated with proper access control', function () 
 test('EditResourceHubCategory is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -119,7 +119,7 @@ test('EditResourceHubCategory is gated with proper feature access control', func
     ])
         ->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubCategory/ListResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubCategory/ListResourceHubCategoryTest.php
@@ -68,7 +68,7 @@ test('ListResourceHubCategory is gated with proper access control', function () 
 test('ListResourceHubCategory is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -81,7 +81,7 @@ test('ListResourceHubCategory is gated with proper feature access control', func
             ResourceHubCategoryResource::getUrl('index')
         )->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 
@@ -95,7 +95,7 @@ test('ListResourceHubCategory is gated with proper license access control', func
     $settings = app(LicenseSettings::class);
 
     // When the feature is enabled
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubCategory/ViewResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubCategory/ViewResourceHubCategoryTest.php
@@ -74,7 +74,7 @@ test('ViewResourceHubCategory is gated with proper access control', function () 
 test('ViewResourceHubCategory is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -92,7 +92,7 @@ test('ViewResourceHubCategory is gated with proper feature access control', func
             ])
         )->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubQuality/CreateResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubQuality/CreateResourceHubQualityTest.php
@@ -89,7 +89,7 @@ test('CreateResourceHubQuality is gated with proper access control', function ()
 test('CreateResourceHubQuality is gated with proper feature ccess control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -106,7 +106,7 @@ test('CreateResourceHubQuality is gated with proper feature ccess control', func
     livewire(CreateResourceHubQuality::class)
         ->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubQuality/EditResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubQuality/EditResourceHubQualityTest.php
@@ -96,7 +96,7 @@ test('EditResourceHubQuality is gated with proper access control', function () {
 test('EditResourceHubQuality is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -119,7 +119,7 @@ test('EditResourceHubQuality is gated with proper feature access control', funct
     ])
         ->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubQuality/ListResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubQuality/ListResourceHubQualityTest.php
@@ -68,7 +68,7 @@ test('ListResourceHubQuality is gated with proper access control', function () {
 test('ListResourceHubQuality is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -81,7 +81,7 @@ test('ListResourceHubQuality is gated with proper feature access control', funct
             ResourceHubQualityResource::getUrl('index')
         )->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 
@@ -95,7 +95,7 @@ test('ListResourceHubQuality is gated with proper license access control', funct
     $settings = app(LicenseSettings::class);
 
     // When the feature is enabled
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubQuality/ViewResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubQuality/ViewResourceHubQualityTest.php
@@ -74,7 +74,7 @@ test('ViewResourceHubQuality is gated with proper access control', function () {
 test('ViewResourceHubQuality is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -92,7 +92,7 @@ test('ViewResourceHubQuality is gated with proper feature access control', funct
             ])
         )->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubStatus/CreateResourceHubStatusTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubStatus/CreateResourceHubStatusTest.php
@@ -89,7 +89,7 @@ test('CreateResourceHubStatus is gated with proper access control', function () 
 test('CreateResourceHubStatus is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -106,7 +106,7 @@ test('CreateResourceHubStatus is gated with proper feature access control', func
     livewire(CreateResourceHubStatus::class)
         ->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubStatus/EditResourceHubStatusTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubStatus/EditResourceHubStatusTest.php
@@ -96,7 +96,7 @@ test('EditResourceHubStatus is gated with proper access control', function () {
 test('EditResourceHubStatus is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -119,7 +119,7 @@ test('EditResourceHubStatus is gated with proper feature access control', functi
     ])
         ->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubStatus/ListResourceHubStatusesTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubStatus/ListResourceHubStatusesTest.php
@@ -68,7 +68,7 @@ test('ListResourceHubStatuses is gated with proper access control', function () 
 test('ListResourceHubStatuses is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -81,7 +81,7 @@ test('ListResourceHubStatuses is gated with proper feature access control', func
             ResourceHubStatusResource::getUrl('index')
         )->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 
@@ -95,7 +95,7 @@ test('ListResourceHubStatus is gated with proper license access control', functi
     $settings = app(LicenseSettings::class);
 
     // When the feature is enabled
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app-modules/resource-hub/tests/ResourceHubStatus/ViewResourceHubStatusTest.php
+++ b/app-modules/resource-hub/tests/ResourceHubStatus/ViewResourceHubStatusTest.php
@@ -74,7 +74,7 @@ test('ViewResourceHubStatus is gated with proper access control', function () {
 test('ViewResourceHubStatus is gated with proper feature access control', function () {
     $settings = app(LicenseSettings::class);
 
-    $settings->data->addons->knowledgeManagement = false;
+    $settings->data->addons->resourceHub = false;
 
     $settings->save();
 
@@ -92,7 +92,7 @@ test('ViewResourceHubStatus is gated with proper feature access control', functi
             ])
         )->assertForbidden();
 
-    $settings->data->addons->knowledgeManagement = true;
+    $settings->data->addons->resourceHub = true;
 
     $settings->save();
 

--- a/app/Console/Commands/CreateTenant.php
+++ b/app/Console/Commands/CreateTenant.php
@@ -155,7 +155,7 @@ class CreateTenant extends Command
                     onlineSurveys: true,
                     onlineAdmissions: true,
                     serviceManagement: true,
-                    knowledgeManagement: true,
+                    resourceHub: true,
                     eventManagement: true,
                     realtimeChat: true,
                     mobileApps: true,

--- a/app/DataTransferObjects/LicenseManagement/LicenseAddonsData.php
+++ b/app/DataTransferObjects/LicenseManagement/LicenseAddonsData.php
@@ -43,16 +43,16 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 #[MapInputName(SnakeCaseMapper::class)]
 class LicenseAddonsData extends Data
 {
-    public function __construct(
-        public bool $onlineForms,
-        public bool $onlineSurveys,
-        public bool $onlineAdmissions,
-        public bool $serviceManagement,
-        public bool $knowledgeManagement,
-        public bool $eventManagement,
-        public bool $realtimeChat,
-        public bool $mobileApps,
-        public bool $scheduleAndAppointments = false,
-        public bool $customAiAssistants = false,
-    ) {}
+  public function __construct(
+    public bool $onlineForms,
+    public bool $onlineSurveys,
+    public bool $onlineAdmissions,
+    public bool $serviceManagement,
+    public bool $resourceHub,
+    public bool $eventManagement,
+    public bool $realtimeChat,
+    public bool $mobileApps,
+    public bool $scheduleAndAppointments = false,
+    public bool $customAiAssistants = false,
+  ) {}
 }

--- a/app/DataTransferObjects/LicenseManagement/LicenseData.php
+++ b/app/DataTransferObjects/LicenseManagement/LicenseData.php
@@ -44,10 +44,10 @@ use Spatie\LaravelData\Mappers\SnakeCaseMapper;
 #[MapInputName(SnakeCaseMapper::class)]
 class LicenseData extends Data
 {
-    public function __construct(
-        public Carbon $updatedAt,
-        public LicenseSubscriptionData $subscription,
-        public LicenseLimitsData $limits,
-        public LicenseAddonsData $addons,
-    ) {}
+  public function __construct(
+    public Carbon $updatedAt,
+    public LicenseSubscriptionData $subscription,
+    public LicenseLimitsData $limits,
+    public LicenseAddonsData $addons,
+  ) {}
 }

--- a/app/Enums/Feature.php
+++ b/app/Enums/Feature.php
@@ -42,36 +42,36 @@ use Illuminate\Support\Facades\Gate;
 
 enum Feature: string
 {
-    case OnlineForms = 'online-forms';
+  case OnlineForms = 'online-forms';
 
-    case OnlineSurveys = 'online-surveys';
+  case OnlineSurveys = 'online-surveys';
 
-    case OnlineAdmissions = 'online-admissions';
+  case OnlineAdmissions = 'online-admissions';
 
-    case ServiceManagement = 'service-management';
+  case ServiceManagement = 'service-management';
 
-    case KnowledgeManagement = 'knowledge-management';
+  case ResourceHub = 'resource-hub';
 
-    case EventManagement = 'event-management';
-    case RealtimeChat = 'realtime-chat';
+  case EventManagement = 'event-management';
+  case RealtimeChat = 'realtime-chat';
 
-    case MobileApps = 'mobile-apps';
+  case MobileApps = 'mobile-apps';
 
-    case ScheduleAndAppointments = 'schedule-and-appointments';
+  case ScheduleAndAppointments = 'schedule-and-appointments';
 
-    case CustomAiAssistants = 'custom-ai-assistants';
+  case CustomAiAssistants = 'custom-ai-assistants';
 
-    public function generateGate(): void
-    {
-        // If features are added that are not based on a License Addon we will need to update this
-        Gate::define(
-            $this->getGateName(),
-            fn (?Authenticatable $authenticatable) => app(LicenseSettings::class)->data->addons->{str($this->value)->camel()}
-        );
-    }
+  public function generateGate(): void
+  {
+    // If features are added that are not based on a License Addon we will need to update this
+    Gate::define(
+      $this->getGateName(),
+      fn(?Authenticatable $authenticatable) => app(LicenseSettings::class)->data->addons->{str($this->value)->camel()}
+    );
+  }
 
-    public function getGateName(): string
-    {
-        return "feature-{$this->value}";
-    }
+  public function getGateName(): string
+  {
+    return "feature-{$this->value}";
+  }
 }

--- a/app/Filament/Pages/ManageLicenseSettings.php
+++ b/app/Filament/Pages/ManageLicenseSettings.php
@@ -113,7 +113,7 @@ class ManageLicenseSettings extends SettingsPage
                                 ->numeric()
                                 ->minValue(0)
                                 ->required()
-                                ->disabled(fn (Get $get): bool => (bool) $get('conversationalAiSeats')),
+                                ->disabled(fn(Get $get): bool => (bool) $get('conversationalAiSeats')),
                             TextInput::make('data.limits.retentionCrmSeats')
                                 ->label('Student Success / Retention Seats')
                                 ->numeric()
@@ -151,7 +151,7 @@ class ManageLicenseSettings extends SettingsPage
                                 ->label('Online Admissions'),
                             Toggle::make('data.addons.serviceManagement')
                                 ->label('Case Management'),
-                            Toggle::make('data.addons.knowledgeManagement')
+                            Toggle::make('data.addons.resourceHub')
                                 ->label('Resource Hub'),
                             Toggle::make('data.addons.eventManagement')
                                 ->label('Event Management'),

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -146,7 +146,7 @@ abstract class TestCase extends BaseTestCase
                         onlineSurveys: true,
                         onlineAdmissions: true,
                         serviceManagement: true,
-                        knowledgeManagement: true,
+                        resourceHub: true,
                         eventManagement: true,
                         realtimeChat: true,
                         mobileApps: true,
@@ -261,7 +261,7 @@ abstract class TestCase extends BaseTestCase
                     onlineSurveys: true,
                     onlineAdmissions: true,
                     serviceManagement: true,
-                    knowledgeManagement: true,
+                    resourceHub: true,
                     eventManagement: true,
                     realtimeChat: true,
                     mobileApps: true,
@@ -323,7 +323,7 @@ abstract class TestCase extends BaseTestCase
 
     protected function getCachedMigrationChecksum(string $connection): ?string
     {
-        return rescue(fn () => file_get_contents($this->getMigrationChecksumFile($connection)), null, false);
+        return rescue(fn() => file_get_contents($this->getMigrationChecksumFile($connection)), null, false);
     }
 
     protected function getMigrationChecksumFile(string $connection): string


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1014

### Technical Description

>Rename the knowledge base addon to Resource Hub in the backend

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
