### PR TITLE
[ADVAPP-1382]: Sometimes the product admin does not have values available for Email or SMS Deliverability, Dual Enrollment, FERPA, SAP, or First Generation, and the record sync and importer tools generate an exception when students/prospects are missing this information

### DIFF
--- a/app-modules/prospect/database/migrations/2025_04_11_165212_make_all_prospect_boolean_columns_nullable.php
+++ b/app-modules/prospect/database/migrations/2025_04_11_165212_make_all_prospect_boolean_columns_nullable.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;

--- a/app-modules/prospect/database/migrations/2025_04_11_165212_make_all_prospect_boolean_columns_nullable.php
+++ b/app-modules/prospect/database/migrations/2025_04_11_165212_make_all_prospect_boolean_columns_nullable.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('prospects', function (Blueprint $table) {
+            $table->boolean('sms_opt_out')->nullable()->change();
+            $table->boolean('email_bounce')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('prospects', function (Blueprint $table) {
+            $table->boolean('sms_opt_out')->default(false)->change();
+            $table->boolean('email_bounce')->default(false)->change();
+        });
+    }
+};

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/CreateProspect.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/CreateProspect.php
@@ -45,7 +45,6 @@ use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Grid;
-use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
@@ -286,13 +285,11 @@ class CreateProspect extends CreateRecord
                     ->columns(2),
                 Section::make('Engagement Restrictions')
                     ->schema([
-                        Radio::make('sms_opt_out')
+                        Select::make('sms_opt_out')
                             ->label('SMS Opt Out')
-                            ->default(false)
                             ->boolean(),
-                        Radio::make('email_bounce')
+                        Select::make('email_bounce')
                             ->label('Email Bounce')
-                            ->default(false)
                             ->boolean(),
                     ])
                     ->columns(2),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/EditProspect.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/EditProspect.php
@@ -53,7 +53,6 @@ use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Grid;
-use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
@@ -274,10 +273,10 @@ class EditProspect extends EditRecord
                     ->columns(2),
                 Section::make('Engagement Restrictions')
                     ->schema([
-                        Radio::make('sms_opt_out')
+                        Select::make('sms_opt_out')
                             ->label('SMS Opt Out')
                             ->boolean(),
-                        Radio::make('email_bounce')
+                        Select::make('email_bounce')
                             ->label('Email Bounce')
                             ->boolean(),
                     ])

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
@@ -54,7 +54,6 @@ use App\Filament\Tables\Columns\IdColumn;
 use App\Models\Tag;
 use Filament\Actions\CreateAction;
 use Filament\Actions\ImportAction;
-use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -204,10 +203,9 @@ class ListProspects extends ListRecords
                                 ->string()
                                 ->required()
                                 ->visible(fn (Get $get) => $get('field') === 'description'),
-                            Radio::make('email_bounce')
+                            Select::make('email_bounce')
                                 ->label('Email Bounce')
                                 ->boolean()
-                                ->required()
                                 ->visible(fn (Get $get) => $get('field') === 'email_bounce'),
                             TextInput::make('hsgrad')
                                 ->label('High School Graduation Date')
@@ -216,10 +214,9 @@ class ListProspects extends ListRecords
                                 ->maxValue(now()->addYears(25)->year)
                                 ->required()
                                 ->visible(fn (Get $get) => $get('field') === 'hsgrad'),
-                            Radio::make('sms_opt_out')
+                            Select::make('sms_opt_out')
                                 ->label('SMS Opt Out')
                                 ->boolean()
