### PR TITLE
[ADVAPP-1061]: Users who do not have a profile image set via SSO present a broken image as their avatar.

### DIFF
--- a/app-modules/resource-hub/database/migrations/2024_12_09_174712_data_change_knowledge_management_to_resource_hub_in_license_group_in_settings_table.php
+++ b/app-modules/resource-hub/database/migrations/2024_12_09_174712_data_change_knowledge_management_to_resource_hub_in_license_group_in_settings_table.php
@@ -46,9 +46,9 @@ return new class () extends SettingsMigration {
             group: 'license',
             name: 'data',
             modifyPayload: function (array $data) {
-                if (array_key_exists('knowledge_management', $data['addons'] ?? [])) {
-                    $data['addons']['resource_hub'] = $data['addons']['knowledge_management'];
-                    unset($data['addons']['knowledge_management']);
+                if (array_key_exists('knowledgeManagement', $data['addons'] ?? [])) {
+                    $data['addons']['resourceHub'] = $data['addons']['knowledgeManagement'];
+                    unset($data['addons']['knowledgeManagement']);
                 }
 
                 return $data;
@@ -63,9 +63,9 @@ return new class () extends SettingsMigration {
             group: 'license',
             name: 'data',
             modifyPayload: function (array $data) {
-                if (array_key_exists('resource_hub', $data['addons'] ?? [])) {
-                    $data['addons']['knowledge_management'] = $data['addons']['resource_hub'];
-                    unset($data['addons']['resource_hub']);
+                if (array_key_exists('resourceHub', $data['addons'] ?? [])) {
+                    $data['addons']['knowledgeManagement'] = $data['addons']['resourceHub'];
+                    unset($data['addons']['resourceHub']);
                 }
 
                 return $data;

--- a/app-modules/resource-hub/database/migrations/2024_12_09_174712_data_change_knowledge_management_to_resource_hub_in_license_group_in_settings_table.php
+++ b/app-modules/resource-hub/database/migrations/2024_12_09_174712_data_change_knowledge_management_to_resource_hub_in_license_group_in_settings_table.php
@@ -51,6 +51,11 @@ return new class () extends SettingsMigration {
                     unset($data['addons']['knowledgeManagement']);
                 }
 
+                if (array_key_exists('knowledge_management', $data['addons'] ?? [])) {
+                    $data['addons']['resource_hub'] = $data['addons']['knowledge_management'];
+                    unset($data['addons']['knowledge_management']);
+                }
+
                 return $data;
             },
             isEncrypted: true,
@@ -66,6 +71,11 @@ return new class () extends SettingsMigration {
                 if (array_key_exists('resourceHub', $data['addons'] ?? [])) {
                     $data['addons']['knowledgeManagement'] = $data['addons']['resourceHub'];
                     unset($data['addons']['resourceHub']);
+                }
+
+                if (array_key_exists('resource_hub', $data['addons'] ?? [])) {
+                    $data['addons']['knowledge_management'] = $data['addons']['resource_hub'];
+                    unset($data['addons']['resource_hub']);
                 }
 
                 return $data;

--- a/app/Exceptions/InvalidUserAvatarMimeType.php
+++ b/app/Exceptions/InvalidUserAvatarMimeType.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Exceptions;
+
+use Exception;
+use App\Models\User;
+
+class InvalidUserAvatarMimeType extends Exception
+{
+    public function __construct(
+        protected string $mimeType,
+        protected User $user
+    ) {
+        parent::__construct(
+            "The provided avatar image for user {$user->getKey()} has an invalid MIME type: {$mimeType}."
+        );
+    }
+}

--- a/database/migrations/2024_12_11_221606_data_remove_all_media_user_avatars_that_saved_as_json.php
+++ b/database/migrations/2024_12_11_221606_data_remove_all_media_user_avatars_that_saved_as_json.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 

--- a/database/migrations/2024_12_11_221606_data_remove_all_media_user_avatars_that_saved_as_json.php
+++ b/database/migrations/2024_12_11_221606_data_remove_all_media_user_avatars_that_saved_as_json.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Media::query()
+            ->where('model_type', 'user')
+            ->where('collection_name', 'avatar')
+            ->where('mime_type', 'application/json')
+            ->get()
+            ->each(function (Media $media) {
+                $media->forceDelete();
+            });
+    }
+
+    public function down(): void
+    {
+        // Not possible to revert
+    }
+};


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1061

### Technical Description

- Fixes an issue with license addon data migration
- Fixes a bug with the Azure Socialite login avatar retrieval
- Data fixes removing all User Avatars that saved as JSON due to the previous bug
    - I am aware that I am breaking our rule to not use Model classes like Media. But I would like to propose an exception since this will be short lived and is the fastest way to ensure the media Model is deleted and the media itself is purged from storage.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

Data Migration: `database/migrations/2024_12_11_221606_data_remove_all_media_user_avatars_that_saved_as_json.php`

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
