### PR TITLE
[ADVAPP-1212]: While editing a Division that is not the default if you toggle it to be default, the warning that is supposed to display does not display

### DIFF
--- a/app-modules/division/src/Filament/Resources/DivisionResource/Pages/CreateDivision.php
+++ b/app-modules/division/src/Filament/Resources/DivisionResource/Pages/CreateDivision.php
@@ -88,7 +88,8 @@ class CreateDivision extends CreateRecord
                         return "The current default status is '{$currentDefault}', you are replacing it.";
                     })
                     ->hintColor('danger')
-                    ->columnStart(1),
+                    ->columnStart(1)
+                    ->live(),
             ]);
     }
 }

--- a/app-modules/division/src/Filament/Resources/DivisionResource/Pages/EditDivision.php
+++ b/app-modules/division/src/Filament/Resources/DivisionResource/Pages/EditDivision.php
@@ -99,7 +99,8 @@ class EditDivision extends EditRecord
                         return "The current default status is '{$currentDefault}', you are replacing it.";
                     })
                     ->hintColor('danger')
-                    ->columnStart(1),
+                    ->columnStart(1)
+                    ->live(),
             ]);
     }
 


### PR DESCRIPTION

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1212

### Technical Description

While editing a Division that is not the default if you toggle it to be default, the warning that is supposed to display does not display

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