-                                ->required()
                                 ->visible(fn (Get $get) => $get('field') === 'sms_opt_out'),
                             Select::make('source_id')
                                 ->label('Source')

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Schemas/ProspectProfileInfolist.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Schemas/ProspectProfileInfolist.php
@@ -101,10 +101,12 @@ class ProspectProfileInfolist
                         Subsection::make([
                             IconEntry::make('sms_opt_out')
                                 ->label('SMS Opt Out')
-                                ->boolean(),
+                                ->boolean()
+                                ->placeholder('N/A'),
                             IconEntry::make('email_bounce')
                                 ->label('Email Bounce')
-                                ->boolean(),
+                                ->boolean()
+                                ->placeholder('N/A'),
                         ]),
                         Subsection::make([
                             TextEntry::make('createdBy.name')

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Tables/ProspectsTable.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Tables/ProspectsTable.php
@@ -129,9 +129,11 @@ class ProspectsTable
                             ),
                         BooleanConstraint::make('sms_opt_out')
                             ->label('SMS Opt Out')
-                            ->icon('heroicon-m-chat-bubble-bottom-center'),
+                            ->icon('heroicon-m-chat-bubble-bottom-center')
+                            ->nullable(),
                         BooleanConstraint::make('email_bounce')
-                            ->icon('heroicon-m-arrow-uturn-left'),
+                            ->icon('heroicon-m-arrow-uturn-left')
+                            ->nullable(),
                         TextConstraint::make('hsgrad')
                             ->label('HS Grad')
                             ->icon('heroicon-m-academic-cap'),

--- a/app-modules/prospect/src/Imports/ProspectImporter.php
+++ b/app-modules/prospect/src/Imports/ProspectImporter.php
@@ -272,12 +272,18 @@ class ProspectImporter extends Importer
             ImportColumn::make('sms_opt_out')
                 ->label('SMS opt out')
                 ->boolean()
-                ->rules(['boolean'])
-                ->example('no'),
+                ->rules([
+                    'nullable',
+                    'boolean',
+                ])
+                ->example('false'),
             ImportColumn::make('email_bounce')
                 ->boolean()
-                ->rules(['boolean'])
-                ->example('yes'),
+                ->rules([
+                    'nullable',
+                    'boolean',
+                ])
+                ->example('true'),
             ImportColumn::make('birthdate')
                 ->rules(['date'])
                 ->example('1990-01-01'),

--- a/app-modules/report/src/Filament/Widgets/StudentEmailOptInOptOutPieChart.php
+++ b/app-modules/report/src/Filament/Widgets/StudentEmailOptInOptOutPieChart.php
@@ -74,14 +74,19 @@ class StudentEmailOptInOptOutPieChart extends PieChartReportWidget
             return Student::where('email_bounce', true)->count();
         });
 
+        $emailNullPercentage = Cache::tags([$this->cacheTag])->remember('email_null_count', now()->addHours(24), function (): int {
+            return Student::whereNull('email_bounce')->count();
+        });
+
         return [
-            'labels' => ['Can receive emails', 'Cannot receive emails'],
+            'labels' => ['Can receive emails', 'Cannot receive emails', 'Data unavailable'],
             'datasets' => [
                 [
-                    'data' => [$emailOptInPercentage, $emailOptOutPercentage],
+                    'data' => [$emailOptInPercentage, $emailOptOutPercentage, $emailNullPercentage],
                     'backgroundColor' => [
                         $this->getRgbString(Color::Orange[500]),
                         $this->getRgbString(Color::Blue[500]),
+                        $this->getRgbString(Color::Gray[500]),
                     ],
                     'hoverOffset' => 4,
                 ],

--- a/app-modules/report/src/Filament/Widgets/StudentSmsOptInOptOutPieChart.php
+++ b/app-modules/report/src/Filament/Widgets/StudentSmsOptInOptOutPieChart.php
@@ -74,15 +74,20 @@ class StudentSmsOptInOptOutPieChart extends PieChartReportWidget
             return Student::where('sms_opt_out', true)->count();
         });
 
