### PR TITLE
[ADVAPP-1145]: Correct typo in spelling for new and edit forms for manually created students

### DIFF
--- a/app-modules/student-data-model/src/Filament/Imports/StudentImporter.php
+++ b/app-modules/student-data-model/src/Filament/Imports/StudentImporter.php
@@ -225,7 +225,7 @@ class StudentImporter extends Importer
                     'date',
                 ]),
             ImportColumn::make('f_e_term')
-                ->label('First Enrollement Term')
+                ->label('First Enrollment Term')
                 ->example('1234')
                 ->rules([
                     'nullable',
@@ -233,7 +233,7 @@ class StudentImporter extends Importer
                     'max:255',
                 ]),
             ImportColumn::make('mr_e_term')
-                ->label('Most Recent Enrollement Term')
+                ->label('Most Recent Enrollment Term')
                 ->example('1234')
                 ->rules([
                     'nullable',

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Actions/EditStudentAction.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Actions/EditStudentAction.php
@@ -170,11 +170,11 @@ class EditStudentAction extends Action
                             ->format('Y-m-d H:i:s')
                             ->displayFormat('Y-m-d H:i:s'),
                         TextInput::make('f_e_term')
-                            ->label('First Enrollement Term')
+                            ->label('First Enrollment Term')
                             ->string()
                             ->maxLength(255),
                         TextInput::make('mr_e_term')
-                            ->label('Most Recent Enrollement Term')
+                            ->label('Most Recent Enrollment Term')
                             ->string()
                             ->maxLength(255),
                     ])

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/ListStudents.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/ListStudents.php
@@ -358,11 +358,11 @@ class ListStudents extends ListRecords implements HasBulkEngagementAction
                             ->format('Y-m-d H:i:s')
                             ->displayFormat('Y-m-d H:i:s'),
                         TextInput::make('f_e_term')
-                            ->label('First Enrollement Term')
+                            ->label('First Enrollment Term')
                             ->string()
                             ->maxLength(255),
                         TextInput::make('mr_e_term')
-                            ->label('Most Recent Enrollement Term')
+                            ->label('Most Recent Enrollment Term')
                             ->string()
                             ->maxLength(255),
                     ])


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1145

### Technical Description

> Correct typo in spelling for new and edit forms for manually created students.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
