### PR TITLE
[ADVAPP-1159]: Error thrown by interactions without an end date set

### DIFF
--- a/app-modules/interaction/src/Filament/Concerns/HasManyMorphedInteractionsTrait.php
+++ b/app-modules/interaction/src/Filament/Concerns/HasManyMorphedInteractionsTrait.php
@@ -78,7 +78,7 @@ trait HasManyMorphedInteractionsTrait
                             ->dateTime(),
                         TextEntry::make('start_datetime')
                             ->label('Duration')
-                            ->state(fn ($record) => $record->end_datetime->diffForHumans($record->start_datetime, CarbonInterface::DIFF_ABSOLUTE, true, 6)),
+                            ->state(fn ($record) => $record->end_datetime ? $record->end_datetime->diffForHumans($record->start_datetime, CarbonInterface::DIFF_ABSOLUTE, true, 6) : '-'),
                     ]),
                 Fieldset::make('Notes')
                     ->schema([

--- a/app-modules/interaction/src/Filament/Concerns/HasManyMorphedInteractionsTrait.php
+++ b/app-modules/interaction/src/Filament/Concerns/HasManyMorphedInteractionsTrait.php
@@ -108,7 +108,7 @@ trait HasManyMorphedInteractionsTrait
                     ->label('End Time')
                     ->dateTime(),
                 TextColumn::make('created_at')
-                    ->state(fn ($record) => $record->end_datetime->diffForHumans($record->start_datetime, CarbonInterface::DIFF_ABSOLUTE, true, 6))
+                    ->state(fn ($record) => $record->end_datetime ? $record->end_datetime->diffForHumans($record->start_datetime, CarbonInterface::DIFF_ABSOLUTE, true, 6) : '-')
                     ->label('Duration'),
                 TextColumn::make('subject'),
                 TextColumn::make('description'),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1159

### Technical Description

> Error thrown by interactions without an end date set.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
