### PR TITLE
[ADVAPP-1389]: When adding a new care team member, users already in the care team are still listed and selectable

### DIFF
--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
@@ -112,7 +112,7 @@ class ManageProspectCareTeam extends ManageRelatedRecords
                             ->label('User')
                             ->searchable()
                             ->required()
-                            ->options(User::query()->tap(new HasLicense(Prospect::getLicenseType()))->whereDoesntHave('prospectCareTeams')->pluck('name', 'id')),
+                            ->options(User::query()->tap(new HasLicense(Prospect::getLicenseType()))->whereDoesntHave('prospectCareTeams', fn($query) => $query->where('educatable_id', $this->getOwnerRecord()->getKey()))->pluck('name', 'id')),
                         Select::make('care_team_role_id')
                             ->label('Role')
                             ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Prospect))

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
@@ -115,7 +115,7 @@ class ManageProspectCareTeam extends ManageRelatedRecords
                             ->options(
                                 User::query()->tap(new HasLicense(Prospect::getLicenseType()))
                                     ->whereDoesntHave('prospectCareTeams', fn ($query) => $query
-                                        ->where('educatable_type', CareTeamRoleType::Prospect)
+                                        ->where('educatable_type', $this->getOwnerRecord()->getMorphClass())
                                         ->where('educatable_id', $this->getOwnerRecord()->getKey()))
                                     ->pluck('name', 'id')
                             ),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
@@ -112,7 +112,13 @@ class ManageProspectCareTeam extends ManageRelatedRecords
                             ->label('User')
                             ->searchable()
                             ->required()
-                            ->options(User::query()->tap(new HasLicense(Prospect::getLicenseType()))->whereDoesntHave('prospectCareTeams', fn ($query) => $query->where('educatable_id', $this->getOwnerRecord()->getKey()))->pluck('name', 'id')),
+                            ->options(
+                                User::query()->tap(new HasLicense(Prospect::getLicenseType()))
+                                    ->whereDoesntHave('prospectCareTeams', fn ($query) => $query
+                                        ->where('educatable_type', CareTeamRoleType::Prospect)
+                                        ->where('educatable_id', $this->getOwnerRecord()->getKey()))
+                                    ->pluck('name', 'id')
+                            ),
                         Select::make('care_team_role_id')
                             ->label('Role')
                             ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Prospect))

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
@@ -112,7 +112,7 @@ class ManageProspectCareTeam extends ManageRelatedRecords
                             ->label('User')
                             ->searchable()
                             ->required()
-                            ->options(User::query()->tap(new HasLicense(Prospect::getLicenseType()))->whereDoesntHave('prospectCareTeam')->pluck('name', 'id')),
+                            ->options(User::query()->tap(new HasLicense(Prospect::getLicenseType()))->whereDoesntHave('prospectCareTeams')->pluck('name', 'id')),
                         Select::make('care_team_role_id')
                             ->label('Role')
                             ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Prospect))

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
@@ -112,7 +112,7 @@ class ManageProspectCareTeam extends ManageRelatedRecords
                             ->label('User')
                             ->searchable()
                             ->required()
-                            ->options(User::query()->tap(new HasLicense(Prospect::getLicenseType()))->pluck('name', 'id')),
+                            ->options(User::query()->tap(new HasLicense(Prospect::getLicenseType()))->whereDoesntHave('prospectCareTeam')->pluck('name', 'id')),
                         Select::make('care_team_role_id')
                             ->label('Role')
                             ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Prospect))

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
@@ -112,7 +112,7 @@ class ManageProspectCareTeam extends ManageRelatedRecords
                             ->label('User')
                             ->searchable()
                             ->required()
