### PR TITLE
[ADVAPP-1220]: When attempting to add a proactive alert campaign journey step, an error is generated

### DIFF
--- a/resources/views/filament/forms/components/campaigns/actions/proactive-alert.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/proactive-alert.blade.php
@@ -39,7 +39,7 @@
 
     $alertStatus = AlertStatus::find($action['status_id']);
 
-    if(!$alertStatus) {
+    if (!$alertStatus) {
         return null;
     }
 

--- a/resources/views/filament/forms/components/campaigns/actions/proactive-alert.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/proactive-alert.blade.php
@@ -35,8 +35,14 @@
     use AdvisingApp\Campaign\Settings\CampaignSettings;
     use Carbon\Carbon;
     use AdvisingApp\Alert\Models\AlertStatus;
+    use Filament\Notifications\Notification;
 
-    $alertStatus = AlertStatus::findOrFail($action['status_id']);
+    $alertStatus = AlertStatus::find($action['status_id']);
+
+    if(!$alertStatus) {
+        return null;
+    }
+
 @endphp
 
 <x-filament::fieldset>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1220

### Technical Description

> Fixed the 404 error that occurred when no default alert was set and while selecting a proactive alert in the campaign journey.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
