### PR TITLE
[ADVAPP-1169]: Interaction duration calculation throws errors

### DIFF
--- a/app-modules/interaction/src/Filament/Resources/InteractionResource/Pages/CreateInteraction.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionResource/Pages/CreateInteraction.php
@@ -92,7 +92,7 @@ class CreateInteraction extends CreateRecord
             }
 
             $set('end_datetime', Carbon::parse($startDateTime)
-                ->addMinutes($duration)
+                ->addMinutes((int) $duration)
                 ->toDateTimeString());
         };
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1169

### Technical Description

Fixes an issue caused by Carbon updates by ensuring that `$duration` is cast to an `int` before being used by Carbon.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
