### PR TITLE
[ADVAPP-1198]: Update to RoadRunner v2024.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN echo "source $NVM_DIR/nvm.sh \
 COPY ./docker/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY ./docker/nginx/site-opts.d /etc/nginx/site-opts.d
 
-COPY --from=ghcr.io/roadrunner-server/roadrunner:2024.3.2 --chown=$PUID:$PGID --chmod=0755 /usr/bin/rr /usr/local/bin/rr
+COPY --from=ghcr.io/roadrunner-server/roadrunner:2024.3.4 --chown=$PUID:$PGID --chmod=0755 /usr/bin/rr /usr/local/bin/rr
 
 RUN rm -rf /etc/s6-overlay/s6-rc.d/laravel-automations
 RUN rm /etc/s6-overlay/s6-rc.d/user/contents.d/laravel-automations


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1198

### Technical Description

> Update RoadRunner version in Dockerfile to 2024.3.4

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
