### PR TITLE
[ADVAPP-1248]: Maintain a complete history of incoming requests for SMS messages from the provider

### DIFF
--- a/app-modules/integration-twilio/routes/web.php
+++ b/app-modules/integration-twilio/routes/web.php
@@ -36,10 +36,14 @@
 
 use AdvisingApp\IntegrationTwilio\Http\Controllers\TwilioInboundWebhookController;
 use AdvisingApp\IntegrationTwilio\Http\Middleware\EnsureTwilioRequestIsValid;
+use AdvisingApp\IntegrationTwilio\Http\Middleware\LogTwilioRequest;
 use App\Http\Middleware\TrimStrings;
 use Illuminate\Support\Facades\Route;
 
 Route::post('inbound/webhook/twilio/{event}', TwilioInboundWebhookController::class)
-    ->middleware(EnsureTwilioRequestIsValid::class)
+    ->middleware([
+        EnsureTwilioRequestIsValid::class,
+        LogTwilioRequest::class,
+    ])
     ->withoutMiddleware(TrimStrings::class)
     ->name('inbound.webhook.twilio');

--- a/app-modules/integration-twilio/src/Http/Middleware/LogTwilioRequest.php
+++ b/app-modules/integration-twilio/src/Http/Middleware/LogTwilioRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AdvisingApp\IntegrationTwilio\Http\Middleware;
+
+use AdvisingApp\Webhook\Actions\StoreInboundWebhook;
+use AdvisingApp\Webhook\Enums\InboundWebhookSource;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class LogTwilioRequest
+{
+    public function __construct(
+        protected StoreInboundWebhook $storeInboundWebhook
+    ) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $this->storeInboundWebhook->handle(
+            source: InboundWebhookSource::Twilio,
+            event: $request->route('event'),
+            url: $request->url(),
+            payload: is_array($request->getContent()) ? json_encode($request->getContent()) : $request->getContent()
+        );
+
+        return $next($request);
+    }
+}

--- a/app-modules/integration-twilio/src/Http/Middleware/LogTwilioRequest.php
+++ b/app-modules/integration-twilio/src/Http/Middleware/LogTwilioRequest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\IntegrationTwilio\Http\Middleware;
 
 use AdvisingApp\Webhook\Actions\StoreInboundWebhook;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1248

### Technical Description

Changes the logging of Twilio messages to happen before the Controller in middleware so that it is always logged as long as it is valid.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
