### PR TITLE
[ADVAPP-1259]: Remove unnecessary information about the delivery channel from the display of email messages sent to students or prospects

### DIFF
--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -89,20 +89,6 @@ class EngagementsRelationManager extends RelationManager
                                             ->getStateUsing(fn (Timeline $record): HtmlString => $record->timelineable->getBody())
                                             ->columnSpanFull(),
                                     ]),
-                                InfolistFieldset::make('delivery')
-                                    ->label('Delivery Information')
-                                    ->columnSpanFull()
-                                    ->schema([
-                                        TextEntry::make('channel')
-                                            ->label('Channel')
-                                            ->getStateUsing(function (Timeline $record): string {
-                                                /** @var HasDeliveryMethod $timelineable */
-                                                $timelineable = $record->timelineable;
-
-                                                return $timelineable->getDeliveryMethod()->getLabel();
-                                            }),
-                                    ])
-                                    ->columns(),
                             ]),
                         Tab::make('Events')
                             ->schema([


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1259

### Technical Description

> Remove unnecessary information about the delivery channel from the display of email messages sent to students and prospects

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
