### PR TITLE
[ADVAPP-1351]: When writing to prospects, merge values show label of 'student' as default instead of 'prospect'

### DIFF
--- a/app-modules/campaign/src/Filament/Blocks/EngagementBatchEmailBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/EngagementBatchEmailBlock.php
@@ -79,11 +79,11 @@ class EngagementBatchEmailBlock extends CampaignActionBlock
                 ->disk('s3-public')
                 ->label('Body')
                 ->mergeTags($mergeTags = [
-                    'student first name',
-                    'student last name',
-                    'student full name',
-                    'student email',
-                    'student preferred name',
+                    'recipient first name',
+                    'recipient last name',
+                    'recipient full name',
+                    'recipient email',
+                    'recipient preferred name',
                 ])
                 ->profile('email')
                 ->required()

--- a/app-modules/campaign/src/Filament/Blocks/EngagementBatchSmsBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/EngagementBatchSmsBlock.php
@@ -66,11 +66,11 @@ class EngagementBatchSmsBlock extends CampaignActionBlock
                 DraftCampaignEngagementBlockWithAi::make()
                     ->channel(NotificationChannel::Sms)
                     ->mergeTags([
-                        'student first name',
-                        'student last name',
-                        'student full name',
-                        'student email',
-                        'student preferred name',
+                        'recipient first name',
+                        'recipient last name',
+                        'recipient full name',
+                        'recipient email',
+                        'recipient preferred name',
                     ]),
             ]),
             DateTimePicker::make('execute_at')

--- a/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkEngagementAction.php
@@ -94,11 +94,11 @@ class BulkEngagementAction
                             ->disk('s3-public')
                             ->label('Body')
                             ->mergeTags($mergeTags = [
-                                'student first name',
-                                'student last name',
-                                'student full name',
-                                'student email',
-                                'student preferred name',
+                                'recipient first name',
+                                'recipient last name',
+                                'recipient full name',
+                                'recipient email',
+                                'recipient preferred name',
                             ])
                             ->showMergeTagsInBlocksPanel(false)
                             ->profile('email')

