### PR TITLE
[ADVAPP-1390]: When adding care team members in bulk, if the user is already a care team member for some of the students/prospects, the role duplicates for those students/prospects

### DIFF
--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
@@ -88,7 +88,7 @@ class ManageProspectCareTeam extends ManageRelatedRecords
                     ->color('primary'),
                 TextColumn::make('job_title'),
                 TextColumn::make('careTeams.prospectCareTeamRole.name')
-                    ->getStateUsing(fn ($record) => CareTeamRole::find($record->care_team_role_id)?->pluck('name'))
+                    ->getStateUsing(fn ($record) => CareTeamRole::find($record->care_team_role_id)?->name)
                     ->label('Role')
                     ->badge()
                     ->visible(CareTeamRole::where('type', CareTeamRoleType::Prospect)->count() > 0),

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
@@ -88,6 +88,7 @@ class ManageProspectCareTeam extends ManageRelatedRecords
                     ->color('primary'),
                 TextColumn::make('job_title'),
                 TextColumn::make('careTeams.prospectCareTeamRole.name')
+                    ->getStateUsing(fn ($record) => CareTeamRole::find($record->care_team_role_id)?->pluck('name'))
                     ->label('Role')
                     ->badge()
                     ->visible(CareTeamRole::where('type', CareTeamRoleType::Prospect)->count() > 0),

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -53,7 +53,6 @@ use Filament\Tables\Actions\DetachBulkAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Log;
 
 trait CanManageEducatableCareTeam
 {

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -76,7 +76,7 @@ trait CanManageEducatableCareTeam
                     ->color('primary'),
                 TextColumn::make('job_title'),
                 TextColumn::make('careTeams.studentCareTeamRole.name')
-                    ->getStateUsing(fn ($record) => CareTeamRole::find($record->care_team_role_id)?->pluck('name'))
+                    ->getStateUsing(fn ($record) => CareTeamRole::find($record->care_team_role_id)?->name)
                     ->label('Role')
                     ->badge()
                     ->visible(CareTeamRole::where('type', CareTeamRoleType::Student)->count() > 0),

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -53,6 +53,7 @@ use Filament\Tables\Actions\DetachBulkAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
 
 trait CanManageEducatableCareTeam
 {
@@ -76,6 +77,7 @@ trait CanManageEducatableCareTeam
                     ->color('primary'),
                 TextColumn::make('job_title'),
                 TextColumn::make('careTeams.studentCareTeamRole.name')
+                    ->getStateUsing(fn ($record) => CareTeamRole::find($record->care_team_role_id)?->pluck('name'))
                     ->label('Role')
                     ->badge()
                     ->visible(CareTeamRole::where('type', CareTeamRoleType::Student)->count() > 0),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1390

### Technical Description

Restrict care team roles shown on a specific educatable's care team page to only show roles that a user has for that particular educatable.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