+        $smsNullCount = Cache::tags([$this->cacheTag])->remember('sms_null_count', now()->addHours(24), function (): int {
+            return Student::whereNull('sms_opt_out')->count();
+        });
+
         return [
-            'labels' => ['Can receive texts', 'Cannot receive texts'],
+            'labels' => ['Can receive texts', 'Cannot receive texts', 'Data unavailable'],
             'datasets' => [
                 [
                     'label' => 'My First Dataset',
-                    'data' => [$smsOptInCount, $smsOptOutCount],
+                    'data' => [$smsOptInCount, $smsOptOutCount, $smsNullCount],
                     'backgroundColor' => [
                         $this->getRgbString(Color::Orange[500]),
                         $this->getRgbString(Color::Blue[500]),
+                        $this->getRgbString(Color::Gray[500]),
                     ],
                     'hoverOffset' => 4,
                 ],

--- a/app-modules/student-data-model/database/migrations/2025_04_11_164454_make_all_student_boolean_columns_nullable.php
+++ b/app-modules/student-data-model/database/migrations/2025_04_11_164454_make_all_student_boolean_columns_nullable.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;

--- a/app-modules/student-data-model/database/migrations/2025_04_11_164454_make_all_student_boolean_columns_nullable.php
+++ b/app-modules/student-data-model/database/migrations/2025_04_11_164454_make_all_student_boolean_columns_nullable.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('students', function (Blueprint $table) {
+            $table->boolean('sms_opt_out')->nullable()->change();
+            $table->boolean('email_bounce')->nullable()->change();
+            $table->boolean('dual')->nullable()->change();
+            $table->boolean('ferpa')->nullable()->change();
+            $table->boolean('sap')->nullable()->change();
+            $table->boolean('firstgen')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('students', function (Blueprint $table) {
+            $table->boolean('sms_opt_out')->default(false)->change();
+            $table->boolean('email_bounce')->default(false)->change();
+            $table->boolean('dual')->default(false)->change();
+            $table->boolean('ferpa')->default(false)->change();
+            $table->boolean('sap')->default(false)->change();
+            $table->boolean('firstgen')->default(false)->change();
+        });
+    }
+};

--- a/app-modules/student-data-model/src/Filament/Imports/StudentImporter.php
+++ b/app-modules/student-data-model/src/Filament/Imports/StudentImporter.php
@@ -110,17 +110,33 @@ class StudentImporter extends Importer
             ImportColumn::make('sms_opt_out')
                 ->label('SMS opt out')
                 ->example('false')
-                ->boolean(),
+                ->boolean()
+                ->rules([
+                    'nullable',
+                    'boolean',
+                ]),
             ImportColumn::make('email_bounce')
                 ->example('true')
-                ->boolean(),
+                ->boolean()
+                ->rules([
+                    'nullable',
+                    'boolean',
+                ]),
             ImportColumn::make('dual')
                 ->example('true')
-                ->boolean(),
+                ->boolean()
+                ->rules([
+                    'nullable',
+                    'boolean',
+                ]),
             ImportColumn::make('ferpa')
                 ->label('FERPA')
                 ->example('true')
-                ->boolean(),
+                ->boolean()
+                ->rules([
+                    'nullable',
+                    'boolean',
+                ]),
             ImportColumn::make('dfw')
                 ->label('DFW')
                 ->example('2024-10-21')
@@ -131,7 +147,11 @@ class StudentImporter extends Importer
             ImportColumn::make('sap')
                 ->label('SAP')
                 ->example('true')
-                ->boolean(),
+                ->boolean()
+                ->rules([
+                    'nullable',
+                    'boolean',
+                ]),
             ImportColumn::make('holds')
                 ->example('UHIJN')
                 ->rules([
@@ -141,7 +161,11 @@ class StudentImporter extends Importer
                 ]),
             ImportColumn::make('firstgen')
                 ->example('true')
-                ->boolean(),
+                ->boolean()
+                ->rules([
+                    'nullable',
+                    'boolean',
+                ]),
             ImportColumn::make('ethnicity')
                 ->rules([
                     'nullable',

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/CreateStudent.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/CreateStudent.php
@@ -46,8 +46,8 @@ use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
@@ -261,18 +261,24 @@ class CreateStudent extends CreateRecord
                     ]),
                 Section::make('Engagement Restrictions')
                     ->schema([
-                        Toggle::make('sms_opt_out')
-                            ->label('SMS Opt Out'),
-                        Toggle::make('email_bounce')
-                            ->label('Email Bounce'),
-                        Toggle::make('dual')
-                            ->label('Dual'),
-                        Toggle::make('ferpa')
-                            ->label('FERPA'),
-                        Toggle::make('firstgen')
-                            ->label('Firstgen'),
-                        Toggle::make('sap')
-                            ->label('SAP'),
+                        Select::make('sms_opt_out')
+                            ->label('SMS Opt Out')
+                            ->boolean(),
+                        Select::make('email_bounce')
+                            ->label('Email Bounce')
+                            ->boolean(),
+                        Select::make('dual')
+                            ->label('Dual')
+                            ->boolean(),
+                        Select::make('ferpa')
+                            ->label('FERPA')
+                            ->boolean(),
+                        Select::make('firstgen')
+                            ->label('Firstgen')
+                            ->boolean(),
+                        Select::make('sap')
+                            ->label('SAP')
+                            ->boolean(),
                         TextInput::make('holds')
                             ->label('Holds'),
                         DatePicker::make('dfw')

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/EditStudent.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/EditStudent.php
@@ -50,8 +50,8 @@ use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Support\Enums\ActionSize;
@@ -244,18 +244,24 @@ class EditStudent extends EditRecord
                     ]),
                 Section::make('Engagement Restrictions')
                     ->schema([
-                        Toggle::make('sms_opt_out')
-                            ->label('SMS Opt Out'),
-                        Toggle::make('email_bounce')
-                            ->label('Email Bounce'),
-                        Toggle::make('dual')
-                            ->label('Dual'),
-                        Toggle::make('ferpa')
-                            ->label('FERPA'),
-                        Toggle::make('firstgen')
-                            ->label('Firstgen'),
-                        Toggle::make('sap')
-                            ->label('SAP'),
+                        Select::make('sms_opt_out')
+                            ->label('SMS Opt Out')
+                            ->boolean(),
+                        Select::make('email_bounce')
+                            ->label('Email Bounce')
+                            ->boolean(),
+                        Select::make('dual')
+                            ->label('Dual')
+                            ->boolean(),
+                        Select::make('ferpa')
+                            ->label('FERPA')
+                            ->boolean(),
+                        Select::make('firstgen')
+                            ->label('Firstgen')
+                            ->boolean(),
+                        Select::make('sap')
+                            ->label('SAP')
+                            ->boolean(),
                         TextInput::make('holds')
                             ->label('Holds'),
                         DatePicker::make('dfw')

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Tables/StudentsTable.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Tables/StudentsTable.php
@@ -122,14 +122,18 @@ class StudentsTable
                             ->icon('heroicon-m-exclamation-triangle'),
                         BooleanConstraint::make('sap')
                             ->label('SAP')
-                            ->icon('heroicon-m-academic-cap'),
-                        BooleanConstraint::make('dual'),
+                            ->icon('heroicon-m-academic-cap')
+                            ->nullable(),
+                        BooleanConstraint::make('dual')
+                            ->nullable(),
                         BooleanConstraint::make('firstgen')
                             ->label('First Generation')
-                            ->icon('heroicon-m-academic-cap'),
+                            ->icon('heroicon-m-academic-cap')
+                            ->nullable(),
                         BooleanConstraint::make('ferpa')
                             ->label('FERPA')
-                            ->icon('heroicon-m-lock-open'),
+                            ->icon('heroicon-m-lock-open')
+                            ->nullable(),
                         Constraint::make('subscribed')
                             ->icon('heroicon-m-bell')
                             ->operators([
@@ -199,9 +203,11 @@ class StudentsTable
                             ->relationship('enrollments', 'unt_earned'),
                         BooleanConstraint::make('sms_opt_out')
                             ->label('SMS Opt Out')
-                            ->icon('heroicon-m-chat-bubble-bottom-center'),
+                            ->icon('heroicon-m-chat-bubble-bottom-center')
+                            ->nullable(),
                         BooleanConstraint::make('email_bounce')
-                            ->icon('heroicon-m-arrow-uturn-left'),
+                            ->icon('heroicon-m-arrow-uturn-left')
+                            ->nullable(),
                     ])
                     ->constraintPickerColumns([
                         'md' => 2,

--- a/app-modules/student-data-model/src/Models/Student.php
+++ b/app-modules/student-data-model/src/Models/Student.php
@@ -150,6 +150,12 @@ class Student extends BaseAuthenticatable implements Auditable, Subscribable, Ed
         'updated_at_source' => 'datetime',
         'birthdate' => 'date',
         'dfw' => 'date',
+        'sms_opt_out' => 'boolean',
+        'email_bounce' => 'boolean',
+        'dual' => 'boolean',
+        'ferpa' => 'boolean',
+        'sap' => 'boolean',
+        'firstgen' => 'boolean',
     ];
 
     public function identifier(): string


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1382

### Technical Description

Makes boolean columns on students and prospects nullable.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
