### PR TITLE
[ADVAPP-1381]: When building campaigns, users are unable to see segments created by users other than themselves

### DIFF
--- a/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/CreateCampaign.php
@@ -40,6 +40,8 @@ use AdvisingApp\Campaign\Enums\CampaignActionType;
 use AdvisingApp\Campaign\Filament\Blocks\CampaignActionBlock;
 use AdvisingApp\Campaign\Filament\Resources\CampaignResource;
 use AdvisingApp\Campaign\Models\Campaign;
+use AdvisingApp\Segment\Models\Segment;
+use AdvisingApp\Team\Models\TeamUser;
 use App\Models\User;
 use Filament\Forms\Components\Builder;
 use Filament\Forms\Components\Select;
@@ -71,7 +73,18 @@ class CreateCampaign extends CreateRecord
                         ->required(),
                     Select::make('segment_id')
                         ->label('Population Segment')
-                        ->options($user->segments()->pluck('name', 'id'))
+                        ->options(function () use ($user) {
+                            $teamIds = $user->teams->pluck('id');
+                            $users = TeamUser::query()
+                                ->whereIn('team_id', $teamIds)
+                                ->pluck('user_id');
+                            $users->push($user->getKey());
+                            $users->unique();
+
+                            return Segment::query()
+                                ->whereIn('user_id', $users)
+                                ->pluck('name', 'id');
+                        })
                         ->searchable()
                         ->required(),
                 ]),

--- a/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/EditCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/EditCampaign.php
@@ -37,7 +37,10 @@
 namespace AdvisingApp\Campaign\Filament\Resources\CampaignResource\Pages;
 
 use AdvisingApp\Campaign\Filament\Resources\CampaignResource;
+use AdvisingApp\Segment\Models\Segment;
+use AdvisingApp\Team\Models\TeamUser;
 use App\Filament\Resources\Pages\EditRecord\Concerns\EditPageRedirection;
+use App\Models\User;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -62,7 +65,18 @@ class EditCampaign extends EditRecord
                     ->required(),
                 Select::make('segment_id')
                     ->label('Population Segment')
-                    ->options($user->segments()->pluck('name', 'id'))
+                    ->options(function () use ($user) {
+                        $teamIds = $user->teams->pluck('id');
+                        $users = TeamUser::query()
+                            ->whereIn('team_id', $teamIds)
+                            ->pluck('user_id');
+                        $users->push($user->getKey());
+                        $users->unique();
+
+                        return Segment::query()
+                            ->whereIn('user_id', $users)
+                            ->pluck('name', 'id');
+                    })
                     ->searchable()
                     ->required(),
                 Toggle::make('enabled'),

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -451,8 +451,8 @@ class User extends Authenticatable implements HasLocalePreference, FilamentUser,
     }
 
     /**
-    * @return MorphMany<TrackedEventCount, $this>
-    */
+     * @return MorphMany<TrackedEventCount, $this>
+     */
     public function loginsCount(): MorphMany
     {
         return $this->morphMany(TrackedEventCount::class, 'related_to')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1381

### Technical Description

> When building campaigns, users are unable to see segments created by users other than themselves

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
