### PR TITLE
[ADVAPP-1305]: Improve the ability to identify groups of students and prospects by introducing a segment filter for care team membership

### DIFF
--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Tables/ProspectsTable.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Tables/ProspectsTable.php
@@ -162,6 +162,17 @@ class ProspectsTable
                                         fn (Builder $query) => $query->whereKey(auth()->user()),
                                     )),
                             ]),
+                        Constraint::make('careTeam')
+                            ->icon('heroicon-m-user-group')
+                            ->operators([
+                                Operator::make('careTeam')
+                                    ->label(fn (bool $isInverse): string => $isInverse ? 'Not my care team' : 'My care team')
+                                    ->summary('Care team')
+                                    ->baseQuery(fn (Builder $query, bool $isInverse) => $query->{$isInverse ? 'whereDoesntHave' : 'whereHas'}(
+                                        'careTeam',
+                                        fn (Builder $query) => $query->whereKey(auth()->user()),
+                                    )),
+                            ]),
                     ])
                     ->constraintPickerColumns([
                         'md' => 2,

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Tables/StudentsTable.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Tables/StudentsTable.php
@@ -144,13 +144,13 @@ class StudentsTable
                         Constraint::make('careTeam')
                             ->icon('heroicon-m-user-group')
                             ->operators([
-                                Operator::make('subscribed')
+                                Operator::make('careTeam')
                                     ->label(fn (bool $isInverse): string => $isInverse ? 'Not my care team' : 'My care team')
-                                    ->summary(fn (bool $isInverse): string => $isInverse ? 'You are not in my care team' : 'You are in my care team'),
-                                // ->baseQuery(fn(Builder $query, bool $isInverse) => $query->{$isInverse ? 'whereDoesntHave' : 'whereHas'}(
-                                //     'subscriptions.user',
-                                //     fn(Builder $query) => $query->whereKey(auth()->user()),
-                                // )),
+                                    ->summary('Care team')
+                                    ->baseQuery(fn (Builder $query, bool $isInverse) => $query->{$isInverse ? 'whereDoesntHave' : 'whereHas'}(
+                                        'careTeam',
+                                        fn (Builder $query) => $query->whereKey(auth()->user()),
+                                    )),
                             ]),
                         RelationshipConstraint::make('programs')
                             ->multiple()


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1305

### Technical Description

> Add care team filter in student and prospect segment tables.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
