### PR TITLE
advapp-1377 change the prompts to not include a signature for emails

### DIFF
--- a/app-modules/engagement/src/Filament/Actions/BulkDraftWithAiAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkDraftWithAiAction.php
@@ -145,6 +145,9 @@ class BulkDraftWithAiAction extends Action
                             The subject line can not use Markdown formatting, it is plain text.
                             Do not ever mention in your response that the answer is being formatted/rendered in Markdown.
 
+                            You should never include an email signature in your response, a users will add their own signature
+                            when they send the email.
+
                             You may use merge tags to insert dynamic data about the student in the body of the email, but these do not work in the subject line:
                             {$mergeTagsList}
                         EOL,

--- a/app-modules/engagement/src/Filament/Actions/MessageCenterDraftWithAiAction.php
+++ b/app-modules/engagement/src/Filament/Actions/MessageCenterDraftWithAiAction.php
@@ -145,6 +145,9 @@ class MessageCenterDraftWithAiAction extends Action
                             The subject line can not use Markdown formatting, it is plain text.
                             Do not ever mention in your response that the answer is being formatted/rendered in Markdown.
 
+                            You should never include an email signature in your response, a users will add their own signature
+                            when they send the email.
+
                             You may use merge tags to insert dynamic data about the student in the body of the email, but these do not work in the subject line:
                             {$mergeTagsList}
                         EOL,

--- a/app-modules/engagement/src/Filament/Actions/RelationManagerDraftWithAiAction.php
+++ b/app-modules/engagement/src/Filament/Actions/RelationManagerDraftWithAiAction.php
@@ -142,6 +142,8 @@ class RelationManagerDraftWithAiAction extends Action
                             The first line should contain the raw subject of the email, with no "Subject: " label at the start.
                             All following lines after the subject are the email body.
 
+                            You should never include a signature in your response, the user will add that themselves.
+
                             When you answer, it is crucial that you format the email body using rich text in Markdown format.
                             The subject line can not use Markdown formatting, it is plain text.
                             Do not ever mention in your response that the answer is being formatted/rendered in Markdown.


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1377

### Technical Description
- All this should do is prompt the AI not to include a signature for emails. 
> Replace this block. Describe your changes in detail. This should include technical/architectural decisions and reasoning, if applicable.
>
> Please ensure that at least one correct change type label is added to the PR. For example, if you are adding a new feature, please add the `Change Type | New Feature` label.

### Any deployment steps required?
No
> A deployment step could be a command that needs to be executed or an ENV key that needs to be added, for example.
>
> If yes, please replace this block with a description of the deployment steps required and apply the `Deployment Steps` label to the PR.
> If no, please replace this block with "No".

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?
No
> Specifically Feature Flags to gate and control logic/flow changes to protect against database schema changes. And Data Migrations to provide some type of data fix that can be removed after they are run
>
> If yes to Feature Flags, please list the name of the added Feature Flag/s and apply the `Feature Flag Added` label to the PR.
> If yes to Data Migrations, please list the full relative file path of the added Data Migration/s.
> If no, please replace this block with "No".

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
