### PR TITLE
[ADVAPP-1083]: Allow per notification quota manipulation

### DIFF
--- a/app-modules/integration-twilio/tests/Feature/Jobs/CheckSmsOutboundDeliverableStatusTest.php
+++ b/app-modules/integration-twilio/tests/Feature/Jobs/CheckSmsOutboundDeliverableStatusTest.php
@@ -36,9 +36,9 @@
 
 use AdvisingApp\IntegrationTwilio\Jobs\CheckSmsOutboundDeliverableStatus;
 use AdvisingApp\IntegrationTwilio\Settings\TwilioSettings;
+use AdvisingApp\IntegrationTwilio\Tests\Fixtures\ClientMock;
 use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
 use AdvisingApp\Notification\Models\OutboundDeliverable;
-use Tests\Unit\ClientMock;
 use Twilio\Rest\Api\V2010;
 use Twilio\Rest\Api\V2010\Account\MessageContext;
 use Twilio\Rest\Api\V2010\Account\MessageInstance;

--- a/app-modules/integration-twilio/tests/Fixtures/ClientMock.php
+++ b/app-modules/integration-twilio/tests/Fixtures/ClientMock.php
@@ -34,30 +34,34 @@
 </COPYRIGHT>
 */
 
-namespace Tests\Unit;
+namespace AdvisingApp\IntegrationTwilio\Tests\Fixtures;
 
-use AdvisingApp\Notification\Notifications\Messages\MailMessage;
-use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Notifications\Notification;
+use AllowDynamicProperties;
+use Twilio\Http\Client as HttpClient;
+use Twilio\Rest\Client;
 
