### PR TITLE
[ADVAPP-1207] Remove obsolete header and footer configuration options for Division configuration

### DIFF
--- a/app-modules/division/database/migrations/2025_02_19_220017_remove_header_footer_columns_from_divisions_table.php
+++ b/app-modules/division/database/migrations/2025_02_19_220017_remove_header_footer_columns_from_divisions_table.php
@@ -38,7 +38,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('divisions', function (Blueprint $table) {

--- a/app-modules/division/database/migrations/2025_02_19_220017_remove_header_footer_columns_from_divisions_table.php
+++ b/app-modules/division/database/migrations/2025_02_19_220017_remove_header_footer_columns_from_divisions_table.php
@@ -34,44 +34,23 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Division\Database\Factories;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
-use AdvisingApp\Division\Models\Division;
-use App\Models\User;
-use Illuminate\Database\Eloquent\Factories\Factory;
-
-/**
- * @extends Factory<Division>
- */
-class DivisionFactory extends Factory
-{
-    /**
-     * @return array<string, mixed>
-     */
-    public function definition(): array
+return new class extends Migration {
+    public function up(): void
     {
-        return [
-            'name' => fake()->unique()->company(),
-            'code' => fake()->unique()->word(),
-            'description' => fake()->optional()->sentences(asText: true),
-            'is_default' => false,
-        ];
-    }
-
-    public function default(): Factory
-    {
-        return $this->state(function (array $attributes) {
-            return [
-                'is_default' => true,
-            ];
+        Schema::table('divisions', function (Blueprint $table) {
+            $table->dropColumn(['header', 'footer']);
         });
     }
 
-    public function configure(): DivisionFactory|Factory
+    public function down(): void
     {
-        return $this->afterMaking(function (Division $division) {
-            $division->createdBy()->associate(fake()->randomElement([User::inRandomOrder()->first(), null]));
-            $division->lastUpdatedBy()->associate(fake()->randomElement([User::inRandomOrder()->first(), null]));
+        Schema::table('divisions', function (Blueprint $table) {
+            $table->longText('header')->nullable();
+            $table->longText('footer')->nullable();
         });
     }
-}
+};

--- a/app-modules/division/database/seeders/DivisionSeeder.php
+++ b/app-modules/division/database/seeders/DivisionSeeder.php
@@ -50,8 +50,6 @@ class DivisionSeeder extends Seeder
                         'name' => 'Home',
                         'code' => 'home',
                         'description' => 'Home Division',
-                        'header' => null,
-                        'footer' => null,
                     ],
                 ]
             );

--- a/app-modules/division/src/Filament/Resources/DivisionResource/Pages/CreateDivision.php
+++ b/app-modules/division/src/Filament/Resources/DivisionResource/Pages/CreateDivision.php
@@ -44,7 +44,6 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Resources\Pages\CreateRecord;
-use FilamentTiptapEditor\TiptapEditor;
 
 class CreateDivision extends CreateRecord
 {
@@ -66,14 +65,6 @@ class CreateDivision extends CreateRecord
                     ->unique(),
                 Textarea::make('description')
                     ->string(),
-                TiptapEditor::make('header')
-                    ->disk('s3-public')
-                    ->string()
-                    ->columnSpanFull(),
-                TiptapEditor::make('footer')
-                    ->disk('s3-public')
-                    ->string()
-                    ->columnSpanFull(),
                 Toggle::make('is_default')
                     ->visible(DivisionIsDefault::active())
                     ->label('Default')

--- a/app-modules/division/src/Filament/Resources/DivisionResource/Pages/EditDivision.php
+++ b/app-modules/division/src/Filament/Resources/DivisionResource/Pages/EditDivision.php
@@ -48,7 +48,6 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Resources\Pages\EditRecord;
-use FilamentTiptapEditor\TiptapEditor;
 
 class EditDivision extends EditRecord
 {
@@ -71,14 +70,6 @@ class EditDivision extends EditRecord
                     ->string()
                     ->unique(ignoreRecord: true),
                 Textarea::make('description')
-                    ->string()
-                    ->columnSpanFull(),
-                TiptapEditor::make('header')
-                    ->disk('s3-public')
-                    ->string()
-                    ->columnSpanFull(),
-                TiptapEditor::make('footer')
-                    ->disk('s3-public')
                     ->string()
                     ->columnSpanFull(),
                 Select::make('notification_setting_id')

--- a/app-modules/division/src/Filament/Resources/DivisionResource/Pages/ViewDivision.php
+++ b/app-modules/division/src/Filament/Resources/DivisionResource/Pages/ViewDivision.php
@@ -90,12 +90,6 @@ class ViewDivision extends ViewRecord
                             ->label('Notification Setting')
                             ->color(fn (Division $record) => $record->notificationSetting?->setting ? 'primary' : null)
                             ->url(fn (Division $record) => $record->notificationSetting?->setting ? NotificationSettingResource::getUrl('edit', ['record' => $record->notificationSetting->setting]) : null),
-                        TextEntry::make('header')
-                            ->columnSpanFull()
-                            ->view('filament.infolists.components.html'),
-                        TextEntry::make('footer')
-                            ->columnSpanFull()
-                            ->view('filament.infolists.components.html'),
                     ])
                     ->columns(),
             ]);

--- a/app-modules/division/src/Models/Division.php
+++ b/app-modules/division/src/Models/Division.php
@@ -64,8 +64,6 @@ class Division extends BaseModel implements Auditable
         'name',
         'code',
         'description',
-        'header',
-        'footer',
         'is_default',
     ];
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-

### Technical Description

Remove header and footer fields from Division pages, related files, and database.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
