### PR TITLE
[ADVAPP-1275]: Normalize permissions related to realtime chat for the role matrix

### DIFF
--- a/app-modules/in-app-communication/database/migrations/2025_03_20_125908_data_remove_realtime_chat_api_permission.php
+++ b/app-modules/in-app-communication/database/migrations/2025_03_20_125908_data_remove_realtime_chat_api_permission.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Database\Migrations\Concerns\CanModifyPermissions;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    use CanModifyPermissions;
+
+    private array $permissionsToDelete = [
+        'realtime_chat.*.view' => 'Realtime Chat',
+    ];
+
+    private array $guards = [
+        'api',
+    ];
+
+    public function up(): void
+    {
+        $realtimeChatPermissionGroup = DB::table('permission_groups')
+            ->where('name', 'Realtime Chat')
+            ->first();
+
+        DB::table('permissions')
+            ->whereIn('name', ['realtime_chat.view-any', 'realtime_chat.*.view'])
+            ->update([
+                'group_id' => $realtimeChatPermissionGroup->id,
+            ]);
+
+        collect($this->guards)
+            ->each(function (string $guard) {
+                $this->deletePermissions(array_keys($this->permissionsToDelete), $guard);
+            });
+    }
+
+    public function down(): void
+    {
+        collect($this->guards)
+            ->each(function (string $guard) {
+                $this->createPermissions($this->permissionsToDelete, $guard);
+            });
+    }
+};


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1275

### Technical Description

Removes unused API permission and duplicate group.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
