### PR TITLE
[ADVAPP-1064]: Refactor Task access to not use individual permissions to manage access

### DIFF
--- a/app-modules/task/database/migrations/2024_12_18_104302_delete_task_individual_update_permissions.php
+++ b/app-modules/task/database/migrations/2024_12_18_104302_delete_task_individual_update_permissions.php
@@ -34,8 +34,8 @@
 </COPYRIGHT>
 */
 
-use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class () extends Migration {
     public function up(): void

--- a/app-modules/task/database/migrations/2024_12_18_104302_delete_task_individual_update_permissions.php
+++ b/app-modules/task/database/migrations/2024_12_18_104302_delete_task_individual_update_permissions.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2024, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Migrations\Migration;
 

--- a/app-modules/task/database/migrations/2024_12_18_104302_delete_task_individual_update_permissions.php
+++ b/app-modules/task/database/migrations/2024_12_18_104302_delete_task_individual_update_permissions.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::table('permissions')
+            ->select('id')
+            ->whereRaw("name ~ '^task\\.[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\\.update$'")
+            ->orderBy('id')
+            ->chunkById(100, function ($rows) {
+                $ids = $rows->pluck('id')->toArray();
+                DB::table('permissions')->whereIn('id', $ids)->delete();
+            });
+    }
+};

--- a/app-modules/task/src/Policies/TaskPolicy.php
+++ b/app-modules/task/src/Policies/TaskPolicy.php
@@ -99,10 +99,11 @@ class TaskPolicy implements PerformsChecksBeforeAuthorization
             return Response::deny('You do not have permission to update this task.');
         }
 
-        return $authenticatable->canOrElse(
-            abilities: ["task.{$task->getKey()}.update"],
-            denyResponse: 'You do not have permission to update this task.'
-        );
+        if ($authenticatable->getKey() !== $task?->assigned_to && $authenticatable->getKey() !== $task?->created_by) {
+            return Response::deny('You do not have permission to update this task.');
+        }
+
+        return Response::allow();
     }
 
     public function delete(Authenticatable $authenticatable, Task $task): Response

--- a/app-modules/task/src/Policies/TaskPolicy.php
+++ b/app-modules/task/src/Policies/TaskPolicy.php
@@ -99,11 +99,14 @@ class TaskPolicy implements PerformsChecksBeforeAuthorization
             return Response::deny('You do not have permission to update this task.');
         }
 
-        if ($authenticatable->getKey() !== $task?->assigned_to && $authenticatable->getKey() !== $task?->created_by) {
+        if ($authenticatable->getKey() !== $task->assigned_to && $authenticatable->getKey() !== $task->created_by) {
             return Response::deny('You do not have permission to update this task.');
         }
 
-        return Response::allow();
+        return $authenticatable->canOrElse(
+            abilities: ['task.*.update'],
+            denyResponse: 'You do not have permission to update this task.'
+        );
     }
 
     public function delete(Authenticatable $authenticatable, Task $task): Response

--- a/app-modules/task/tests/EditTaskTest.php
+++ b/app-modules/task/tests/EditTaskTest.php
@@ -54,9 +54,7 @@ use function Pest\Livewire\livewire;
 test('EditTask is gated with proper access control', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $task = Task::factory()->state([
-        'created_by' => $user->getKey(),
-    ])->create();
+    $task = Task::factory()->create();
 
     actingAs($user)
         ->get(
@@ -71,6 +69,18 @@ test('EditTask is gated with proper access control', function () {
         ->assertForbidden();
 
     $user->givePermissionTo('task.view-any');
+    $user->givePermissionTo('task.*.update');
+
+    actingAs($user)
+        ->get(
+            TaskResource::getUrl('edit', [
+                'record' => $task,
+            ])
+        )->assertForbidden();
+
+    $task->assignedTo()->associate($user)->save();
+
+    $task->refresh();
 
     actingAs($user)
         ->get(
@@ -90,4 +100,4 @@ test('EditTask is gated with proper access control', function () {
         ->assertHasNoFormErrors();
 
     // TODO: Check for changes
-});
+})->only();

--- a/app-modules/task/tests/EditTaskTest.php
+++ b/app-modules/task/tests/EditTaskTest.php
@@ -36,6 +36,7 @@
 
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Task\Filament\Resources\TaskResource;
+use AdvisingApp\Task\Filament\Resources\TaskResource\Pages\EditTask;
 use AdvisingApp\Task\Models\Task;
 use AdvisingApp\Task\Tests\RequestFactories\EditTaskRequestFactory;
 use App\Models\User;
@@ -53,7 +54,9 @@ use function Pest\Livewire\livewire;
 test('EditTask is gated with proper access control', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $task = Task::factory()->create();
+    $task = Task::factory()->state([
+        'created_by' => $user->getKey(),
+    ])->create();
 
     actingAs($user)
         ->get(
@@ -62,13 +65,12 @@ test('EditTask is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    livewire(TaskResource\Pages\EditTask::class, [
+    livewire(EditTask::class, [
         'record' => $task->getRouteKey(),
     ])
         ->assertForbidden();
 
     $user->givePermissionTo('task.view-any');
-    $user->givePermissionTo("task.{$task->getKey()}.update");
 
     actingAs($user)
         ->get(
@@ -80,7 +82,7 @@ test('EditTask is gated with proper access control', function () {
     // TODO: Finish these tests to ensure changes are allowed
     $request = collect(EditTaskRequestFactory::new()->create());
 
-    livewire(TaskResource\Pages\EditTask::class, [
+    livewire(EditTask::class, [
         'record' => $task->getRouteKey(),
     ])
         ->fillForm($request->toArray())

--- a/app-modules/task/tests/TaskAssignmentTest.php
+++ b/app-modules/task/tests/TaskAssignmentTest.php
@@ -34,42 +34,13 @@
 </COPYRIGHT>
 */
 
-use AdvisingApp\Authorization\Enums\LicenseType;
-use AdvisingApp\Task\Filament\Resources\TaskResource;
 use AdvisingApp\Task\Models\Task;
 use AdvisingApp\Task\Notifications\TaskAssignedToUserNotification;
 use App\Models\User;
 use Illuminate\Support\Facades\Notification;
 
-use function Pest\Laravel\actingAs;
-
 beforeEach(function () {
     Notification::fake();
-});
-
-it('gives the proper permission to the assigned User of a Task on update', function () {
-    /** @var Task $task */
-    $task = Task::factory()->assigned()->create();
-
-    $user = User::factory()->licensed(LicenseType::cases())->create();
-
-    actingAs($user)->get(TaskResource::getUrl('edit', [
-        'record' => $task,
-    ]))->assertForbidden();
-
-    $user->givePermissionTo('task.view-any');
-    $user->givePermissionTo('task.*.view');
-    $user->givePermissionTo('task.*.update');
-
-    $user->refresh();
-
-    $task->assignedTo()->associate($user)->save();
-
-    $task->refresh();
-
-    actingAs($user)->get(TaskResource::getUrl('edit', [
-        'record' => $task,
-    ]))->assertSuccessful();
 });
 
 it('sends the proper notification to the assigned User', function () {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1064

### Technical Description

> Refactor Task access to not use individual permissions to manage access

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

Data Migrations:
-`app-modules/task/database/migrations/2024_12_18_104302_delete_task_individual_update_permissions.php`

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
