### PR TITLE
[ADVAPP-1391]: When building a Campaign with the journey step to Add Care Team member(s), the users defined in the action are not being added to the selected students' Care Teams

### DIFF
--- a/app-modules/campaign/src/Filament/Blocks/CareTeamBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/CareTeamBlock.php
@@ -68,10 +68,10 @@ class CareTeamBlock extends CampaignActionBlock
     public function generateFields(string $fieldPrefix = ''): array
     {
         return [
-            Repeater::make('careTeam')
+            Repeater::make($fieldPrefix . 'careTeam')
                 ->label('Who should be assigned to the care team?')
                 ->schema([
-                    Select::make($fieldPrefix . 'user_id')
+                    Select::make('user_id')
                         ->label('User')
                         ->options(function (Get $get, $livewire, string $operation) {
                             if ($operation === 'create') {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1391

### Technical Description

Add field prefix to repeater to persist data.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
