### PR TITLE
[ADVAPP-1242]: Resolve flaky test in SubscriptionCampaignTest

### DIFF
--- a/app-modules/campaign/tests/Tenant/Actions/SubscriptionCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Actions/SubscriptionCampaignTest.php
@@ -90,7 +90,7 @@ it('will create the subscription records for subscribables in the segment', func
             return expect(
                 $subscribable->subscriptions()->pluck('user_id')->toArray()
             )
-                ->toBe(
+                ->toEqualCanonicalizing(
                     $removePrior
                         ? $users->pluck('id')->toArray()
                         : [...$priorSubscriptions, ...$users->pluck('id')->toArray()]

--- a/app/Jobs/MigrateTenantDatabase.php
+++ b/app/Jobs/MigrateTenantDatabase.php
@@ -70,7 +70,7 @@ class MigrateTenantDatabase implements ShouldQueue, NotTenantAware
             config(['queue.failed.database' => 'landlord']);
 
             Artisan::call(
-                command: 'migrate --force'
+                command: 'migrate:fresh --force'
             );
 
             config(['queue.failed.database' => $currentQueueFailedConnection]);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1242

### Technical Description

Fixes an issue overall with tests where subsequent runs would have issues by making sure we refresh the database when we migrate a new Tenant.

Also fixes the flaky test in `SubscriptionCampaignTest`

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
