### PR TITLE
ADVAPP-1321: Improve campaign journey steps by introducing the ability to add and revise custom institutional tags associated with both dynamic and static segments of students and prospects

### DIFF
--- a/app-modules/campaign/src/Enums/CampaignActionType.php
+++ b/app-modules/campaign/src/Enums/CampaignActionType.php
@@ -45,6 +45,7 @@ use AdvisingApp\Campaign\Filament\Blocks\EventBlock;
 use AdvisingApp\Campaign\Filament\Blocks\InteractionBlock;
 use AdvisingApp\Campaign\Filament\Blocks\ProactiveAlertBlock;
 use AdvisingApp\Campaign\Filament\Blocks\SubscriptionBlock;
+use AdvisingApp\Campaign\Filament\Blocks\TagsBlock;
 use AdvisingApp\Campaign\Filament\Blocks\TaskBlock;
 use AdvisingApp\Campaign\Models\CampaignAction;
 use AdvisingApp\CareTeam\Models\CareTeam;
@@ -54,6 +55,7 @@ use AdvisingApp\Interaction\Models\Interaction;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\Notification\Models\Subscription;
 use AdvisingApp\Task\Models\Task;
+use App\Models\Tag;
 use App\Settings\LicenseSettings;
 use Filament\Support\Contracts\HasLabel;
 
@@ -77,6 +79,8 @@ enum CampaignActionType: string implements HasLabel
 
     case Event = 'event';
 
+    case Tags = 'tags';
+
     public static function blocks(): array
     {
         $blocks = [
@@ -96,6 +100,8 @@ enum CampaignActionType: string implements HasLabel
         if (app(LicenseSettings::class)->data->addons->eventManagement) {
             $blocks[] = EventBlock::make();
         }
+
+        $blocks[] = TagsBlock::make();
 
         return $blocks;
     }
@@ -124,6 +130,7 @@ enum CampaignActionType: string implements HasLabel
             CampaignActionType::Task => Task::class,
             CampaignActionType::Subscription => Subscription::class,
             CampaignActionType::Event => Event::class,
+            CampaignActionType::Tags => TagsBlock::class,
         };
     }
 
@@ -139,6 +146,7 @@ enum CampaignActionType: string implements HasLabel
             CampaignActionType::Task => TaskBlock::make(),
             CampaignActionType::Subscription => SubscriptionBlock::make(),
             CampaignActionType::Event => EventBlock::make(),
+            CampaignActionType::Tags => TagsBlock::make(),
         };
 
         return $block->editFields();
@@ -156,6 +164,7 @@ enum CampaignActionType: string implements HasLabel
             CampaignActionType::Task => 'filament.forms.components.campaigns.actions.task',
             CampaignActionType::Subscription => 'filament.forms.components.campaigns.actions.subscription',
             CampaignActionType::Event => 'filament.forms.components.campaigns.actions.event',
+            CampaignActionType::Tags => 'filament.forms.components.campaigns.actions.tags',
         };
     }
 
@@ -171,6 +180,7 @@ enum CampaignActionType: string implements HasLabel
             CampaignActionType::Task => Task::executeFromCampaignAction($action),
             CampaignActionType::Subscription => Subscription::executeFromCampaignAction($action),
             CampaignActionType::Event => Event::executeFromCampaignAction($action),
+            CampaignActionType::Tags => Tag::executeFromCampaignAction($action),
         };
     }
 }

--- a/app-modules/campaign/src/Filament/Blocks/TagsBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/TagsBlock.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Campaign\Filament\Blocks;
+
+use AdvisingApp\Campaign\Settings\CampaignSettings;
+use AdvisingApp\Segment\Models\Segment;
+use App\Models\Tag;
+use Carbon\CarbonImmutable;
+use Filament\Forms\Components\Component;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Get;
+
+class TagsBlock extends CampaignActionBlock
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label('Tags');
+
+        $this->schema($this->createFields());
+    }
+
+    /**
+     *
+     * @param string $fieldPrefix
+     *
+     * @return array<Component>
+     */
+    public function generateFields(string $fieldPrefix = ''): array
+    {
+        return [
+            Select::make($fieldPrefix . 'tag_ids')
+                ->label('Which tags should be applied?')
+                ->options(function (Get $get, $livewire, string $operation) {
+                    if ($operation === 'create') {
+                        $segment_id = $get('../../../segment_id');
+                    } else {
+                        $segment_id = $livewire->getOwnerRecord()->segment_id;
+                    }
+                    $segment = Segment::find($segment_id);
+
+                    return Tag::where('type', $segment->model)->pluck('name', 'id');
+                })
+                ->multiple()
+                ->searchable()
+                ->required()
+                ->exists('tags', 'id'),
+            Toggle::make($fieldPrefix . 'remove_prior')
+                ->label('Remove all previously assigned tags?')
+                ->default(false)
+                ->hintIconTooltip('If checked, all prior tags assignments will be removed.'),
+            DateTimePicker::make('execute_at')
+                ->label('When should the journey step be executed?')
+                ->columnSpanFull()
+                ->timezone(app(CampaignSettings::class)->getActionExecutionTimezone())
+                ->hintIconTooltip('This time is set in ' . app(CampaignSettings::class)->getActionExecutionTimezoneLabel() . '.')
+                ->lazy()
+                ->helperText(fn ($state): ?string => filled($state) ? $this->generateUserTimezoneHint(CarbonImmutable::parse($state)) : null)
+                ->required()
+                ->minDate(now()),
+        ];
+    }
+
+    public static function type(): string
+    {
+        return 'tags';
+    }
+}

