### PR TITLE
[ADVAPP-1385]: Update the label used in the create and edit prospect forms to state High School Graduation Year

### DIFF
--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/CreateProspect.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/CreateProspect.php
@@ -132,7 +132,7 @@ class CreateProspect extends CreateRecord
                             ->displayFormat('Y-m-d')
                             ->maxDate(now()),
                         TextInput::make('hsgrad')
-                            ->label('High School Graduation Date')
+                            ->label('High School Graduation Year')
                             ->nullable()
                             ->numeric()
                             ->minValue(1920)

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/EditProspect.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/EditProspect.php
@@ -125,7 +125,7 @@ class EditProspect extends EditRecord
                             ->displayFormat('Y-m-d')
                             ->maxDate(now()),
                         TextInput::make('hsgrad')
-                            ->label('High School Graduation Date')
+                            ->label('High School Graduation Year')
                             ->nullable()
                             ->numeric()
                             ->minValue(1920)

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ListProspects.php
@@ -192,7 +192,7 @@ class ListProspects extends ListRecords
                                 ->options([
                                     'description' => 'Description',
                                     'email_bounce' => 'Email Bounce',
-                                    'hsgrad' => 'High School Graduation Date',
+                                    'hsgrad' => 'High School Graduation Year',
                                     'sms_opt_out' => 'SMS Opt Out',
                                     'source_id' => 'Source',
                                     'status_id' => 'Status',
@@ -208,7 +208,7 @@ class ListProspects extends ListRecords
                                 ->boolean()
                                 ->visible(fn (Get $get) => $get('field') === 'email_bounce'),
                             TextInput::make('hsgrad')
-                                ->label('High School Graduation Date')
+                                ->label('High School Graduation Year')
                                 ->numeric()
                                 ->minValue(1920)
                                 ->maxValue(now()->addYears(25)->year)


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1385

### Technical Description

> Update the label used in the create and edit prospect forms to state High School Graduation Year.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
