### PR TITLE
[ADVAPP-1087]: Replace HS Grad Year in the header for a student with the Student ID

### DIFF
--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/Concerns/HasStudentHeader.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/Concerns/HasStudentHeader.php
@@ -74,7 +74,7 @@ trait HasStudentHeader
                 ...(filled($student->preferred) ? [["Goes by \"{$student->preferred}\"", 'heroicon-m-heart']] : []),
                 ...(filled($student->phone) ? [[$student->phone, 'heroicon-m-phone']] : []),
                 ...(filled($student->email) ? [[$student->email, 'heroicon-m-envelope']] : []),
-                ...(filled($student->hsgrad) ? [[$student->hsgrad, 'heroicon-m-building-library']] : []),
+                ...(filled($student->sisid) ? [[$student->sisid, 'heroicon-m-identification']] : []),
             ],
             'hasSisSystem' => $sisSettings->is_enabled && $sisSettings->sis_system,
             'educatable' => $student,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1087

### Technical Description

Replace HS Grad Year in the header for a student with the Student ID

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
