### PR TITLE
[ADVAPP-1346]: When creating emails but canceling send, the emails persist unxpectedly

### DIFF
--- a/app-modules/engagement/src/Filament/Actions/RelationManagerSendEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/RelationManagerSendEngagementAction.php
@@ -69,6 +69,7 @@ use FilamentTiptapEditor\TiptapEditor;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Carbon;
+use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
 class RelationManagerSendEngagementAction extends CreateAction
@@ -310,7 +311,7 @@ class RelationManagerSendEngagementAction extends CreateAction
                     ->color('gray')
                     ->cancelParentActions()
                     ->requiresConfirmation()
-                    ->action(fn () => null)
+                    ->action(fn (Component $livewire) => $livewire->js('$store.previous = {}')) // This fixes an issue where the TipTap editor inside this modal is persisted after the modal is closed, and the old content is restored to the editor. This can be removed when the app is upgraded to Filament v4.
                     ->modalSubmitAction(fn (StaticAction $action) => $action->color('danger')),
             ]);
     }

--- a/app-modules/engagement/src/Filament/Actions/SendEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/SendEngagementAction.php
@@ -70,6 +70,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Carbon;
+use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
 class SendEngagementAction extends Action
@@ -343,7 +344,7 @@ class SendEngagementAction extends Action
                     ->color('gray')
                     ->cancelParentActions()
                     ->requiresConfirmation()
-                    ->action(fn () => null)
+                    ->action(fn (Component $livewire) => $livewire->js('$store.previous = {}')) // This fixes an issue where the TipTap editor inside this modal is persisted after the modal is closed, and the old content is restored to the editor. This can be removed when the app is upgraded to Filament v4.
                     ->modalSubmitAction(fn (StaticAction $action) => $action->color('danger')),
             ]);
     }


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1346

### Technical Description

Due to a TipTap editor bug, the editor instance is stored and reused when a modal is closed and opened again. This code change is a small patch that should fix the problem until we can upgrade to Filament v4.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