-class TestEmailNotification extends Notification implements ShouldQueue
+#[AllowDynamicProperties]
+class ClientMock extends Client
 {
-    use Queueable;
-
-    /**
-     * @return array<int, string>
-     */
-    public function via(object $notifiable): array
-    {
-        return ['mail'];
-    }
-
-    public function toMail(object $notifiable): MailMessage
-    {
-        return MailMessage::make()
-            ->subject('Test Subject')
-            ->greeting('Test Greeting')
-            ->content('This is a test email');
+    public function __construct(
+        $messageList = null,
+        string $username = null,
+        string $password = null,
+        string $accountSid = null,
+        string $region = null,
+        HttpClient $httpClient = null,
+        array $environment = null,
+        array $userAgentExtensions = null,
+    ) {
+        parent::__construct(
+            $username,
+            $password,
+            $accountSid,
+            $region,
+            $httpClient,
+            $environment,
+            $userAgentExtensions
+        );
+        $this->messages = $messageList;
     }
 }

--- a/app-modules/notification/database/factories/OutboundDeliverableFactory.php
+++ b/app-modules/notification/database/factories/OutboundDeliverableFactory.php
@@ -38,9 +38,9 @@ namespace AdvisingApp\Notification\Database\Factories;
 
 use AdvisingApp\Notification\Enums\NotificationChannel;
 use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
+use AdvisingApp\Notification\Tests\Fixtures\TestEmailNotification;
+use AdvisingApp\Notification\Tests\Fixtures\TestSmsNotification;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Tests\Unit\TestEmailNotification;
-use Tests\Unit\TestSmsNotification;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\AdvisingApp\Notification\Models\OutboundDeliverable>

--- a/app-modules/notification/tests/Feature/LicenseSettingsEmailQuotaTrackingTest.php
+++ b/app-modules/notification/tests/Feature/LicenseSettingsEmailQuotaTrackingTest.php
@@ -38,6 +38,7 @@ use AdvisingApp\IntegrationAwsSesEventHandling\Settings\SesSettings;
 use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
 use AdvisingApp\Notification\Models\OutboundDeliverable;
 use AdvisingApp\Notification\Tests\Fixtures\TestEmailNotification;
+use AdvisingApp\Prospect\Models\Prospect;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Settings\LicenseSettings;
@@ -55,7 +56,7 @@ test('An email is allowed to be sent if there is available quota and its quota u
     $settings->configuration_set = $configurationSet;
     $settings->save();
 
-    $notifiable = User::factory()->create();
+    $notifiable = Prospect::factory()->create();
 
     $notification = new TestEmailNotification();
 
@@ -90,7 +91,7 @@ test('An email is prevented from being sent if there is no available quota', fun
     $licenseSettings->data->limits->emails = 0;
     $licenseSettings->save();
 
-    $notifiable = User::factory()->create();
+    $notifiable = Prospect::factory()->create();
 
     $notification = new TestEmailNotification();
 

--- a/app-modules/notification/tests/Feature/LicenseSettingsEmailQuotaTrackingTest.php
+++ b/app-modules/notification/tests/Feature/LicenseSettingsEmailQuotaTrackingTest.php
@@ -37,7 +37,7 @@
 use AdvisingApp\IntegrationAwsSesEventHandling\Settings\SesSettings;
 use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
 use AdvisingApp\Notification\Models\OutboundDeliverable;
-use App\Models\Authenticatable;
+use AdvisingApp\Notification\Tests\Fixtures\TestEmailNotification;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Settings\LicenseSettings;
@@ -46,9 +46,7 @@ use Illuminate\Support\Facades\Event;
 
 use function Pest\Laravel\assertDatabaseCount;
 
-use Tests\Unit\TestEmailNotification;
-
-it('An email is allowed to be sent if there is available quota and its quota usage is tracked', function () {
+test('An email is allowed to be sent if there is available quota and its quota usage is tracked', function () {
     Event::fake(MessageSent::class);
 
     $configurationSet = 'test';
@@ -78,7 +76,7 @@ it('An email is allowed to be sent if there is available quota and its quota usa
     );
 });
 
-it('An email is prevented from being sent if there is no available quota', function () {
+test('An email is prevented from being sent if there is no available quota', function () {
     Event::fake(MessageSent::class);
 
     $configurationSet = 'test';
@@ -108,7 +106,7 @@ it('An email is prevented from being sent if there is no available quota', funct
         ->and($outboundDeliverable->delivery_status)->toBe(NotificationDeliveryStatus::RateLimited);
 });
 
-it('An email is sent to a super admin user even if there is no available quota', function () {
+test('An email is sent to a user even if there is no available quota', function () {
     Event::fake(MessageSent::class);
 
     $configurationSet = 'test';
@@ -123,8 +121,6 @@ it('An email is sent to a super admin user even if there is no available quota',
     $licenseSettings->save();
 
     $notifiable = User::factory()->create();
-
-    $notifiable->assignRole(Authenticatable::SUPER_ADMIN_ROLE);
 
     $notification = new TestEmailNotification();
 

--- a/app-modules/notification/tests/Feature/LicenseSettingsSmsQuotaTrackingTest.php
+++ b/app-modules/notification/tests/Feature/LicenseSettingsSmsQuotaTrackingTest.php
@@ -35,24 +35,23 @@
 */
 
 use AdvisingApp\IntegrationTwilio\Settings\TwilioSettings;
+use AdvisingApp\IntegrationTwilio\Tests\Fixtures\ClientMock;
 use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
 use AdvisingApp\Notification\Models\OutboundDeliverable;
+use AdvisingApp\Notification\Tests\Fixtures\TestSmsNotification;
 use AdvisingApp\Prospect\Models\Prospect;
-use App\Models\Authenticatable;
 use App\Models\User;
 use App\Settings\LicenseSettings;
 
 use function Pest\Laravel\assertDatabaseCount;
 
-use Tests\Unit\ClientMock;
-use Tests\Unit\TestSmsNotification;
 use Twilio\Rest\Api\V2010;
 use Twilio\Rest\Api\V2010\Account\MessageInstance;
 use Twilio\Rest\Api\V2010\Account\MessageList;
 use Twilio\Rest\Client;
 use Twilio\Rest\MessagingBase;
 
-it('An sms is allowed to be sent if there is available quota and its quota usage is tracked', function () {
+test('An sms is allowed to be sent if there is available quota and its quota usage is tracked', function () {
     $notifiable = Prospect::factory()->create();
 
     $notification = new TestSmsNotification();
@@ -103,7 +102,7 @@ it('An sms is allowed to be sent if there is available quota and its quota usage
         ->toBe(NotificationDeliveryStatus::Dispatched);
 });
 
-it('An sms is prevented from being sent if there is no available quota', function () {
+test('An sms is prevented from being sent if there is no available quota', function () {
     $notifiable = Prospect::factory()->create();
 
     $notification = new TestSmsNotification();
@@ -159,10 +158,8 @@ it('An sms is prevented from being sent if there is no available quota', functio
         ->and($outboundDeliverable->delivery_status)->toBe(NotificationDeliveryStatus::RateLimited);
 });
 
-it('An sms is sent to a super admin user even if there is no available quota', function () {
+test('An sms is sent to a user even if there is no available quota', function () {
     $notifiable = User::factory()->create();
-
-    $notifiable->assignRole(Authenticatable::SUPER_ADMIN_ROLE);
 
     $notification = new TestSmsNotification();
 

--- a/app-modules/notification/tests/Feature/NotificationFromNameTest.php
+++ b/app-modules/notification/tests/Feature/NotificationFromNameTest.php
@@ -34,7 +34,7 @@
 </COPYRIGHT>
 */
 
-use AdvisingApp\Notification\Tests\Feature\TestEmailSettingFromNameNotification;
+use AdvisingApp\Notification\Tests\Fixtures\TestEmailSettingFromNameNotification;
 use App\Models\NotificationSetting;
 use App\Models\User;
 use Illuminate\Support\Facades\Notification;

--- a/app-modules/notification/tests/Feature/NotificationSendingTest.php
+++ b/app-modules/notification/tests/Feature/NotificationSendingTest.php
@@ -39,6 +39,7 @@ use AdvisingApp\Notification\Enums\NotificationDeliveryStatus;
 use AdvisingApp\Notification\Models\OutboundDeliverable;
 use AdvisingApp\Notification\Notifications\Attributes\SystemNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
+use AdvisingApp\Notification\Tests\Fixtures\TestEmailNotification;
 use App\Models\Authenticatable;
 use App\Models\Tenant;
 use App\Models\User;
@@ -46,7 +47,6 @@ use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
-use Tests\Unit\TestEmailNotification;
 
 it('will create an outbound deliverable for the outbound notification', function () {
     $notifiable = User::factory()->create();

--- a/app-modules/notification/tests/Feature/NotificationSendingTest.php
+++ b/app-modules/notification/tests/Feature/NotificationSendingTest.php
@@ -40,7 +40,6 @@ use AdvisingApp\Notification\Models\OutboundDeliverable;
 use AdvisingApp\Notification\Notifications\Attributes\SystemNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use AdvisingApp\Notification\Tests\Fixtures\TestEmailNotification;
-use App\Models\Authenticatable;
 use App\Models\Tenant;
 use App\Models\User;
 use Filament\Notifications\Notification as FilamentNotification;
@@ -69,25 +68,6 @@ it('will create an outbound deliverable for each of the channels that the notifi
     expect(OutboundDeliverable::count())->toBe(2);
     expect(OutboundDeliverable::where('channel', NotificationChannel::Email)->count())->toBe(1);
     expect(OutboundDeliverable::where('channel', NotificationChannel::Database)->count())->toBe(1);
-});
-
-it('will not count emails sent to Super Admin Users against quota usage', function () {
-    // Given that we have a super admin user
-    $user = User::factory()->create();
-    $nonSuperAdminUser = User::factory()->create();
-
-    $user->assignRole(Authenticatable::SUPER_ADMIN_ROLE);
-
-    // And they are sent a deliverable of any kind
-    $notification = new TestMultipleChannelNotification();
-    $user->notify($notification);
-
-    $notification = new TestMultipleChannelNotification();
-    $nonSuperAdminUser->notify($notification);
-
-    // Then the quota usage for the super admin user should be 0
-    expect(OutboundDeliverable::where('recipient_id', $user->id)->where('channel', NotificationChannel::Email)->first()->quota_usage)->toBe(0);
-    expect(OutboundDeliverable::where('recipient_id', $nonSuperAdminUser->id)->where('channel', NotificationChannel::Email)->first()->quota_usage)->toBe(1);
 });
 
 it('will not send emails in demo mode and mark the outbound deliverable as blocked', function () {

--- a/app-modules/notification/tests/Fixtures/TestEmailNotification.php
+++ b/app-modules/notification/tests/Fixtures/TestEmailNotification.php
@@ -34,14 +34,14 @@
 </COPYRIGHT>
 */
 
-namespace Tests\Unit;
+namespace AdvisingApp\Notification\Tests\Fixtures;
 
-use AdvisingApp\Notification\Notifications\Messages\TwilioMessage;
+use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
 
-class TestSmsNotification extends Notification implements ShouldQueue
+class TestEmailNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
@@ -50,12 +50,14 @@ class TestSmsNotification extends Notification implements ShouldQueue
      */
     public function via(object $notifiable): array
     {
-        return ['sms'];
+        return ['mail'];
     }
 
-    public function toSms(object $notifiable): TwilioMessage
+    public function toMail(object $notifiable): MailMessage
     {
-        return TwilioMessage::make($notifiable)
-            ->content('This is a test');
+        return MailMessage::make()
+            ->subject('Test Subject')
+            ->greeting('Test Greeting')
+            ->content('This is a test email');
     }
 }

--- a/app-modules/notification/tests/Fixtures/TestEmailSettingFromNameNotification.php
+++ b/app-modules/notification/tests/Fixtures/TestEmailSettingFromNameNotification.php
@@ -34,34 +34,36 @@
 </COPYRIGHT>
 */
 
-namespace Tests\Unit;
+namespace AdvisingApp\Notification\Tests\Fixtures;
 
-use AllowDynamicProperties;
-use Twilio\Http\Client as HttpClient;
-use Twilio\Rest\Client;
+use AdvisingApp\Notification\Notifications\Messages\MailMessage;
+use App\Models\NotificationSetting;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
 
-#[AllowDynamicProperties]
-class ClientMock extends Client
+class TestEmailSettingFromNameNotification extends Notification implements ShouldQueue
 {
+    use Queueable;
+
     public function __construct(
-        $messageList = null,
-        string $username = null,
-        string $password = null,
-        string $accountSid = null,
-        string $region = null,
-        HttpClient $httpClient = null,
-        array $environment = null,
-        array $userAgentExtensions = null,
-    ) {
-        parent::__construct(
-            $username,
-            $password,
-            $accountSid,
-            $region,
-            $httpClient,
-            $environment,
-            $userAgentExtensions
-        );
-        $this->messages = $messageList;
+        public NotificationSetting $setting,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return MailMessage::make()
+            ->settings($this->setting)
+            ->subject('Test Subject')
+            ->greeting('Test Greeting')
+            ->content('This is a test email');
     }
 }

--- a/app-modules/notification/tests/Fixtures/TestSmsNotification.php
+++ b/app-modules/notification/tests/Fixtures/TestSmsNotification.php
@@ -34,36 +34,28 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Notification\Tests\Feature;
+namespace AdvisingApp\Notification\Tests\Fixtures;
 
-use AdvisingApp\Notification\Notifications\Messages\MailMessage;
-use App\Models\NotificationSetting;
+use AdvisingApp\Notification\Notifications\Messages\TwilioMessage;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
 
-class TestEmailSettingFromNameNotification extends Notification implements ShouldQueue
+class TestSmsNotification extends Notification implements ShouldQueue
 {
     use Queueable;
-
-    public function __construct(
-        public NotificationSetting $setting,
-    ) {}
 
     /**
      * @return array<int, string>
      */
     public function via(object $notifiable): array
     {
-        return ['mail'];
+        return ['sms'];
     }
 
-    public function toMail(object $notifiable): MailMessage
+    public function toSms(object $notifiable): TwilioMessage
     {
-        return MailMessage::make()
-            ->settings($this->setting)
-            ->subject('Test Subject')
-            ->greeting('Test Greeting')
-            ->content('This is a test email');
+        return TwilioMessage::make($notifiable)
+            ->content('This is a test');
     }
 }


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1083

### Technical Description

Changes the super admin check to just check if a user exists, and if so do not count the notification towards the quota.

Remove duplicate test from `NotificationSendingTest`.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
