### PR TITLE
[ADVAPP-1368]: Update canyongbs/filament-tiptap-editor to version 1.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "canyon-gbs/multifactor-authentication": "*",
         "canyon-gbs/segment": "*",
         "canyongbs/common": "^1.1.1",
-        "canyongbs/filament-tiptap-editor": "^1.2.0",
+        "canyongbs/filament-tiptap-editor": "^1.2.3",
         "canyongbs/model-state-machine": "^1.0",
         "cknow/laravel-money": "^8.1",
         "composer/composer": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e304ee78535293b67c5499d38fbaed2",
+    "content-hash": "bd2ec3c622aa9779e5027136560bed27",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2806,16 +2806,16 @@
         },
         {
             "name": "canyongbs/filament-tiptap-editor",
-            "version": "1.2.1",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/canyongbs/filament-tiptap-editor.git",
-                "reference": "d93400d65a27909e9f3ce20c3e3d2febd678606c"
+                "reference": "2a2aa8962f6aec5a4bc057f0515dd6d672f27e77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/canyongbs/filament-tiptap-editor/zipball/d93400d65a27909e9f3ce20c3e3d2febd678606c",
-                "reference": "d93400d65a27909e9f3ce20c3e3d2febd678606c",
+                "url": "https://api.github.com/repos/canyongbs/filament-tiptap-editor/zipball/2a2aa8962f6aec5a4bc057f0515dd6d672f27e77",
+                "reference": "2a2aa8962f6aec5a4bc057f0515dd6d672f27e77",
                 "shasum": ""
             },
             "require": {
@@ -2878,7 +2878,7 @@
             ],
             "support": {
                 "issues": "https://github.com/canyongbs/filament-tiptap-editor/issues",
-                "source": "https://github.com/canyongbs/filament-tiptap-editor/tree/1.2.1"
+                "source": "https://github.com/canyongbs/filament-tiptap-editor/tree/1.2.3"
             },
             "funding": [
                 {
@@ -2886,7 +2886,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-02T16:59:26+00:00"
+            "time": "2025-04-08T22:31:28+00:00"
         },
         {
             "name": "canyongbs/model-state-machine",


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1368

### Technical Description

> Update canyongbs/filament-tiptap-editor to version 1.2.3

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> Yes.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
