### PR TITLE
[ADVAPP-1345]: Click to email and click to text only available from main student profile page

### DIFF
--- a/app-modules/engagement/src/Filament/Actions/DraftWithAiAction.php
+++ b/app-modules/engagement/src/Filament/Actions/DraftWithAiAction.php
@@ -1,0 +1,221 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Engagement\Filament\Actions;
+
+use AdvisingApp\Ai\Actions\CompletePrompt;
+use AdvisingApp\Ai\Exceptions\MessageResponseException;
+use AdvisingApp\Ai\Models\AiAssistant;
+use AdvisingApp\Ai\Settings\AiIntegratedAssistantSettings;
+use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\Notification\Enums\NotificationChannel;
+use AdvisingApp\StudentDataModel\Models\Contracts\Educatable;
+use App\Settings\LicenseSettings;
+use Closure;
+use Exception;
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Enums\MaxWidth;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Vite;
+use Illuminate\Support\Str;
+
+class DraftWithAiAction extends Action
+{
+    /**
+     * @var array<string> | Closure
+     */
+    protected array | Closure $mergeTags = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this
+            ->label('Draft with AI Assistant')
+            ->link()
+            ->icon('heroicon-m-pencil')
+            ->modalContent(function (Page $livewire): View {
+                throw_unless(method_exists($livewire, 'getRecord'), new Exception('The Livewire component must have a [getRecord()] method.'));
+
+                $educatable = $livewire->getRecord();
+
+                throw_unless($educatable instanceof Model, new Exception('The educatable must be a model.'));
+
+                throw_unless($educatable instanceof Educatable, new Exception('The educatable must have the [Educatable] interface.'));
+
+                $educatableName = $educatable->getAttributeValue($educatable::displayNameKey());
+
+                return view('engagement::filament.actions.draft-with-ai-modal-content', [
+                    'recordTitle' => $educatableName,
+                    'avatarUrl' => AiAssistant::query()->where('is_default', true)->first()
+                        ?->getFirstTemporaryUrl(now()->addHour(), 'avatar', 'avatar-height-250px') ?: Vite::asset('resources/images/canyon-ai-headshot.jpg'),
+                ]);
+            })
+            ->modalWidth(MaxWidth::ExtraLarge)
+            ->modalSubmitActionLabel('Draft')
+            ->form([
+                Textarea::make('instructions')
+                    ->hiddenLabel()
+                    ->rows(4)
+                    ->placeholder('What do you want to write about?')
+                    ->required(),
+            ])
+            ->action(function (array $data, Get $get, Set $set, Page $livewire) {
+                throw_unless(method_exists($livewire, 'getRecord'), new Exception('The Livewire component must have a [getRecord()] method.'));
+
+                $model = app(AiIntegratedAssistantSettings::class)->default_model;
+
+                $userName = auth()->user()->name;
+                $userJobTitle = auth()->user()->job_title ?? 'staff member';
+                $clientName = app(LicenseSettings::class)->data->subscription->clientName;
+                $educatableLabel = $livewire->getRecord()::getLabel();
+
+                $mergeTagsList = collect($this->getMergeTags())
+                    ->map(fn (string $tag): string => <<<HTML
+                        <span data-type="mergeTag" data-id="{$tag}" contenteditable="false">{$tag}</span>
+                    HTML)
+                    ->join(', ', ' and ');
+
+                if ($get('channel') === NotificationChannel::Sms->value) {
+                    try {
+                        $content = app(CompletePrompt::class)->execute(
+                            aiModel: $model,
+                            prompt: <<<EOL
+                                The user's name is {$userName} and they are a {$userJobTitle} at {$clientName}.
+                                Please draft a short SMS message for a {$educatableLabel} at their college.
+                                The user will send a message to you containing instructions for the content.
+
+                                You should only respond with the SMS content, you should never greet them.
+
+                                You may use merge tags to insert dynamic data about the student in the body of the SMS:
+                                {$mergeTagsList}
+                            EOL,
+                            content: $data['instructions'],
+                        );
+                    } catch (MessageResponseException $exception) {
+                        report($exception);
+
+                        Notification::make()
+                            ->title('AI Assistant Error')
+                            ->body('There was an issue using the AI assistant. Please try again later.')
+                            ->danger()
+                            ->send();
+
+                        $this->halt();
+
+                        return;
+                    }
+
+                    $set('body', Str::markdown($content));
+
+                    return;
+                }
+
+                try {
+                    $content = app(CompletePrompt::class)->execute(
+                        aiModel: $model,
+                        prompt: <<<EOL
+                            The user's name is {$userName} and they are a {$userJobTitle} at {$clientName}.
+                            Please draft an email for a {$educatableLabel} at their college.
+                            The user will send a message to you containing instructions for the content.
+
+                            You should only respond with the email content, you should never greet them.
+                            The first line should contain the raw subject of the email, with no "Subject: " label at the start.
+                            All following lines after the subject are the email body.
+
+                            When you answer, it is crucial that you format the email body using rich text in Markdown format.
+                            The subject line can not use Markdown formatting, it is plain text.
+                            Do not ever mention in your response that the answer is being formatted/rendered in Markdown.
+
+                            You may use merge tags to insert dynamic data about the student in the body of the email, but these do not work in the subject line:
+                            {$mergeTagsList}
+                        EOL,
+                        content: $data['instructions'],
+                    );
+                } catch (MessageResponseException $exception) {
+                    report($exception);
+
+                    Notification::make()
+                        ->title('AI Assistant Error')
+                        ->body('There was an issue using the AI assistant. Please try again later.')
+                        ->danger()
+                        ->send();
+
+                    $this->halt();
+
+                    return;
+                }
+
+                $set('subject', (string) str($content)
+                    ->before("\n")
+                    ->trim());
+
+                $set('body', (string) str($content)->after("\n")->markdown());
+            })
+            ->visible(
+                auth()->user()->hasLicense(LicenseType::ConversationalAi)
+            );
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'draftWithAi';
+    }
+
+    /**
+     * @param array<string> | Closure $tags
+     */
+    public function mergeTags(array | Closure $tags): static
+    {
+        $this->mergeTags = $tags;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getMergeTags(): array
+    {
+        return $this->evaluate($this->mergeTags);
+    }
+}

