### PR TITLE
[ADVAPP-1223]: When a logged in user visits the login page, it does not automatically redirect them to the appropriate target

### DIFF
--- a/app-modules/authorization/src/Filament/Pages/Auth/Login.php
+++ b/app-modules/authorization/src/Filament/Pages/Auth/Login.php
@@ -76,6 +76,8 @@ class Login extends FilamentLogin
 
     public function mount(): void
     {
+        parent::mount();
+
         $themeSettings = app(ThemeSettings::class);
 
         $this->themeChangelogUrl = ! empty($themeSettings->changelog_url) ? $themeSettings->changelog_url : 'https://advising.app/changelog/';


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1223

### Technical Description

Call parent `mount()` when overriding a class to ensure original logic is retained.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
