### PR TITLE
[ADVAPP-1254]: Fix the storage of job batches so they are properly managed within tenants

### DIFF
--- a/app/Multitenancy/Tasks/SwitchTenantDatabasesTask.php
+++ b/app/Multitenancy/Tasks/SwitchTenantDatabasesTask.php
@@ -88,6 +88,7 @@ class SwitchTenantDatabasesTask implements SwitchTenantTask
         config([
             'database.default' => $this->tenantConnectionName,
             'queue.failed.database' => $this->tenantConnectionName,
+            'queue.batching.database' => $this->tenantConnectionName,
         ]);
 
         // Octane will have an old `db` instance in the Model::$resolver.
@@ -111,6 +112,7 @@ class SwitchTenantDatabasesTask implements SwitchTenantTask
         config([
             'database.default' => 'landlord',
             'queue.failed.database' => 'landlord',
+            'queue.batching.database' => 'landlord',
         ]);
 
         // Octane will have an old `db` instance in the Model::$resolver.


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1254

### Technical Description

This makes sure that the batch connection is changed to the Tenant when we switch to the Tenant context. This way job batches are stored in the Tenants database.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
