### PR TITLE
[ADVAPP-1185]: Include additional details like date created and created by to the display of files attached to a student or prospect record

### DIFF
--- a/app-modules/engagement/database/migrations/2025_02_07_041430_add_created_by_to_engagement_files_table.php
+++ b/app-modules/engagement/database/migrations/2025_02_07_041430_add_created_by_to_engagement_files_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('engagement_files', function (Blueprint $table) {
+            $table->nullableUuidMorphs('created_by');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('engagement_files', function (Blueprint $table) {
+            $table->dropMorphs('created_by');
+        });
+    }
+};

--- a/app-modules/engagement/database/migrations/2025_02_07_052340_data_activate_engagement_files_created_by_feature.php
+++ b/app-modules/engagement/database/migrations/2025_02_07_052340_data_activate_engagement_files_created_by_feature.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Features\EngagementFilesCreatedByFeature;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        EngagementFilesCreatedByFeature::activate();
+    }
+
+    public function down(): void
+    {
+        EngagementFilesCreatedByFeature::deactivate();
+    }
+};

--- a/app-modules/engagement/src/Filament/Resources/EngagementFileResource/RelationManagers/EngagementFilesRelationManager.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementFileResource/RelationManagers/EngagementFilesRelationManager.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Engagement\Filament\Resources\EngagementFileResource\Relat
 use AdvisingApp\Engagement\Filament\Resources\EngagementFileResource;
 use AdvisingApp\Engagement\Models\EngagementFile;
 use AdvisingApp\Prospect\Models\Prospect;
+use App\Features\EngagementFilesCreatedByFeature;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -114,6 +115,14 @@ class EngagementFilesRelationManager extends RelationManager
                         'video/mp4' => 'heroicon-o-video-camera',
                         'application/zip' => 'heroicon-o-archive-box'
                     }),
+                TextColumn::make('created_at')
+                    ->label('Date Created')
+                    ->sortable()
+                    ->visible(fn (): bool => EngagementFilesCreatedByFeature::active()),
+                TextColumn::make('createdBy.name')
+                    ->label('Created By')
+                    ->sortable()
+                    ->visible(fn (): bool => EngagementFilesCreatedByFeature::active()),
             ])
             ->headerActions([
                 CreateAction::make()

--- a/app-modules/engagement/src/Models/EngagementFile.php
+++ b/app-modules/engagement/src/Models/EngagementFile.php
@@ -37,11 +37,14 @@
 namespace AdvisingApp\Engagement\Models;
 
 use AdvisingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
+use AdvisingApp\Engagement\Observers\EngagementFileObserver;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\BaseModel;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use OwenIt\Auditing\Contracts\Auditable;
 use Spatie\MediaLibrary\HasMedia;
@@ -50,6 +53,7 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 /**
  * @mixin IdeHelperEngagementFile
  */
+#[ObservedBy(EngagementFileObserver::class)]
 class EngagementFile extends BaseModel implements HasMedia, Auditable
 {
     use InteractsWithMedia;
@@ -124,6 +128,15 @@ class EngagementFile extends BaseModel implements HasMedia, Auditable
             'retention_date',
             '<',
             now()->startOfDay(),
+        );
+    }
+
+    public function createdBy(): MorphTo
+    {
+        return $this->morphTo(
+            name: 'createdBy',
+            type: 'created_by_type',
+            id: 'created_by_id',
         );
     }
 }

--- a/app-modules/engagement/src/Observers/EngagementFileObserver.php
+++ b/app-modules/engagement/src/Observers/EngagementFileObserver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AdvisingApp\Engagement\Observers;
+
+use AdvisingApp\Engagement\Models\EngagementFile;
+use App\Features\EngagementFilesCreatedByFeature;
+use App\Models\User;
+
+class EngagementFileObserver
+{
+    public function saving(EngagementFile $engagementFile): void
+    {
+        $user = auth()->user();
+
+        if (EngagementFilesCreatedByFeature::active() && $user instanceof User && is_null($engagementFile->created_by_id)) {
+            $engagementFile->created_by_id = $user->getKey();
+            $engagementFile->created_by_type = $user->getMorphClass();
+        }
+    }
+}

--- a/app/Features/EngagementFilesCreatedByFeature.php
+++ b/app/Features/EngagementFilesCreatedByFeature.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class EngagementFilesCreatedByFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1185

### Technical Description

> Include additional details like date created and created by to the display of files attached to a student or prospect record

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> Yes, `EngagementFilesCreatedByFeature`

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
