### PR TITLE
[ADVAPP-1170]: When viewing a record that has a confidential interaction that was not created by and is not authorized for me, an exception is generated

### DIFF
--- a/app-modules/timeline/src/Livewire/Concerns/CanLoadTimelineRecords.php
+++ b/app-modules/timeline/src/Livewire/Concerns/CanLoadTimelineRecords.php
@@ -67,6 +67,7 @@ trait CanLoadTimelineRecords
 
         $records = Timeline::query()
             ->forEntity($this->recordModel)
+            ->whereHas('timelineable')
             ->whereIn(
                 'timelineable_type',
                 collect($this->modelsToTimeline)->map(fn ($model) => resolve($model)->getMorphClass())->toArray()


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1170

### Technical Description

Scopes timeline records to only those with a timelineable (to observe the global scope).

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
