### PR TITLE
[ADVAPP-1284]: Enable the usage of stored customizable signatures in sending of Engagements

### DIFF
--- a/app-modules/engagement/src/Filament/Actions/RelationManagerSendEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/RelationManagerSendEngagementAction.php
@@ -59,6 +59,7 @@ use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\CreateAction;
+use FilamentTiptapEditor\Enums\TiptapOutput;
 use FilamentTiptapEditor\TiptapEditor;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
@@ -173,6 +174,26 @@ class RelationManagerSendEngagementAction extends CreateAction
                                 ->mergeTags($mergeTags),
                         ]),
                     ]),
+                Fieldset::make('Email signature')
+                    ->schema([
+                        Toggle::make('is_signature_enabled')
+                            ->label('Include signature')
+                            ->helperText('You may configure your email signature in Profile Settings by selecting your avatar in the upper right portion of the screen.')
+                            ->live(),
+                        TiptapEditor::make('signature')
+                            ->profile('signature')
+                            ->extraInputAttributes(['style' => 'min-height: 12rem;'])
+                            ->output(TiptapOutput::Json)
+                            ->required(fn (Get $get) => $get('is_signature_enabled'))
+                            ->disk('s3-public')
+                            ->visible(fn (Get $get) => $get('is_signature_enabled'))
+                            ->default(auth()->user()->signature)
+                            // By default, the TipTap editor will attempt to save relationships to media items, but these will instead be saved as part of the main body content.
+                            ->saveRelationshipsUsing(null),
+                    ])
+                    ->visible(auth()->user()->is_signature_enabled)
+                    ->hidden(fn (Get $get): bool => $get('channel') === NotificationChannel::Sms->value)
+                    ->columns(1),
                 Fieldset::make('Send your email or text')
                     ->schema([
                         Toggle::make('send_later')
@@ -193,19 +214,36 @@ class RelationManagerSendEngagementAction extends CreateAction
                     $this->halt();
                 }
 
+                $data['body'] ??= ['type' => 'doc', 'content' => []];
+                $data['body']['content'] = [
+                    ...($data['body']['content'] ?? []),
+                    ...($data['signature']['content'] ?? []),
+                ];
+
+                $formFields = $form->getFlatFields();
+
                 $engagement = app(CreateEngagement::class)->execute(new EngagementCreationData(
                     user: auth()->user(),
                     recipient: $livewire->getOwnerRecord(),
                     channel: NotificationChannel::parse($data['channel']),
                     subject: $data['subject'] ?? null,
                     body: $data['body'] ?? null,
-                    temporaryBodyImages: array_map(
-                        fn (TemporaryUploadedFile $file): array => [
-                            'extension' => $file->getClientOriginalExtension(),
-                            'path' => (fn () => $this->path)->call($file),
-                        ],
-                        $form->getFlatFields()['body']->getTemporaryImages(),
-                    ),
+                    temporaryBodyImages: [
+                        ...array_map(
+                            fn (TemporaryUploadedFile $file): array => [
+                                'extension' => $file->getClientOriginalExtension(),
+                                'path' => (fn () => $this->path)->call($file),
+                            ],
+                            $formFields['body']->getTemporaryImages(),
+                        ),
+                        ...(($formFields['signature'] ?? null) ? array_map(
+                            fn (TemporaryUploadedFile $file): array => [
+                                'extension' => $file->getClientOriginalExtension(),
+                                'path' => (fn () => $this->path)->call($file),
+                            ],
+                            $formFields['signature']->getTemporaryImages(),
+                        ) : []),
+                    ],
                     scheduledAt: ($data['send_later'] ?? false) ? Carbon::parse($data['scheduled_at'] ?? null) : null,
                 ));
 

--- a/app/Filament/Pages/EditProfile.php
+++ b/app/Filament/Pages/EditProfile.php
@@ -320,8 +320,7 @@ class EditProfile extends Page
                             ->extraInputAttributes(['style' => 'min-height: 12rem;'])
                             ->output(TiptapOutput::Json)
                             ->required(fn (Get $get) => $get('is_signature_enabled'))
-                            ->visibility('public')
-                            ->disk('s3')
+                            ->disk('s3-public')
                             ->visible(fn (Get $get) => $get('is_signature_enabled')),
                     ]),
                 Section::make('Out of Office')

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -148,6 +148,8 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
         'last_logged_in_at' => 'datetime',
         'password_history' => 'array',
         'password_last_updated_at' => 'datetime',
+        'is_signature_enabled' => 'boolean',
+        'signature' => 'array',
     ];
 
     protected $fillable = [

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,6 +31,8 @@ services:
       - 'host.docker.internal:host-gateway'
     volumes:
       - '.:/var/www/html'
+      # - '../common:/var/www/common'
+      # - '../filament-tiptap-editor:/var/www/filament-tiptap-editor'
     networks:
       cgbs-development:
         ipv4_address: 172.16.1.3
@@ -74,6 +76,8 @@ services:
       - 'host.docker.internal:host-gateway'
     volumes:
       - '.:/var/www/html'
+      # - '../common:/var/www/common'
+      # - '../filament-tiptap-editor:/var/www/filament-tiptap-editor'
     networks:
       - cgbs-development
     depends_on:
@@ -104,6 +108,8 @@ services:
       - 'host.docker.internal:host-gateway'
     volumes:
       - '.:/var/www/html'
+      # - '../common:/var/www/common'
+      # - '../filament-tiptap-editor:/var/www/filament-tiptap-editor'
     networks:
       - cgbs-development
     depends_on:


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1284

### Technical Description

Allows the signature to be included in the email content, and copies images from the signature collection on the user record to the engagement record for longevity.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
