### PR TITLE
[ADVAPP-1171]: Spatie Health package throws errors when trying to email about failures

### DIFF
--- a/config/health.php
+++ b/config/health.php
@@ -72,8 +72,9 @@ return [
     'notifications' => [
         /*
          * Notifications will only get sent if this option is set to `true`.
+         * NOTE: If we decide to turn this back on, the `Notifiable` class will need to be updated. As right now it fails when trying to create the OutboundDeliverable.
          */
-        'enabled' => true,
+        'enabled' => false,
 
         'notifications' => [
             CheckFailedNotification::class => ['mail'],


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1171

### Technical Description

Turns off the Spatie Health failure email as we currently don't have it set to send to anyone real anyways. And it throws errors due to the way OutboundDeliverables are made.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
