### PR TITLE
[ADVAPP-1100]: Organize list of attached permissions groups presented in the role editor in descending alphabetical order for view and edit experiences on save

### DIFF
--- a/app-modules/authorization/resources/views/filament/forms/components/permissions-matrix.blade.php
+++ b/app-modules/authorization/resources/views/filament/forms/components/permissions-matrix.blade.php
@@ -112,7 +112,7 @@
         </div>
 
         <template
-            x-for="group in visiblePermissionGroups"
+            x-for="group in visiblePermissionGroups.sort()"
             x-bind:key="group"
         >
             <div


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1100

### Technical Description

Sorts the list of permission groups alphabetically.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
