### PR TITLE
[ADVAPP-1124]: Exceptions are thrown when login Azure profile image cannot be found

### DIFF
--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -43,6 +43,7 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
@@ -114,6 +115,10 @@ class SocialiteController extends Controller
                 }
             } catch (Throwable $e) {
                 report($e);
+            } catch (RequestException $e) {
+                if (! str_contains($e->getMessage(), 'Microsoft.Fast.Profile.Core.Exception.ImageNotFoundException')) {
+                    report($e);
+                }
             }
         }
 

--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -113,12 +113,12 @@ class SocialiteController extends Controller
                 } else {
                     throw new InvalidUserAvatarMimeType($mimeType, $user);
                 }
-            } catch (Throwable $e) {
-                report($e);
             } catch (RequestException $e) {
                 if (! str_contains($e->getMessage(), 'Microsoft.Fast.Profile.Core.Exception.ImageNotFoundException')) {
                     report($e);
                 }
+            } catch (Throwable $e) {
+                report($e);
             }
         }
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1124

### Technical Description

> Exceptions are thrown when login Azure profile image cannot be found.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
