### PR TITLE
[ADVAPP-1175]: Increase the files size for AI file upload limits per file for threads and custom assistants from 256kb to 20MB

### DIFF
--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanUploadFiles.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanUploadFiles.php
@@ -69,8 +69,8 @@ trait CanUploadFiles
                 FileUpload::make('attachment')
                     ->acceptedFileTypes(config('ai.supported_file_types'))
                     ->storeFiles(false)
-                    ->helperText('The maximum file size is 256KB.')
-                    ->maxSize(256)
+                    ->helperText('The maximum file size is 20MB.')
+                    ->maxSize(20000)
                     ->required(),
             ])
             ->action(function (array $data) {

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -169,12 +169,12 @@ class AiAssistantForm
                             ->storeFiles(false)
                             ->helperText(function (?AiAssistant $record): string {
                                 if ($record?->files->count() < 3) {
-                                    return 'You may upload a total of 3 files to your custom assistant. Files must be less than 256mb.';
+                                    return 'You may upload a total of 3 files to your custom assistant. Files must be less than 20MB.';
                                 }
 
                                 return "You've reached the maximum file upload limit of 3 for custom assistants. Please delete a file if you wish to upload another.";
                             })
-                            ->maxSize(256)
+                            ->maxSize(20000)
                             ->columnSpan(function (Get $get) {
                                 $files = $get('files');
                                 $firstFile = reset($files);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1175

### Technical Description

> Increase the files size for AI file upload limits per file for threads and custom assistants from 256kb to 20mb

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
