### PR TITLE
[ADVAPP-1129]: Merge values do not show up when sending a message from the holistic student profile

### DIFF
--- a/app-modules/authorization/src/Filament/Forms/Components/PermissionsMatrix.php
+++ b/app-modules/authorization/src/Filament/Forms/Components/PermissionsMatrix.php
@@ -118,7 +118,7 @@ class PermissionsMatrix extends Field
                         "{$permissionGroupNameSlugHyphen}.create", "{$permissionGroupNameSlugUnderscore}.create" => 'create',
                         "{$permissionGroupNameSlugHyphen}.*.update", "{$permissionGroupNameSlugUnderscore}.*.update" => 'update',
                         "{$permissionGroupNameSlugHyphen}.*.delete", "{$permissionGroupNameSlugUnderscore}.*.delete" => 'delete',
-                        "{$permissionGroupNameSlugHyphen}.import", "{$permissionGroupNameSlugHyphen}.import" => 'import',
+                        "{$permissionGroupNameSlugHyphen}.import", "{$permissionGroupNameSlugUnderscore}.import" => 'import',
                         "{$permissionGroupNameSlugHyphen}.*.force-delete", "{$permissionGroupNameSlugUnderscore}.*.force-delete" => 'force-delete',
                         "{$permissionGroupNameSlugHyphen}.*.restore", "{$permissionGroupNameSlugUnderscore}.*.restore" => 'restore',
                         default => null,

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -63,6 +63,7 @@ use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Notifications\Notification;
+use Filament\Pages\Page;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\ViewAction;
@@ -166,7 +167,7 @@ class EngagementsRelationManager extends RelationManager
                             'student email',
                             'student preferred name',
                         ])
-                        ->showMergeTagsInBlocksPanel(! ($form->getLivewire() instanceof RelationManager))
+                        ->showMergeTagsInBlocksPanel(! ($form->getLivewire() instanceof Page))
                         ->profile('email')
                         ->required()
                         ->hintAction(fn (TiptapEditor $component) => Action::make('loadEmailTemplate')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1129

### Technical Description

> Merge values do not show up when sending a message from the holistic student profile.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