--- a/app-modules/engagement/src/Filament/Actions/RelationManagerSendEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/RelationManagerSendEngagementAction.php
@@ -86,19 +86,6 @@ class RelationManagerSendEngagementAction extends CreateAction
 
                 return auth()->user()->can('create', [Engagement::class, $ownerRecord instanceof Prospect ? $ownerRecord : null]);
             })
-            ->mountUsing(function (array $arguments, Form $form, RelationManager $livewire) {
-                $livewire->dispatch('engage-action-finished-loading');
-
-                if (filled($arguments['route'] ?? null)) {
-                    $form->fill([
-                        'channel' => $arguments['channel'] ?? 'email',
-                        'recipient_route_id' => $arguments['route'],
-                        'signature' => auth()->user()->signature,
-                    ]);
-                } else {
-                    $form->fill();
-                }
-            })
             ->form(fn (Form $form, RelationManager $livewire) => $form->schema([
                 Grid::make(2)
                     ->schema([

--- a/app-modules/engagement/src/Filament/Actions/SendEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/SendEngagementAction.php
@@ -42,7 +42,13 @@ use AdvisingApp\Engagement\Filament\Forms\Components\EngagementSmsBodyInput;
 use AdvisingApp\Engagement\Models\EmailTemplate;
 use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\Notification\Enums\NotificationChannel;
+use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\Prospect\Models\ProspectEmailAddress;
+use AdvisingApp\Prospect\Models\ProspectPhoneNumber;
 use AdvisingApp\StudentDataModel\Models\Contracts\Educatable;
+use AdvisingApp\StudentDataModel\Models\StudentEmailAddress;
+use AdvisingApp\StudentDataModel\Models\StudentPhoneNumber;
+use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\StaticAction;
 use Filament\Forms\Components\Actions;
@@ -50,21 +56,23 @@ use Filament\Forms\Components\Actions\Action as FormAction;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Fieldset;
+use Filament\Forms\Components\Grid;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
-use Filament\Notifications\Notification;
+use Filament\Pages\Page;
 use FilamentTiptapEditor\Enums\TiptapOutput;
 use FilamentTiptapEditor\TiptapEditor;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Carbon;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
-class MessageCenterSendEngagementAction extends Action
+class SendEngagementAction extends Action
 {
     protected Educatable $educatable;
 
@@ -74,16 +82,84 @@ class MessageCenterSendEngagementAction extends Action
 
         $this->icon('heroicon-m-chat-bubble-bottom-center-text')
             ->modalHeading('Send Engagement')
-            ->modalDescription(fn () => "Send an engagement to {$this->getEducatable()->display_name}.")
+            ->modalDescription(function (): string {
+                $educatable = $this->getEducatable();
+
+                throw_unless($educatable instanceof Model, new Exception('The educatable must be a model.'));
+
+                $educatableName = $educatable->getAttributeValue($educatable::displayNameKey());
+
+                return "Send an engagement to {$educatableName}.";
+            })
             ->model(Engagement::class)
+            ->authorize(function () {
+                $educatable = $this->getEducatable();
+
+                return auth()->user()->can('create', [Engagement::class, $educatable instanceof Prospect ? $educatable : null]);
+            })
+            ->mountUsing(function (array $arguments, Form $form, Page $livewire) {
+                $livewire->dispatch('engage-action-finished-loading');
+
+                if (filled($arguments['route'] ?? null)) {
+                    $form->fill([
+                        'channel' => $arguments['channel'] ?? 'email',
+                        'recipient_route_id' => $arguments['route'],
+                        'signature' => auth()->user()->signature,
+                    ]);
+                } else {
+                    $form->fill();
+                }
+            })
             ->form([
-                Select::make('channel')
-                    ->label('What would you like to send?')
-                    ->options(NotificationChannel::getEngagementOptions())
-                    ->default(NotificationChannel::Email->value)
-                    ->disableOptionWhen(fn (string $value): bool => (($value == (NotificationChannel::Sms->value) && ! $this->getEducatable()->canReceiveSms())) || NotificationChannel::tryFrom($value)?->getCaseDisabled())
-                    ->selectablePlaceholder(false)
-                    ->live(),
+                Grid::make(2)
+                    ->schema([
+                        Select::make('channel')
+                            ->label('What would you like to send?')
+                            ->options(NotificationChannel::getEngagementOptions())
+                            ->default(NotificationChannel::Email->value)
+                            ->disableOptionWhen(fn (string $value): bool => (($value == (NotificationChannel::Sms->value) && (! $this->getEducatable()->phoneNumbers()->where('can_receive_sms', true)->exists()))) || NotificationChannel::tryFrom($value)?->getCaseDisabled())
+                            ->selectablePlaceholder(false)
+                            ->live()
+                            ->afterStateUpdated(function (mixed $state, Set $set) {
+                                $channel = NotificationChannel::parse($state);
+
+                                $route = match ($channel) {
+                                    NotificationChannel::Email => $this->getEducatable()->primaryEmailAddress?->getKey(),
+                                    NotificationChannel::Sms => $this->getEducatable()->primaryPhoneNumber()
+                                        ->where('can_receive_sms', true)
+                                        ->first()?->getKey(),
+                                } ?? match ($channel) {
+                                    NotificationChannel::Email => $this->getEducatable()->emailAddresses()
+                                        ->first()?->getKey(),
+                                    NotificationChannel::Sms => $this->getEducatable()->phoneNumbers()
+                                        ->where('can_receive_sms', true)
+                                        ->first()?->getKey(),
+                                };
+
+                                $set('recipient_route_id', $route);
+                            }),
+                        Select::make('recipient_route_id')
+                            ->label(fn (Get $get): string => match (NotificationChannel::parse($get('channel'))) {
+                                NotificationChannel::Email => 'Email address',
+                                NotificationChannel::Sms => 'Phone number',
+                            })
+                            ->options(fn (Get $get): array => match (NotificationChannel::parse($get('channel'))) {
+                                NotificationChannel::Email => $this->getEducatable()->emailAddresses
+                                    ->mapWithKeys(fn (StudentEmailAddress | ProspectEmailAddress $emailAddress): array => [
+                                        $emailAddress->getKey() => $emailAddress->address . (filled($emailAddress->type) ? " ({$emailAddress->type})" : ''),
+                                    ])
+                                    ->all(),
+                                NotificationChannel::Sms => $this->getEducatable()->phoneNumbers()
+                                    ->where('can_receive_sms', true)
+                                    ->get()
+                                    ->mapWithKeys(fn (StudentPhoneNumber | ProspectPhoneNumber $phoneNumber): array => [
+                                        $phoneNumber->getKey() => $phoneNumber->number . (filled($phoneNumber->ext) ? " (ext. {$phoneNumber->ext})" : '') . (filled($phoneNumber->type) ? " ({$phoneNumber->type})" : ''),
+                                    ])
+                                    ->all(),
+                            })
+                            ->default(fn (): ?string => $this->getEducatable()->primaryEmailAddress?->getKey())
+                            ->required(),
+                    ]),
                 Fieldset::make('Content')
                     ->schema([
                         TextInput::make('subject')
@@ -132,7 +208,7 @@ class MessageCenterSendEngagementAction extends Action
                                                 )
                                                 ->when(
                                                     $get('onlyMyTeamTemplates'),
-                                                    fn (Builder $query) => $query->whereIn('user_id', auth()->user()->teams->users->pluck('id'))
+                                                    fn (Builder $query) => $query->whereIn('user_id', auth()->user()->teams()->first()->users()->pluck('id'))
                                                 )
                                                 ->where(new Expression('lower(name)'), 'like', "%{$search}%")
                                                 ->orderBy('name')
@@ -165,7 +241,7 @@ class MessageCenterSendEngagementAction extends Action
                             ->columnSpanFull(),
                         EngagementSmsBodyInput::make(context: 'create'),
                         Actions::make([
-                            MessageCenterDraftWithAiAction::make()
+                            DraftWithAiAction::make()
                                 ->mergeTags($mergeTags),
                         ]),
                     ]),
@@ -199,15 +275,9 @@ class MessageCenterSendEngagementAction extends Action
                             ->visible(fn (Get $get) => $get('send_later')),
                     ]),
             ])
-            ->action(function (array $data, Form $form) {
-                if ($data['channel'] == NotificationChannel::Sms->value && ! $this->getEducatable()->canReceiveSms()) {
-                    Notification::make()
-                        ->title(ucfirst($this->getEducatable()->getLabel()) . ' does not have mobile number.')
-                        ->danger()
-                        ->send();
-
-                    $this->halt();
-                }
+            ->action(function (array $data, Form $form, Page $livewire) {
+                /** @var Student | Prospect $recipient */
+                $recipient = $this->getEducatable();
 
                 $data['body'] ??= ['type' => 'doc', 'content' => []];
                 $data['body']['content'] = [
@@ -217,10 +287,24 @@ class MessageCenterSendEngagementAction extends Action
 
                 $formFields = $form->getFlatFields();
 
+                /** @var TiptapEditor $bodyField */
+                $bodyField = $formFields['body'] ?? null;
+
+                /** @var ?TiptapEditor $signatureField */
+                $signatureField = $formFields['signature'] ?? null;
+
+                $channel = NotificationChannel::parse($data['channel']);
+
+                $recipientRoute = match ($channel) {
+                    NotificationChannel::Email => $recipient->emailAddresses()->find($data['recipient_route_id'] ?? null)?->address,
+                    NotificationChannel::Sms => $recipient->phoneNumbers()->find($data['recipient_route_id'] ?? null)?->number,
+                    default => null,
+                };
+
                 $engagement = app(CreateEngagement::class)->execute(new EngagementCreationData(
                     user: auth()->user(),
-                    recipient: $this->getEducatable(),
-                    channel: NotificationChannel::parse($data['channel']),
+                    recipient: $recipient,
+                    channel: $channel,
                     subject: $data['subject'] ?? null,
                     body: $data['body'] ?? null,
                     temporaryBodyImages: [
@@ -229,20 +313,23 @@ class MessageCenterSendEngagementAction extends Action
                                 'extension' => $file->getClientOriginalExtension(),
                                 'path' => (fn () => $this->path)->call($file),
                             ],
-                            $formFields['body']->getTemporaryImages(),
+                            $bodyField->getTemporaryImages(),
                         ),
-                        ...(($formFields['signature'] ?? null) ? array_map(
+                        ...($signatureField ? array_map(
                             fn (TemporaryUploadedFile $file): array => [
                                 'extension' => $file->getClientOriginalExtension(),
                                 'path' => (fn () => $this->path)->call($file),
                             ],
-                            $formFields['signature']->getTemporaryImages(),
+                            $signatureField->getTemporaryImages(),
                         ) : []),
                     ],
                     scheduledAt: ($data['send_later'] ?? false) ? Carbon::parse($data['scheduled_at'] ?? null) : null,
+                    recipientRoute: $recipientRoute,
                 ));
 
                 $form->model($engagement)->saveRelationships();
+
+                $livewire->dispatch('engagement-sent');
             })
             ->modalSubmitActionLabel('Send')
             ->modalCloseButton(false)

--- a/app-modules/engagement/src/Filament/Pages/MessageCenter.php
+++ b/app-modules/engagement/src/Filament/Pages/MessageCenter.php
@@ -38,7 +38,7 @@ namespace AdvisingApp\Engagement\Filament\Pages;
 
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\CaseManagement\Models\CaseModel;
-use AdvisingApp\Engagement\Filament\Actions\MessageCenterSendEngagementAction;
+use AdvisingApp\Engagement\Filament\Actions\SendEngagementAction;
 use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\Engagement\Models\EngagementResponse;
 use AdvisingApp\Prospect\Models\Prospect;
@@ -356,9 +356,14 @@ class MessageCenter extends Page
 
     public function createAction(): Action
     {
-        return MessageCenterSendEngagementAction::make()
+        return SendEngagementAction::make()
             ->educatable($this->recordModel)
             ->after(fn () => $this->refreshSelectedEducatable());
+    }
+
+    public function getRecord(): ?Educatable
+    {
+        return $this->recordModel;
     }
 
     protected function getViewData(): array

--- a/app-modules/prospect/resources/views/filament/resources/prospect-resource/view-prospect.blade.php
+++ b/app-modules/prospect/resources/views/filament/resources/prospect-resource/view-prospect.blade.php
@@ -117,27 +117,29 @@
         </div>
     </div>
 
-    @script
-        <script>
-            Livewire.hook('request', ({
-                fail
-            }) => {
-                fail(({
-                    status,
-                    content,
-                    preventDefault
+    @if (! app()->hasDebugModeEnabled())
+        @script
+            <script>
+                Livewire.hook('request', ({
+                    fail
                 }) => {
-                    preventDefault();
+                    fail(({
+                        status,
+                        content,
+                        preventDefault
+                    }) => {
+                        preventDefault();
 
-                    new FilamentNotification()
-                        .title('Error while loading page')
-                        .body(
-                            'There was an error rendering some information on the holistic prospect profile page. We are tracking this error on the back end and will work on getting this fixed.'
-                        )
-                        .danger()
-                        .send()
+                        new FilamentNotification()
+                            .title('Error while loading page')
+                            .body(
+                                'There was an error rendering some information on the holistic prospect profile page. We are tracking this error on the back end and will work on getting this fixed.'
+                            )
+                            .danger()
+                            .send()
+                    })
                 })
-            })
-        </script>
-    @endscript
+            </script>
+        @endscript
+    @endif
 </x-filament-panels::page>

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/Concerns/HasProspectHeader.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/Concerns/HasProspectHeader.php
@@ -43,12 +43,15 @@ use AdvisingApp\Prospect\Filament\Resources\ProspectResource\Actions\Disassociat
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource\Actions\ProspectTagsAction;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource\Pages\ViewProspect;
 use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Filament\Resources\EducatableResource\Pages\Concerns\HasEducatableHeader;
 use AdvisingApp\StudentDataModel\Settings\StudentInformationSystemSettings;
 use App\Settings\DisplaySettings;
 use Illuminate\Contracts\View\View;
 
 trait HasProspectHeader
 {
+    use HasEducatableHeader;
+
     public function getHeader(): ?View
     {
         $sisSettings = app(StudentInformationSystemSettings::class);

--- a/app-modules/student-data-model/resources/views/components/filament/resources/educatable-resource/view-educatable/email-address-detail.blade.php
+++ b/app-modules/student-data-model/resources/views/components/filament/resources/educatable-resource/view-educatable/email-address-detail.blade.php
@@ -9,43 +9,40 @@
     Notice:
 
     - You may not provide the software to third parties as a hosted or managed
-      service, where the service provides users with access to any substantial set of
-      the features or functionality of the software.
+    service, where the service provides users with access to any substantial set of
+    the features or functionality of the software.
     - You may not move, change, disable, or circumvent the license key functionality
-      in the software, and you may not remove or obscure any functionality in the
-      software that is protected by the license key.
+    in the software, and you may not remove or obscure any functionality in the
+    software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
-      to applicable law.
+    of the licensor in the software. Any use of the licensor’s trademarks is subject
+    to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
-      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
-      vigorously.
+    same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+    Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+    vigorously.
     - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS LLC.
+    Software as a Service (SaaS) by Canyon GBS LLC.
     - Use of this software implies agreement to the license terms and conditions as stated
-      in the Elastic License 2.0.
+    in the Elastic License 2.0.
 
     For more information or inquiries please visit our website at
     https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
 
 </COPYRIGHT>
 --}}
-<button
-    class="flex items-center gap-2"
-    type="button"
-    x-data="{ isLoading: false }"
+@php
+    use AdvisingApp\Engagement\Models\Engagement;
+    use AdvisingApp\Prospect\Models\ProspectEmailAddress;
+@endphp
+
+<button class="flex items-center gap-2" type="button" x-data="{ isLoading: false }"
     x-on:engage-action-finished-loading.window="isLoading = false"
     x-on:click="isLoading = true; $dispatch('send-email', { emailAddressKey: @js($emailAddress->getKey()) })"
-    x-tooltip.raw="Click to send an email"
->
+    x-tooltip.raw="Click to send an email" @disabled(!auth()->user()->can('create', [Engagement::class, $emailAddress instanceof ProspectEmailAddress ? $emailAddress->prospect : null]))>
     @svg('heroicon-m-envelope', 'size-5', ['x-show' => '! isLoading'])
 
-    <x-filament::loading-indicator
-        class="size-5"
-        x-show="isLoading"
-        x-cloak
-    />
+    <x-filament::loading-indicator class="size-5" x-show="isLoading" x-cloak />
 
     {{ $emailAddress->address }}
 

--- a/app-modules/student-data-model/resources/views/components/filament/resources/educatable-resource/view-educatable/phone-number-detail.blade.php
+++ b/app-modules/student-data-model/resources/views/components/filament/resources/educatable-resource/view-educatable/phone-number-detail.blade.php
@@ -9,44 +9,40 @@
     Notice:
 
     - You may not provide the software to third parties as a hosted or managed
-      service, where the service provides users with access to any substantial set of
-      the features or functionality of the software.
+    service, where the service provides users with access to any substantial set of
+    the features or functionality of the software.
     - You may not move, change, disable, or circumvent the license key functionality
-      in the software, and you may not remove or obscure any functionality in the
-      software that is protected by the license key.
+    in the software, and you may not remove or obscure any functionality in the
+    software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
-      to applicable law.
+    of the licensor in the software. Any use of the licensor’s trademarks is subject
+    to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
-      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
-      vigorously.
+    same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+    Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+    vigorously.
     - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS LLC.
+    Software as a Service (SaaS) by Canyon GBS LLC.
     - Use of this software implies agreement to the license terms and conditions as stated
-      in the Elastic License 2.0.
+    in the Elastic License 2.0.
 
     For more information or inquiries please visit our website at
     https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
 
 </COPYRIGHT>
 --}}
-<button
-    class="flex items-center gap-2"
-    type="button"
-    x-data="{ isLoading: false }"
+@php
+    use AdvisingApp\Engagement\Models\Engagement;
+    use AdvisingApp\Prospect\Models\ProspectPhoneNumber;
+@endphp
+
+<button class="flex items-center gap-2" type="button" x-data="{ isLoading: false }"
     x-on:engage-action-finished-loading.window="isLoading = false"
     x-on:click="isLoading = true; $dispatch('send-sms', { phoneNumberKey: @js($phoneNumber->getKey()) })"
-    x-tooltip.raw="Click to send an SMS"
-    @disabled(!$phoneNumber->can_receive_sms)
->
+    x-tooltip.raw="Click to send an SMS" @disabled((!$phoneNumber->can_receive_sms) || (!auth()->user()->can('create', [Engagement::class, $phoneNumber instanceof ProspectPhoneNumber ? $phoneNumber->prospect : null])))>
     @svg('heroicon-m-phone', 'size-5', ['x-show' => '! isLoading'])
 
-    <x-filament::loading-indicator
-        class="size-5"
-        x-show="isLoading"
-        x-cloak
-    />
+    <x-filament::loading-indicator class="size-5" x-show="isLoading" x-cloak />
 
     {{ $phoneNumber->number }}
 

--- a/app-modules/student-data-model/resources/views/components/filament/resources/educatable-resource/view-educatable/relation-managers.blade.php
+++ b/app-modules/student-data-model/resources/views/components/filament/resources/educatable-resource/view-educatable/relation-managers.blade.php
@@ -9,22 +9,22 @@
     Notice:
 
     - You may not provide the software to third parties as a hosted or managed
-      service, where the service provides users with access to any substantial set of
-      the features or functionality of the software.
+    service, where the service provides users with access to any substantial set of
+    the features or functionality of the software.
     - You may not move, change, disable, or circumvent the license key functionality
-      in the software, and you may not remove or obscure any functionality in the
-      software that is protected by the license key.
+    in the software, and you may not remove or obscure any functionality in the
+    software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
-      to applicable law.
+    of the licensor in the software. Any use of the licensor’s trademarks is subject
+    to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
-      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
-      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
-      vigorously.
+    same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+    Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+    vigorously.
     - The software solution, including services, infrastructure, and code, is offered as a
-      Software as a Service (SaaS) by Canyon GBS LLC.
+    Software as a Service (SaaS) by Canyon GBS LLC.
     - Use of this software implies agreement to the license terms and conditions as stated
-      in the Elastic License 2.0.
+    in the Elastic License 2.0.
 
     For more information or inquiries please visit our website at
     https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
@@ -40,15 +40,11 @@
 @endphp
 
 @if ($managers)
-    <div
-        x-data="{ activeTab: @js(array_key_first($managers)) }"
-        x-on:send-email.window="activeTab = 'messages'"
-        x-on:send-sms.window="activeTab = 'messages'"
-        {{ $attributes->class(['flex flex-col gap-3']) }}
-    >
+    <div x-data="{ activeTab: @js(array_key_first($managers)) }" {{ $attributes->class(['flex flex-col gap-3']) }}>
         <x-filament::tabs>
             @foreach ($managers as $managerKey => $manager)
-                <x-filament::tabs.item :alpine-active="'activeTab === ' . Js::from($managerKey)" :x-on:click="'activeTab = ' . Js::from($managerKey)">
+                <x-filament::tabs.item :alpine-active="'activeTab === ' . Js::from($managerKey)"
+                    :x-on:click="'activeTab = ' . Js::from($managerKey)">
                     {{ $manager::getTitle($this->getRecord(), static::class) }}
                 </x-filament::tabs.item>
             @endforeach
@@ -61,11 +57,11 @@
                     [
                         'ownerRecord' => $this->getRecord(),
                         'pageClass' => static::class,
-                        'lazy' => $loop->first || $managerKey === 'messages' ? false : 'on-load',
+                        'lazy' => $loop->first ? false : 'on-load',
                     ],
                     key('relation-manager-' . $managerKey)
                 )
-            </div>
+                    </div>
         @endforeach
-    </div>
+            </div>
 @endif

--- a/app-modules/student-data-model/resources/views/filament/resources/student-resource/view-student.blade.php
+++ b/app-modules/student-data-model/resources/views/filament/resources/student-resource/view-student.blade.php
@@ -122,27 +122,29 @@
         </div>
     </div>
 
-    @script
-        <script>
-            Livewire.hook('request', ({
-                fail
-            }) => {
-                fail(({
-                    status,
-                    content,
-                    preventDefault
+    @if (! app()->hasDebugModeEnabled())
+        @script
+            <script>
+                Livewire.hook('request', ({
+                    fail
                 }) => {
-                    preventDefault();
+                    fail(({
+                        status,
+                        content,
+                        preventDefault
+                    }) => {
+                        preventDefault();
 
-                    new FilamentNotification()
-                        .title('Error while loading page')
-                        .body(
-                            'There was an error rendering some information on the holistic student profile page. We are tracking this error on the back end and will work on getting this fixed.'
-                        )
-                        .danger()
-                        .send()
+                        new FilamentNotification()
+                            .title('Error while loading page')
+                            .body(
+                                'There was an error rendering some information on the holistic student profile page. We are tracking this error on the back end and will work on getting this fixed.'
+                            )
+                            .danger()
+                            .send()
+                    })
                 })
-            })
-        </script>
-    @endscript
+            </script>
+        @endscript
+    @endif
 </x-filament-panels::page>

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/HasEducatableHeader.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/HasEducatableHeader.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\StudentDataModel\Filament\Resources\EducatableResource\Pages\Concerns;
+
+use AdvisingApp\Engagement\Filament\Actions\SendEngagementAction;
+use Livewire\Attributes\On;
+
+trait HasEducatableHeader
+{
+    #[On('send-email')]
+    public function mountSendEmailMessageAction(string $emailAddressKey): void
+    {
+        $this->mountAction('engage', arguments: ['channel' => 'email', 'route' => $emailAddressKey]);
+    }
+
+    #[On('send-sms')]
+    public function mountSendSmsMessageAction(string $phoneNumberKey): void
+    {
+        $this->mountAction('engage', arguments: ['channel' => 'sms', 'route' => $phoneNumberKey]);
+    }
+
+    public function engage(): SendEngagementAction
+    {
+        return SendEngagementAction::make()
+            ->educatable($this->getRecord());
+    }
+}

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/Concerns/HasStudentHeader.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Pages/Concerns/HasStudentHeader.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\Pages\
 
 use AdvisingApp\Notification\Filament\Actions\SubscribeHeaderAction;
 use AdvisingApp\StudentDataModel\Actions\DeleteStudent;
+use AdvisingApp\StudentDataModel\Filament\Resources\EducatableResource\Pages\Concerns\HasEducatableHeader;
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource;
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\Actions\StudentTagsAction;
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\Actions\SyncStudentSisAction;
@@ -49,6 +50,8 @@ use Illuminate\Contracts\View\View;
 
 trait HasStudentHeader
 {
+    use HasEducatableHeader;
+
     public function getHeader(): ?View
     {
         $sisSettings = app(StudentInformationSystemSettings::class);

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -68,17 +68,8 @@ class EngagementsRelationManager extends RelationManager
 
     protected static ?string $title = 'Messages';
 
-    #[On('send-email')]
-    public function mountSendEmailMessageAction(string $emailAddressKey): void
-    {
-        $this->mountTableAction('engage', arguments: ['channel' => 'email', 'route' => $emailAddressKey]);
-    }
-
-    #[On('send-sms')]
-    public function mountSendSmsMessageAction(string $phoneNumberKey): void
-    {
-        $this->mountTableAction('engage', arguments: ['channel' => 'sms', 'route' => $phoneNumberKey]);
-    }
+    #[On('engagement-sent')]
+    public function refresh(): void {}
 
     public function infolist(Infolist $infolist): Infolist
     {


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1345

### Technical Description

Moves the action onto the pages themselves instead of the relation manager, as the relation manager is not loaded outside of the profile page. Repurposes the message center actions for this purpose.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