--- a/app-modules/prospect/src/Models/Prospect.php
+++ b/app-modules/prospect/src/Models/Prospect.php
@@ -379,6 +379,9 @@ class Prospect extends BaseAuthenticatable implements Auditable, Subscribable, E
         return filled($this->primaryPhoneNumber?->number) && $this->primaryPhoneNumber->can_receive_sms;
     }
 
+    /**
+     * @return MorphToMany<Tag>
+     */
     public function tags(): MorphToMany
     {
         return $this->morphToMany(
@@ -428,7 +431,7 @@ class Prospect extends BaseAuthenticatable implements Auditable, Subscribable, E
     protected function displayName(): Attribute
     {
         return Attribute::make(
-            get: fn (?string $value, array $attributes) => $attributes[$this->displayNameKey()],
+            get: fn(?string $value, array $attributes) => $attributes[$this->displayNameKey()],
         );
     }
 

--- a/app-modules/prospect/src/Models/Prospect.php
+++ b/app-modules/prospect/src/Models/Prospect.php
@@ -431,7 +431,7 @@ class Prospect extends BaseAuthenticatable implements Auditable, Subscribable, E
     protected function displayName(): Attribute
     {
         return Attribute::make(
-            get: fn(?string $value, array $attributes) => $attributes[$this->displayNameKey()],
+            get: fn (?string $value, array $attributes) => $attributes[$this->displayNameKey()],
         );
     }
 

--- a/app-modules/prospect/src/Models/Prospect.php
+++ b/app-modules/prospect/src/Models/Prospect.php
@@ -431,7 +431,7 @@ class Prospect extends BaseAuthenticatable implements Auditable, Subscribable, E
     protected function displayName(): Attribute
     {
         return Attribute::make(
-            get: fn (?string $value, array $attributes) => $attributes[$this->displayNameKey()],
+            get: fn(?string $value, array $attributes) => $attributes[$this->displayNameKey()],
         );
     }
 

--- a/app-modules/prospect/src/Models/Prospect.php
+++ b/app-modules/prospect/src/Models/Prospect.php
@@ -380,7 +380,7 @@ class Prospect extends BaseAuthenticatable implements Auditable, Subscribable, E
     }
 
     /**
-     * @return MorphToMany<Tag>
+     * @return MorphToMany
      */
     public function tags(): MorphToMany
     {

--- a/app-modules/prospect/src/Models/Prospect.php
+++ b/app-modules/prospect/src/Models/Prospect.php
@@ -380,7 +380,7 @@ class Prospect extends BaseAuthenticatable implements Auditable, Subscribable, E
     }
 
     /**
-     * @return MorphToMany
+     * @return MorphToMany<Tag, $this>
      */
     public function tags(): MorphToMany
     {

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -38,8 +38,6 @@ namespace AdvisingApp\StudentDataModel\Models\Contracts;
 
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Notification\Models\Contracts\CanBeNotified;
-use AdvisingApp\Prospect\Models\Prospect;
-use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\Tag;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -69,4 +69,5 @@ interface Educatable extends Identifiable, CanBeNotified
      * @return MorphToMany<Tag>
      */
     public function tags(): MorphToMany;
+
 }

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -67,5 +67,4 @@ interface Educatable extends Identifiable, CanBeNotified
      * @return MorphToMany<Tag>
      */
     public function tags(): MorphToMany;
-
 }

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -69,4 +69,5 @@ interface Educatable extends Identifiable, CanBeNotified
      * @return MorphToMany<Tag,covariant Student|Prospect>
      */
     public function tags(): MorphToMany;
+
 }

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -36,12 +36,13 @@
 
 namespace AdvisingApp\StudentDataModel\Models\Contracts;
 
-use AdvisingApp\Authorization\Enums\LicenseType;
-use AdvisingApp\Notification\Models\Contracts\CanBeNotified;
 use App\Models\Tag;
