### PR TITLE
[ADVAPP-1128]: The filter for In Progress displays as a typo in Tasks

### DIFF
--- a/app-modules/task/src/Filament/Resources/TaskResource/Pages/ListTasks.php
+++ b/app-modules/task/src/Filament/Resources/TaskResource/Pages/ListTasks.php
@@ -152,7 +152,7 @@ class ListTasks extends ListRecords
                     ->multiple(),
                 SelectFilter::make('status')
                     ->label('Status')
-                    ->options(collect(TaskStatus::cases())->mapWithKeys(fn (TaskStatus $direction) => [$direction->value => \Livewire\str($direction->name)->title()->headline()]))
+                    ->options(collect(TaskStatus::cases())->mapWithKeys(fn (TaskStatus $status) => [$status->value => $status->getLabel()]))
                     ->multiple()
                     ->default([
                         TaskStatus::Pending->value,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1128

### Technical Description

> The filter for In Progress displays as a typo in Tasks.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
