### PR TITLE
[ADVAPP-1220]: When attempting to add a proactive alert campaign journey step, an error is generated

### DIFF
--- a/app-modules/alert/src/Models/Alert.php
+++ b/app-modules/alert/src/Models/Alert.php
@@ -134,7 +134,7 @@ class Alert extends BaseModel implements Auditable, CanTriggerAutoSubscription, 
                         'concern_id' => $educatable->getKey(),
                         'description' => $action->data['description'],
                         'severity' => $action->data['severity'],
-                        'status_id' => $action->data['status'],
+                        'status_id' => $action->data['status_id'],
                         'suggested_intervention' => $action->data['suggested_intervention'],
                     ]);
                 });

--- a/app-modules/campaign/tests/Tenant/Actions/ProactiveAlertsCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Actions/ProactiveAlertsCampaignTest.php
@@ -81,7 +81,7 @@ it('will create the appropriate records for educatables in the segment', functio
                 'description' => 'This is the description',
                 'severity' => 'low',
                 'suggested_intervention' => 'This is the suggested intervention',
-                'status' => $alertStatus->getKey(),
+                'status_id' => $alertStatus->getKey(),
             ],
         ]);
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1220

### Technical Description

> Fixed: When attempting to add a proactive alert campaign journey step, an error is generated.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