+use AdvisingApp\Prospect\Models\Prospect;
 use Illuminate\Database\Eloquent\Collection;
+use AdvisingApp\Authorization\Enums\LicenseType;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use AdvisingApp\Notification\Models\Contracts\CanBeNotified;
 
 /**
  * @property-read Collection $careTeam
@@ -64,7 +65,7 @@ interface Educatable extends Identifiable, CanBeNotified
     public function canReceiveSms(): bool;
 
     /**
-     * @return MorphToMany<Tag>
+     * @return MorphToMany<Tag,Prospect|Student>
      */
     public function tags(): MorphToMany;
 }

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -36,13 +36,13 @@
 
 namespace AdvisingApp\StudentDataModel\Models\Contracts;
 
-use App\Models\Tag;
-use AdvisingApp\Prospect\Models\Prospect;
-use Illuminate\Database\Eloquent\Collection;
 use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\Notification\Models\Contracts\CanBeNotified;
+use AdvisingApp\Prospect\Models\Prospect;
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
-use AdvisingApp\Notification\Models\Contracts\CanBeNotified;
 
 /**
  * @property-read Collection $careTeam

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -69,5 +69,4 @@ interface Educatable extends Identifiable, CanBeNotified
      * @return MorphToMany<Tag,covariant Student|Prospect>
      */
     public function tags(): MorphToMany;
-
 }

--- a/app-modules/student-data-model/src/Models/Contracts/Educatable.php
+++ b/app-modules/student-data-model/src/Models/Contracts/Educatable.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\StudentDataModel\Models\Contracts;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Notification\Models\Contracts\CanBeNotified;
 use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\Tag;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -65,7 +66,7 @@ interface Educatable extends Identifiable, CanBeNotified
     public function canReceiveSms(): bool;
 
     /**
-     * @return MorphToMany<Tag,Prospect|Student>
+     * @return MorphToMany<Tag,covariant Student|Prospect>
      */
     public function tags(): MorphToMany;
 }

--- a/app-modules/student-data-model/src/Models/Student.php
+++ b/app-modules/student-data-model/src/Models/Student.php
@@ -380,7 +380,7 @@ class Student extends BaseAuthenticatable implements Auditable, Subscribable, Ed
     }
 
     /**
-     * @return MorphToMany
+     * @return MorphToMany<Tag, $this>
      */
     public function tags(): MorphToMany
     {

--- a/app-modules/student-data-model/src/Models/Student.php
+++ b/app-modules/student-data-model/src/Models/Student.php
@@ -380,7 +380,7 @@ class Student extends BaseAuthenticatable implements Auditable, Subscribable, Ed
     }
 
     /**
-     * @return MorphToMany<Tag>
+     * @return MorphToMany
      */
     public function tags(): MorphToMany
     {

--- a/app-modules/student-data-model/src/Models/Student.php
+++ b/app-modules/student-data-model/src/Models/Student.php
@@ -379,6 +379,9 @@ class Student extends BaseAuthenticatable implements Auditable, Subscribable, Ed
         return filled($this->primaryPhoneNumber?->number) && $this->primaryPhoneNumber->can_receive_sms;
     }
 
