### PR TITLE
[ADVAPP-1342]: SIS ID and Other ID column titles in the Students overview section of the Report Library are incorrectly formatted

### DIFF
--- a/app-modules/report/src/Filament/Widgets/MostRecentStudentsTable.php
+++ b/app-modules/report/src/Filament/Widgets/MostRecentStudentsTable.php
@@ -88,8 +88,10 @@ class MostRecentStudentsTable extends BaseWidget
                 TextColumn::make(Student::displayNameKey())
                     ->label('Name'),
                 TextColumn::make('email'),
-                TextColumn::make('sisid'),
-                TextColumn::make('otherid'),
+                TextColumn::make('sisid')
+                    ->label('SIS ID'),
+                TextColumn::make('otherid')
+                    ->label('Other ID'),
                 TextColumn::make('created_at_source')
                     ->label('Created'),
             ])


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1342

### Technical Description

> SIS ID and Other ID column titles in the Students overview section of the Report Library are incorrectly formatted.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