--- a/app-modules/engagement/src/Filament/Actions/RelationManagerSendEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/RelationManagerSendEngagementAction.php
@@ -150,11 +150,11 @@ class RelationManagerSendEngagementAction extends CreateAction
                             ->disk('s3-public')
                             ->label('Body')
                             ->mergeTags($mergeTags = [
-                                'student first name',
-                                'student last name',
-                                'student full name',
-                                'student email',
-                                'student preferred name',
+                                'recipient first name',
+                                'recipient last name',
+                                'recipient full name',
+                                'recipient email',
+                                'recipient preferred name',
                                 'user first name',
                                 'user full name',
                                 'user job title',

--- a/app-modules/engagement/src/Filament/Actions/SendEngagementAction.php
+++ b/app-modules/engagement/src/Filament/Actions/SendEngagementAction.php
@@ -175,11 +175,11 @@ class SendEngagementAction extends Action
                             ->disk('s3-public')
                             ->label('Body')
                             ->mergeTags($mergeTags = [
-                                'student first name',
-                                'student last name',
-                                'student full name',
-                                'student email',
-                                'student preferred name',
+                                'recipient first name',
+                                'recipient last name',
+                                'recipient full name',
+                                'recipient email',
+                                'recipient preferred name',
                                 'user first name',
                                 'user full name',
                                 'user job title',

--- a/app-modules/engagement/src/Filament/Forms/Components/EngagementSmsBodyInput.php
+++ b/app-modules/engagement/src/Filament/Forms/Components/EngagementSmsBodyInput.php
@@ -60,11 +60,11 @@ class EngagementSmsBodyInput
         return TiptapEditor::make("{$fieldPrefix}body")
             ->label('Body')
             ->mergeTags([
-                'student first name',
-                'student last name',
-                'student full name',
-                'student email',
-                'student preferred name',
+                'recipient first name',
+                'recipient last name',
+                'recipient full name',
+                'recipient email',
+                'recipient preferred name',
             ])
             ->showMergeTagsInBlocksPanel(is_null($form) ? false : ! ($form->getLivewire() instanceof RelationManager))
             ->profile('sms')

--- a/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/CreateEmailTemplate.php
+++ b/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/CreateEmailTemplate.php
@@ -65,11 +65,11 @@ class CreateEmailTemplate extends CreateRecord
                 TiptapEditor::make('content')
                     ->disk('s3-public')
                     ->mergeTags($mergeTags = [
-                        'student first name',
-                        'student last name',
-                        'student full name',
-                        'student email',
-                        'student preferred name',
+                        'recipient first name',
+                        'recipient last name',
+                        'recipient full name',
+                        'recipient email',
+                        'recipient preferred name',
                     ])
                     ->profile('email')
                     ->columnSpanFull()

--- a/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/EditEmailTemplate.php
+++ b/app-modules/engagement/src/Filament/Resources/EmailTemplateResource/Pages/EditEmailTemplate.php
@@ -68,11 +68,11 @@ class EditEmailTemplate extends EditRecord
                 TiptapEditor::make('content')
                     ->disk('s3-public')
                     ->mergeTags($mergeTags = [
-                        'student first name',
-                        'student last name',
-                        'student full name',
-                        'student email',
-                        'student preferred name',
+                        'recipient first name',
+                        'recipient last name',
+                        'recipient full name',
+                        'recipient email',
+                        'recipient preferred name',
                     ])
                     ->profile('email')
                     ->columnSpanFull()

--- a/app-modules/engagement/src/Filament/Resources/SmsTemplateResource/Pages/CreateSmsTemplate.php
+++ b/app-modules/engagement/src/Filament/Resources/SmsTemplateResource/Pages/CreateSmsTemplate.php
@@ -66,11 +66,11 @@ class CreateSmsTemplate extends CreateRecord
                 // https://www.twilio.com/docs/glossary/what-sms-character-limit#:~:text=Twilio's%20platform%20supports%20long%20messages,best%20deliverability%20and%20user%20experience.
                 TiptapEditor::make('content')
                     ->mergeTags($mergeTags = [
-                        'student first name',
-                        'student last name',
-                        'student full name',
-                        'student email',
-                        'student preferred name',
+                        'recipient first name',
+                        'recipient last name',
+                        'recipient full name',
+                        'recipient email',
+                        'recipient preferred name',
                     ])
                     ->profile('sms')
                     ->columnSpanFull()

--- a/app-modules/engagement/src/Filament/Resources/SmsTemplateResource/Pages/EditSmsTemplate.php
+++ b/app-modules/engagement/src/Filament/Resources/SmsTemplateResource/Pages/EditSmsTemplate.php
@@ -67,11 +67,11 @@ class EditSmsTemplate extends EditRecord
                     ->string(),
                 TiptapEditor::make('content')
                     ->mergeTags($mergeTags = [
-                        'student first name',
-                        'student last name',
-                        'student full name',
-                        'student email',
-                        'student preferred name',
+                        'recipient first name',
+                        'recipient last name',
+                        'recipient full name',
+                        'recipient email',
+                        'recipient preferred name',
                     ])
                     ->profile('sms')
                     ->columnSpanFull()

--- a/app-modules/engagement/src/Models/Engagement.php
+++ b/app-modules/engagement/src/Models/Engagement.php
@@ -231,6 +231,11 @@ class Engagement extends BaseModel implements Auditable, CanTriggerAutoSubscript
     public function getMergeData(): array
     {
         return [
+            'recipient first name' => $this->recipient->getAttribute($this->recipient->displayFirstNameKey()),
+            'recipient last name' => $this->recipient->getAttribute($this->recipient->displayLastNameKey()),
+            'recipient full name' => $this->recipient->getAttribute($this->recipient->displayNameKey()),
+            'recipient email' => $this->recipient?->primaryEmailAddress?->address,
+            'recipient preferred name' => $this->recipient->getAttribute($this->recipient->displayPreferredNameKey()),
             'student first name' => $this->recipient->getAttribute($this->recipient->displayFirstNameKey()),
             'student last name' => $this->recipient->getAttribute($this->recipient->displayLastNameKey()),
             'student full name' => $this->recipient->getAttribute($this->recipient->displayNameKey()),
@@ -249,21 +254,18 @@ class Engagement extends BaseModel implements Auditable, CanTriggerAutoSubscript
      */
     public static function getMergeTags(string $type): array
     {
-        return match ($type) {
-            Student::class => [
-                'student first name',
-                'student last name',
-                'student full name',
-                'student email',
-                'student preferred name',
-                'user first name',
-                'user full name',
-                'user job title',
-                'user email',
-                'user phone number',
-            ],
-            default => [],
-        };
+        return [
+            'recipient first name',
+            'recipient last name',
+            'recipient full name',
+            'recipient email',
+            'recipient preferred name',
+            'user first name',
+            'user full name',
+            'user job title',
+            'user email',
+            'user phone number',
+        ];
     }
 
     public function getDeliveryMethod(): NotificationChannel

--- a/app-modules/form/src/Filament/Resources/FormResource/Pages/ManageFormEmailAutoReply.php
+++ b/app-modules/form/src/Filament/Resources/FormResource/Pages/ManageFormEmailAutoReply.php
@@ -96,11 +96,11 @@ class ManageFormEmailAutoReply extends EditRecord
                         TiptapEditor::make('body')
                             ->disk('s3-public')
                             ->mergeTags([
-                                'student first name',
-                                'student last name',
-                                'student full name',
-                                'student email',
-                                'student preferred name',
+                                'recipient first name',
+                                'recipient last name',
+                                'recipient full name',
+                                'recipient email',
+                                'recipient preferred name',
                             ])
                             ->profile('email')
                             ->required(fn (Get $get) => $get('is_enabled'))

--- a/app-modules/form/src/Models/FormEmailAutoReply.php
+++ b/app-modules/form/src/Models/FormEmailAutoReply.php
@@ -85,6 +85,11 @@ class FormEmailAutoReply extends BaseModel implements HasMedia
     public function getMergeData(Student|Prospect|null $author): array
     {
         return [
+            'recipient first name' => $author->getAttribute($author->displayFirstNameKey()),
+            'recipient last name' => $author->getAttribute($author->displayLastNameKey()),
+            'recipient full name' => $author->getAttribute($author->displayNameKey()),
+            'recipient email' => $author->primaryEmailAddress?->address,
+            'recipient preferred name' => $author->getAttribute($author->displayPreferredNameKey()),
             'student first name' => $author->getAttribute($author->displayFirstNameKey()),
             'student last name' => $author->getAttribute($author->displayLastNameKey()),
             'student full name' => $author->getAttribute($author->displayNameKey()),


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1351

### Technical Description

Renames the student merge tags to recipient, but ensures backwards compatibility for already stored tags.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
