### PR TITLE
[ADVAPP-1357]: Improve the remaining "Assistant" terminology in Artificial Intelligence to match "Advisor" labeling

### DIFF
--- a/app-modules/ai/database/migrations/2025_04_16_090001_data_update_default_personal_assistant_name_to_institutional_advisor.php
+++ b/app-modules/ai/database/migrations/2025_04_16_090001_data_update_default_personal_assistant_name_to_institutional_advisor.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::table('ai_assistants')
+            ->where('is_default', true)
+            ->update([
+                'name' => 'Institutional Advisor',
+                'updated_at' => now(),
+            ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('ai_assistants')
+            ->where('is_default', true)
+            ->update([
+                'name' => 'Institutional Assistant',
+                'updated_at' => now(),
+            ]);
+    }
+};

--- a/app-modules/ai/database/migrations/2025_04_16_090001_data_update_default_personal_assistant_name_to_institutional_advisor.php
+++ b/app-modules/ai/database/migrations/2025_04_16_090001_data_update_default_personal_assistant_name_to_institutional_advisor.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 

--- a/app-modules/ai/resources/views/components/assistant.blade.php
+++ b/app-modules/ai/resources/views/components/assistant.blade.php
@@ -61,7 +61,7 @@
                                 icon="heroicon-m-magnifying-glass"
                                 x-on:click="isSearchingAssistants = ! isSearchingAssistants"
                             >
-                                Use Custom Assistant
+                                Use Custom Advisor
                             </x-filament::button>
                         @endif
                     </div>
@@ -611,9 +611,7 @@
                                                         messageCopied: false,
                                                         copyMessage: function() {
                                                             navigator.clipboard.writeText(message.content.replace(/(<([^>]+)>)/gi, ''))
-                                                    
                                                             this.messageCopied = true
-                                                    
                                                             setTimeout(() => { this.messageCopied = false }, 2000)
                                                         }
                                                     }"

--- a/app-modules/ai/src/Actions/CompletePrompt.php
+++ b/app-modules/ai/src/Actions/CompletePrompt.php
@@ -64,7 +64,7 @@ class CompletePrompt
             ],
             'sent_at' => now(),
             'user_id' => auth()->id(),
-            'ai_assistant_name' => 'Institutional Assistant',
+            'ai_assistant_name' => 'Institutional Advisor',
             'feature' => AiFeature::DraftWithAi,
         ]);
 

--- a/app-modules/ai/src/Actions/CreateThread.php
+++ b/app-modules/ai/src/Actions/CreateThread.php
@@ -86,7 +86,7 @@ class CreateThread
         $assistant = new AiAssistant();
 
         if ($application === AiApplication::PersonalAssistant) {
-            $assistant->name = 'Institutional Assistant';
+            $assistant->name = 'Institutional Advisor';
             $assistant->description = 'Using the most powerful models available, the primary Institutional Assistant has robust general intelligence, and is designed to serve your college or university.';
         } else {
             $assistant->name = "{$tenant->name} AI Assistant";

--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManageThreads.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManageThreads.php
@@ -125,7 +125,7 @@ trait CanManageThreads
             ->schema([
                 Select::make($propertyName)
                     ->label('Choose an assistant')
-                    ->placeholder('Search for an assistant')
+                    ->placeholder('Search for an advisor')
                     ->searchPrompt('Search')
                     ->hiddenLabel()
                     ->allowHtml()

--- a/app-modules/ai/tests/Tenant/Feature/Actions/CompletePromptTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Actions/CompletePromptTest.php
@@ -95,6 +95,6 @@ it('creates a new AI message log', function () {
             'completion' => 'test-completion',
         ])
         ->user_id->toBe(auth()->id())
-        ->ai_assistant_name->toBe('Institutional Assistant')
+        ->ai_assistant_name->toBe('Institutional Advisor')
         ->feature->toBe(AiFeature::DraftWithAi);
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1357

### Technical Description

> Improve the remaining "Assistant" terminology in Artificial Intelligence to match "Advisor" labeling

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