-                            ->options(User::query()->tap(new HasLicense(Prospect::getLicenseType()))->whereDoesntHave('prospectCareTeams', fn($query) => $query->where('educatable_id', $this->getOwnerRecord()->getKey()))->pluck('name', 'id')),
+                            ->options(User::query()->tap(new HasLicense(Prospect::getLicenseType()))->whereDoesntHave('prospectCareTeams', fn ($query) => $query->where('educatable_id', $this->getOwnerRecord()->getKey()))->pluck('name', 'id')),
                         Select::make('care_team_role_id')
                             ->label('Role')
                             ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Prospect))

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -105,7 +105,7 @@ trait CanManageEducatableCareTeam
                                     ->whereDoesntHave(
                                         'studentCareTeams',
                                         fn ($query) => $query
-                                            ->where('educatable_type', CareTeamRoleType::Student)
+                                            ->where('educatable_type', $this->getOwnerRecord()->getMorphClass())
                                             ->where('educatable_id', $this->getOwnerRecord()->getKey())
                                     )->pluck('name', 'id')
                             ),

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -100,7 +100,13 @@ trait CanManageEducatableCareTeam
                             ->label('User')
                             ->searchable()
                             ->required()
-                            ->options(User::query()->tap(new HasLicense(Student::getLicenseType()))->whereDoesntHave('studentCareTeams', fn ($query) => $query->where('educatable_id', $this->getOwnerRecord()->getKey()))->pluck('name', 'id')),
+                            ->options(
+                                User::query()->tap(new HasLicense(Student::getLicenseType()))
+                                    ->whereDoesntHave('studentCareTeams', fn ($query) => $query
+                                        ->where('educatable_type', CareTeamRoleType::Student)
+                                        ->where('educatable_id', $this->getOwnerRecord()->getKey())
+                                    )->pluck('name', 'id')
+                            ),
                         Select::make('care_team_role_id')
                             ->label('Role')
                             ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Student))

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -100,7 +100,7 @@ trait CanManageEducatableCareTeam
                             ->label('User')
                             ->searchable()
                             ->required()
-                            ->options(User::query()->tap(new HasLicense(Student::getLicenseType()))->whereDoesntHave('studentCareTeams', fn($query) => $query->where('educatable_id', $this->getOwnerRecord()->getKey()))->pluck('name', 'id')),
+                            ->options(User::query()->tap(new HasLicense(Student::getLicenseType()))->whereDoesntHave('studentCareTeams', fn ($query) => $query->where('educatable_id', $this->getOwnerRecord()->getKey()))->pluck('name', 'id')),
                         Select::make('care_team_role_id')
                             ->label('Role')
                             ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Student))

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -102,9 +102,11 @@ trait CanManageEducatableCareTeam
                             ->required()
                             ->options(
                                 User::query()->tap(new HasLicense(Student::getLicenseType()))
-                                    ->whereDoesntHave('studentCareTeams', fn ($query) => $query
-                                        ->where('educatable_type', CareTeamRoleType::Student)
-                                        ->where('educatable_id', $this->getOwnerRecord()->getKey())
+                                    ->whereDoesntHave(
+                                        'studentCareTeams',
+                                        fn ($query) => $query
+                                            ->where('educatable_type', CareTeamRoleType::Student)
+                                            ->where('educatable_id', $this->getOwnerRecord()->getKey())
                                     )->pluck('name', 'id')
                             ),
                         Select::make('care_team_role_id')

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -100,7 +100,7 @@ trait CanManageEducatableCareTeam
                             ->label('User')
                             ->searchable()
                             ->required()
-                            ->options(User::query()->tap(new HasLicense(Student::getLicenseType()))->pluck('name', 'id')),
+                            ->options(User::query()->tap(new HasLicense(Student::getLicenseType()))->whereDoesntHave('studentCareTeams')->pluck('name', 'id')),
                         Select::make('care_team_role_id')
                             ->label('Role')
                             ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Student))

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -100,7 +100,7 @@ trait CanManageEducatableCareTeam
                             ->label('User')
                             ->searchable()
                             ->required()
-                            ->options(User::query()->tap(new HasLicense(Student::getLicenseType()))->whereDoesntHave('studentCareTeams')->pluck('name', 'id')),
+                            ->options(User::query()->tap(new HasLicense(Student::getLicenseType()))->whereDoesntHave('studentCareTeams', fn($query) => $query->where('educatable_id', $this->getOwnerRecord()->getKey()))->pluck('name', 'id')),
                         Select::make('care_team_role_id')
                             ->label('Role')
                             ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Student))


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1389

### Technical Description

Exclude users who are already on an educatable's care team from being selected

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
