### PR TITLE
[ADVAPP-1123]: Permission normalization errors

### DIFF
--- a/database/migrations/2025_01_14_165537_data_fix_not_normalized_permissions.php
+++ b/database/migrations/2025_01_14_165537_data_fix_not_normalized_permissions.php
@@ -1,0 +1,44 @@
+<?php
+
+use AdvisingApp\Authorization\Models\Permission;
+use AdvisingApp\Authorization\Models\PermissionGroup;
+use Database\Migrations\Concerns\CanModifyPermissions;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    use CanModifyPermissions;
+
+    private array $guards = [
+        'web',
+        'api',
+    ];
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            collect($this->guards)
+                ->each(function (string $guard) {
+                    $this->deletePermissions([
+                        'consent_agreement.update',
+                    ], $guard);
+                });
+
+            Permission::query()
+                ->where('name', 'like', 'realtime_chat.%')
+                ->update([
+                    'group_id' => PermissionGroup::query()
+                        ->where('name', 'Realtime Chat')
+                        ->value('id'),
+                ]);
+
+            $this->deletePermissions([
+                'realtime_chat.*.view',
+            ], 'api');
+        });
+    }
+
+    public function down(): void
+    {
+        // These permissions and groups are not normalized and do not need to be recreated if this migration fails.
+    }
+};

--- a/database/migrations/2025_01_14_165537_data_fix_not_normalized_permissions.php
+++ b/database/migrations/2025_01_14_165537_data_fix_not_normalized_permissions.php
@@ -1,9 +1,8 @@
 <?php
 
-use AdvisingApp\Authorization\Models\Permission;
-use AdvisingApp\Authorization\Models\PermissionGroup;
 use Database\Migrations\Concerns\CanModifyPermissions;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 
 return new class () extends Migration {
     use CanModifyPermissions;
@@ -23,10 +22,10 @@ return new class () extends Migration {
                     ], $guard);
                 });
 
-            Permission::query()
+            DB::table('permissions')
                 ->where('name', 'like', 'realtime_chat.%')
                 ->update([
-                    'group_id' => PermissionGroup::query()
+                    'group_id' => DB::table('permission_groups')
                         ->where('name', 'Realtime Chat')
                         ->value('id'),
                 ]);


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1123

### Technical Description

Removes unused permissions and ensures permissions belong to the correct group.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

This data migration can technically be removed since the correct permissions are already being seeded for new tenants.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