+    /**
+     * @return MorphToMany<Tag>
+     */
     public function tags(): MorphToMany
     {
         return $this->morphToMany(

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -37,12 +37,16 @@
 namespace App\Models;
 
 use AdvisingApp\Audit\Models\Concerns\Auditable as AuditableTrait;
+use AdvisingApp\Campaign\Models\CampaignAction;
 use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Models\Contracts\Educatable;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Enums\TagType;
+use Exception;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\DB;
 use OwenIt\Auditing\Contracts\Auditable;
 
 /**
@@ -73,5 +77,28 @@ class Tag extends BaseModel implements Auditable
     {
         return $this->morphedByMany(Student::class, 'taggable')
             ->using(Taggable::class);
+    }
+
+    public static function executeFromCampaignAction(CampaignAction $action): bool|string
+    {
+        try {
+            DB::beginTransaction();
+
+            $action
+                ->campaign
+                ->segment
+                ->retrieveRecords()
+                ->each(function (Educatable $educatable) use ($action) {
+                    $educatable->tags()->sync(ids: $action->data['tag_ids'], detaching: $action->data['remove_prior']);
+                });
+
+            DB::commit();
+
+            return true;
+        } catch (Exception $e) {
+            DB::rollBack();
+
+            return $e->getMessage();
+        }
     }
 }

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -36,6 +36,7 @@
 
 namespace App\Policies;
 
+use AdvisingApp\Campaign\Models\CampaignAction;
 use App\Enums\TagType;
 use App\Models\Authenticatable;
 use App\Models\Tag;
@@ -77,7 +78,11 @@ class TagPolicy
 
     public function delete(Authenticatable $authenticatable, Tag $tag): Response
     {
-        if (($tag->type === TagType::Student && $tag->students()->exists()) || ($tag->type === TagType::Prospect && $tag->prospects()->exists())) {
+        $tagExist = CampaignAction::where('type', 'tags')
+            ->whereJsonContains('data->tag_ids', $tag->getKey())
+            ->exists();
+
+        if (($tag->type === TagType::Student && $tag->students()->exists()) || ($tag->type === TagType::Prospect && $tag->prospects()->exists()) || $tagExist) {
             return Response::deny('Delete access denided as tag is used in other records');
         }
 
@@ -97,7 +102,11 @@ class TagPolicy
 
     public function forceDelete(Authenticatable $authenticatable, Tag $tag): Response
     {
-        if (($tag->type === TagType::Student && $tag->students()->exists()) || ($tag->type === TagType::Prospect && $tag->prospects()->exists())) {
+        $tagExist = CampaignAction::where('type', 'tags')
+            ->whereJsonContains('data->tag_ids', $tag->getKey())
+            ->exists();
+
+        if (($tag->type === TagType::Student && $tag->students()->exists()) || ($tag->type === TagType::Prospect && $tag->prospects()->exists()) || $tagExist) {
             return Response::deny('Delete access denided as tag is used in other records');
         }
 

--- a/resources/views/filament/forms/components/campaigns/actions/tags.blade.php
+++ b/resources/views/filament/forms/components/campaigns/actions/tags.blade.php
@@ -1,6 +1,4 @@
-<?php
-
-/*
+{{--
 <COPYRIGHT>
 
     Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
@@ -32,41 +30,42 @@
     https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
 
 </COPYRIGHT>
-*/
+--}}
+@php
+    use Carbon\Carbon;
+    use App\Models\User;
+    use AdvisingApp\Campaign\Settings\CampaignSettings;
+    use AdvisingApp\Segment\Models\Segment;
+    use App\Models\Tag;
 
-namespace AdvisingApp\StudentDataModel\Models\Contracts;
+    $get = $evaluate(fn($get) => $get);
+    $segment_id = $get('segment_id');
+    $segment = Segment::find($segment_id);
+@endphp
 
-use AdvisingApp\Authorization\Enums\LicenseType;
-use AdvisingApp\Notification\Models\Contracts\CanBeNotified;
-use AdvisingApp\Prospect\Models\Prospect;
-use AdvisingApp\StudentDataModel\Models\Student;
-use App\Models\Tag;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Relations\MorphToMany;
+<x-filament::fieldset>
+    <x-slot name="label">
+        Tags
+    </x-slot>
 
-/**
- * @property-read Collection $careTeam
- * @property string $email
- */
-interface Educatable extends Identifiable, CanBeNotified
-{
-    public static function getLabel(): string;
+    <dl class="max-w-md divide-y divide-gray-200 text-gray-900 dark:divide-gray-700 dark:text-white">
+        <div class="flex flex-col pb-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Tags to be assigned to the {{ $segment->model }}
+            </dt>
+            <dd class="text-sm font-semibold">
+                {{ collect($action['tag_ids'])->map(fn(string $tagId): Tag => Tag::findOrFail($tagId))->implode('name', ', ') }}
+            </dd>
+        </div>
+        <div class="flex flex-col pb-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Remove all prior {{ $segment->model }} assignments
+            </dt>
+            <dd class="text-sm font-semibold">{{ $action['remove_prior'] ? 'True' : 'False' }}</dd>
+        </div>
+        <div class="flex flex-col pt-3">
+            <dt class="mb-1 text-sm text-gray-500 dark:text-gray-400">Execute At</dt>
+            <dd class="text-sm font-semibold">{{ Carbon::parse($action['execute_at'])->format('M j, Y H:i:s') }}
+                {{ app(CampaignSettings::class)->getActionExecutionTimezoneLabel() }}</dd>
+        </div>
+    </dl>
 
-    public static function displayNameKey(): string;
-
-    public static function displayEmailKey(): string;
-
-    public function careTeam(): MorphToMany;
-
-    public static function getLicenseType(): LicenseType;
-
-    public function eventAttendeeRecords(): HasMany;
-
-    public function canReceiveSms(): bool;
-
-    /**
-     * @return MorphToMany<Tag>
-     */
-    public function tags(): MorphToMany;
-}
+</x-filament::fieldset>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1321

### Technical Description

> Improve campaign journey steps by introducing the ability to add and revise custom institutional tags associated with both dynamic and static segments of students and prospects

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
