### PR TITLE
[ADVAPP-1107]: Update the label used for the navigation group People Management to User Management

### DIFF
--- a/app-modules/authorization/src/Filament/Resources/PermissionResource.php
+++ b/app-modules/authorization/src/Filament/Resources/PermissionResource.php
@@ -53,7 +53,7 @@ class PermissionResource extends Resource
 {
     protected static ?string $model = Permission::class;
 
-    protected static ?string $navigationGroup = 'People Administration';
+    protected static ?string $navigationGroup = 'User Management';
 
     protected static ?int $navigationSort = 40;
 

--- a/app-modules/authorization/src/Filament/Resources/RoleResource.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleResource.php
@@ -48,7 +48,7 @@ class RoleResource extends Resource
 {
     protected static ?string $model = Role::class;
 
-    protected static ?string $navigationGroup = 'People Administration';
+    protected static ?string $navigationGroup = 'User Management';
 
     protected static ?int $navigationSort = 30;
 

--- a/app-modules/division/src/Filament/Resources/DivisionResource.php
+++ b/app-modules/division/src/Filament/Resources/DivisionResource.php
@@ -48,7 +48,7 @@ class DivisionResource extends Resource
 {
     protected static ?string $model = Division::class;
 
-    protected static ?string $navigationGroup = 'People Administration';
+    protected static ?string $navigationGroup = 'User Management';
 
     protected static ?int $navigationSort = 70;
 

--- a/app-modules/team/src/Filament/Resources/TeamResource.php
+++ b/app-modules/team/src/Filament/Resources/TeamResource.php
@@ -48,7 +48,7 @@ class TeamResource extends Resource
 {
     protected static ?string $model = Team::class;
 
-    protected static ?string $navigationGroup = 'People Administration';
+    protected static ?string $navigationGroup = 'User Management';
 
     protected static ?int $navigationSort = 20;
 

--- a/app/Filament/Resources/SystemUserResource.php
+++ b/app/Filament/Resources/SystemUserResource.php
@@ -47,7 +47,7 @@ class SystemUserResource extends Resource
 {
     protected static ?string $model = SystemUser::class;
 
-    protected static ?string $navigationGroup = 'People Administration';
+    protected static ?string $navigationGroup = 'User Management';
 
     protected static ?string $navigationLabel = 'Programmatic Users';
 

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -51,7 +51,7 @@ class UserResource extends Resource
 {
     protected static ?string $model = User::class;
 
-    protected static ?string $navigationGroup = 'People Administration';
+    protected static ?string $navigationGroup = 'User Management';
 
     protected static ?int $navigationSort = 10;
 

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -158,7 +158,7 @@ class AdminPanelProvider extends PanelProvider
                     ->icon('heroicon-o-document-chart-bar')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('People Administration')
+                    ->label('User Management')
                     ->icon('heroicon-o-users')
                     ->collapsed(),
                 NavigationGroup::make()


### PR DESCRIPTION

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1107

### Technical Description

> Update the label used for the navigation group People Management to User Management.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
