### PR TITLE
[ADVAPP-1341]: Validation message is incorrect when no Journey Step is added while attempting to create a campaign

### DIFF
--- a/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/CampaignResource/Pages/CreateCampaign.php
@@ -83,6 +83,7 @@ class CreateCampaign extends CreateRecord
                         ->minItems(1)
                         ->blocks(CampaignActionType::blocks())
                         ->dehydrated(false)
+                        ->validationAttribute('journey steps')
                         ->saveRelationshipsUsing(function (Builder $component, Campaign $record) {
                             foreach ($component->getChildComponentContainers() as $item) {
                                 /** @var CampaignActionBlock $block */


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1341

### Technical Description

> Validation message is incorrect when no Journey Step is added while attempting to create a campaign

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
