### PR TITLE
[ADVAPP-1219]: Alert creation for students or prospects fails when status is not manually set

### DIFF
--- a/app-modules/alert/src/Filament/Resources/AlertResource/Pages/ListAlerts.php
+++ b/app-modules/alert/src/Filament/Resources/AlertResource/Pages/ListAlerts.php
@@ -184,7 +184,6 @@ class ListAlerts extends ListRecords
                                 ->string(),
                             Select::make('severity')
                                 ->options(AlertSeverity::class)
-                                ->selectablePlaceholder(false)
                                 ->default(AlertSeverity::default())
                                 ->required()
                                 ->enum(AlertSeverity::class),
@@ -193,7 +192,6 @@ class ListAlerts extends ListRecords
                                 ->string(),
                             Select::make('status_id')
                                 ->relationship('status', 'name', fn (Builder $query) => $query->orderBy('order'))
-                                ->selectablePlaceholder(false)
                                 ->default(SystemAlertStatusClassification::default())
                                 ->required(),
                         ])

--- a/app-modules/campaign/src/Filament/Blocks/ProactiveAlertBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/ProactiveAlertBlock.php
@@ -64,7 +64,6 @@ class ProactiveAlertBlock extends CampaignActionBlock
                 ->string(),
             Select::make($fieldPrefix . 'severity')
                 ->options(AlertSeverity::class)
-                ->selectablePlaceholder(false)
                 ->default(AlertSeverity::default())
                 ->required()
                 ->enum(AlertSeverity::class),
@@ -74,7 +73,6 @@ class ProactiveAlertBlock extends CampaignActionBlock
             Select::make($fieldPrefix . 'status_id')
                 ->label('Status')
                 ->options(AlertStatus::orderBy('order')->pluck('name', 'id'))
-                ->selectablePlaceholder(false)
                 ->default(fn () => SystemAlertStatusClassification::default()?->getKey())
                 ->exists('alert_statuses', 'id')
                 ->required(),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectAlerts.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectAlerts.php
@@ -120,7 +120,6 @@ class ManageProspectAlerts extends ManageRelatedRecords
                     ->string(),
                 Select::make('severity')
                     ->options(AlertSeverity::class)
-                    ->selectablePlaceholder(false)
                     ->default(AlertSeverity::default())
                     ->required()
                     ->enum(AlertSeverity::class),
@@ -131,7 +130,6 @@ class ManageProspectAlerts extends ManageRelatedRecords
                     ->label('Status')
                     ->relationship('status', 'name', fn (Builder $query) => $query->orderBy('order'))
                     ->default(fn () => SystemAlertStatusClassification::default()?->getKey())
-                    ->selectablePlaceholder(false)
                     ->required(),
             ]);
     }

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableAlerts.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableAlerts.php
@@ -88,7 +88,6 @@ trait CanManageEducatableAlerts
                     ->string(),
                 Select::make('severity')
                     ->options(AlertSeverity::class)
-                    ->selectablePlaceholder(false)
                     ->default(AlertSeverity::default())
                     ->required()
                     ->enum(AlertSeverity::class),
@@ -98,7 +97,6 @@ trait CanManageEducatableAlerts
                 Select::make('status_id')
                     ->label('Status')
                     ->relationship('status', 'name', fn (Builder $query) => $query->orderBy('order'))
-                    ->selectablePlaceholder(false)
                     ->default(fn () => SystemAlertStatusClassification::default()?->getKey())
                     ->required(),
             ]);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1219

### Technical Description

Alert creation for students or prospects fails when status is not manually set

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
