### PR TITLE
[ADVAPP-1337]: Improve deliverability of email messaging by introducing rate limiting in alignment with our infrastructure providers requirements

### DIFF
--- a/app-modules/engagement/src/Jobs/CreateBatchedEngagement.php
+++ b/app-modules/engagement/src/Jobs/CreateBatchedEngagement.php
@@ -40,6 +40,7 @@ use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\Engagement\Models\EngagementBatch;
 use AdvisingApp\Engagement\Notifications\EngagementNotification;
 use AdvisingApp\Notification\Models\Contracts\CanBeNotified;
+use DateTime;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -58,9 +59,8 @@ class CreateBatchedEngagement implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public int $tries = 15;
-
     public int $maxExceptions = 3;
+    
 
     public function __construct(
         public EngagementBatch $engagementBatch,
@@ -73,6 +73,11 @@ class CreateBatchedEngagement implements ShouldQueue
     public function middleware(): array
     {
         return [new RateLimitedWithRedis('notification')];
+    }
+
+    public function retryUntil(): DateTime
+    {
+        return now()->addHours(2);
     }
 
     public function handle(): void

--- a/app-modules/engagement/src/Jobs/CreateBatchedEngagement.php
+++ b/app-modules/engagement/src/Jobs/CreateBatchedEngagement.php
@@ -45,6 +45,8 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\RateLimited;
+use Illuminate\Queue\Middleware\RateLimitedWithRedis;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 
@@ -56,10 +58,22 @@ class CreateBatchedEngagement implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
+    public int $tries = 15;
+
+    public int $maxExceptions = 3;
+
     public function __construct(
         public EngagementBatch $engagementBatch,
         public CanBeNotified $recipient,
     ) {}
+
+    /**
+     * @return array<object>
+     */
+    public function middleware(): array
+    {
+        return [new RateLimitedWithRedis('notification')];
+    }
 
     public function handle(): void
     {

--- a/app-modules/engagement/tests/Tenant/Feature/Jobs/CreateBatchedEngagementTest.php
+++ b/app-modules/engagement/tests/Tenant/Feature/Jobs/CreateBatchedEngagementTest.php
@@ -35,24 +35,16 @@
 */
 
 use AdvisingApp\Engagement\Jobs\CreateBatchedEngagement;
-use AdvisingApp\Engagement\Jobs\Middleware\RateLimited;
 use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\Engagement\Models\EngagementBatch;
 use AdvisingApp\Engagement\Notifications\EngagementNotification;
 use AdvisingApp\StudentDataModel\Models\Student;
 use function Pest\Laravel\assertDatabaseCount;
-use function Pest\Laravel\freezeSecond;
-use function Pest\Laravel\travel;
 
 use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Unlimited;
 use Illuminate\Container\Container;
-use Illuminate\Queue\Middleware\RateLimitedWithRedis;
-use Illuminate\Redis\Limiters\DurationLimiter;
 use Illuminate\Support\Facades\Notification;
-
-
-
 
 it('will create and send an engagement immediately', function () {
     Notification::fake();

--- a/app-modules/engagement/tests/Tenant/SendQueuedNotificationsTest.php
+++ b/app-modules/engagement/tests/Tenant/SendQueuedNotificationsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use AdvisingApp\Notification\Tests\Fixtures\TestEmailNotification;
+use AdvisingApp\StudentDataModel\Models\Student;
+use Illuminate\Cache\RateLimiter;
+use Illuminate\Cache\RateLimiting\Unlimited;
+use Illuminate\Container\Container;
+use Illuminate\Notifications\SendQueuedNotifications;
+use Illuminate\Support\Facades\Queue;
+
+it('has the notification rate limiting applied properly for email notifications', function () {
+    $recipient = Student::factory()->create();
+    $notification = new TestEmailNotification();
+
+    $job = new SendQueuedNotifications(
+        $recipient, // @phpstan-ignore argument.type
+        $notification,
+        ['mail'],
+    );
+
+    $limiter = Container::getInstance()->make(RateLimiter::class)->limiter('notifications');
+
+    $limits = $limiter($job);
+
+    /** @phpstan-ignore property.notFound */
+    expect($limits) 
+        ->toHaveCount(1)
+        ->and($limits[0])
+            ->key->toEqual('mail')
+            ->maxAttempts->toEqual(14)
+            ->decaySeconds->toEqual(1);
+});
+
+it('has the notification rate limiting applied properly for sms notifications', function () {
+    $recipient = Student::factory()->create();
+    $notification = new TestEmailNotification();
+
+    $job = new SendQueuedNotifications(
+        $recipient, // @phpstan-ignore argument.type
+        $notification,
+        ['sms'],
+    );
+
+    $limiter = Container::getInstance()->make(RateLimiter::class)->limiter('notifications');
+
+    $limits = $limiter($job);
+
+    expect($limits) 
+        ->toHaveCount(1)
+        ->and($limits[0])
+            ->toBeInstanceOf(Unlimited::class);
+});
+
+// TODO: checking if the limits are setup properly if it ever dispatches SMS and email at the same time
+
+it('modifies the SendQueuedNotifications job properly', function () {
+    Queue::fake();
+
+    $recipient = Student::factory()->create();
+    $notification = new TestEmailNotification();
+
+    $recipient->notify($notification);
+
+    Queue::assertPushed(SendQueuedNotifications::class, function ($job) use ($recipient, $notification) {
+        return $job->notification::class === $notification::class
+            && $job->notifiables->count() === 1
+            && $job->notifiables->first()->is($recipient)
+            && $job->channels === ['mail'];
+    });
+});
+
+// TODO: Test that the tries, maxExceptions, etc. is properly set

--- a/app-modules/engagement/tests/Tenant/SendQueuedNotificationsTest.php
+++ b/app-modules/engagement/tests/Tenant/SendQueuedNotificationsTest.php
@@ -53,6 +53,7 @@ it('has the notification rate limiting applied properly for sms notifications', 
 
 // TODO: checking if the limits are setup properly if it ever dispatches SMS and email at the same time
 
+// Should we move this to a test file for the Channel Manager?
 it('modifies the SendQueuedNotifications job properly', function () {
     Queue::fake();
 
@@ -65,8 +66,8 @@ it('modifies the SendQueuedNotifications job properly', function () {
         return $job->notification::class === $notification::class
             && $job->notifiables->count() === 1
             && $job->notifiables->first()->is($recipient)
-            && $job->channels === ['mail'];
+            && $job->channels === ['mail']
+            && $job->tries === 15
+            && $job->maxExceptions === 3;
     });
 });
-
-// TODO: Test that the tries, maxExceptions, etc. is properly set

--- a/app-modules/notification/src/Notifications/ChannelManager.php
+++ b/app-modules/notification/src/Notifications/ChannelManager.php
@@ -62,7 +62,7 @@ class ChannelManager extends BaseChannelManager
         }
 
         if ($notification instanceof ShouldQueue) {
-            $notification->tries ??= 15;
+            $notification->retryUntil ??= now()->addHours(2);
         }
 
         if ($notification instanceof ShouldQueue) {

--- a/app-modules/notification/src/Notifications/ChannelManager.php
+++ b/app-modules/notification/src/Notifications/ChannelManager.php
@@ -36,7 +36,9 @@
 
 namespace AdvisingApp\Notification\Notifications;
 
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\ChannelManager as BaseChannelManager;
+use Illuminate\Queue\Middleware\RateLimitedWithRedis;
 use Illuminate\Support\Collection;
 
 class ChannelManager extends BaseChannelManager
@@ -53,6 +55,18 @@ class ChannelManager extends BaseChannelManager
     {
         if (property_exists($notification, 'queue')) {
             $notification->queue ??= config('queue.outbound_communication_queue');
+        }
+
+        if ($notification instanceof ShouldQueue && property_exists($notification, 'middleware')) {
+            $notification->middleware[] = new RateLimitedWithRedis('notification');
+        }
+
+        if ($notification instanceof ShouldQueue && property_exists($notification, 'tries')) {
+            $notification->tries ??= 15;
+        }
+
+        if ($notification instanceof ShouldQueue && property_exists($notification, 'maxExceptions')) {
+            $notification->maxExceptions ??= 3;
         }
 
         parent::send($notifiables, $notification);

--- a/app-modules/notification/src/Notifications/ChannelManager.php
+++ b/app-modules/notification/src/Notifications/ChannelManager.php
@@ -61,11 +61,11 @@ class ChannelManager extends BaseChannelManager
             $notification->middleware[] = new RateLimitedWithRedis('notification');
         }
 
-        if ($notification instanceof ShouldQueue && property_exists($notification, 'tries')) {
+        if ($notification instanceof ShouldQueue) {
             $notification->tries ??= 15;
         }
 
-        if ($notification instanceof ShouldQueue && property_exists($notification, 'maxExceptions')) {
+        if ($notification instanceof ShouldQueue) {
             $notification->maxExceptions ??= 3;
         }
 

--- a/app-modules/notification/tests/Fixtures/TestDualNotification.php
+++ b/app-modules/notification/tests/Fixtures/TestDualNotification.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Notification\Tests\Fixtures;
+
+use AdvisingApp\Notification\Notifications\Messages\MailMessage;
+use AdvisingApp\Notification\Notifications\Messages\TwilioMessage;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class TestDualNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail', 'sms'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return MailMessage::make()
+            ->subject('Test Subject')
+            ->greeting('Test Greeting')
+            ->content('This is a test email');
+    }
+
+    public function toSms(object $notifiable): TwilioMessage
+    {
+        return TwilioMessage::make($notifiable)
+            ->content('This is a test');
+    }
+}

--- a/app-modules/notification/tests/Tenant/Notifications/ChannelManagerTest.php
+++ b/app-modules/notification/tests/Tenant/Notifications/ChannelManagerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use AdvisingApp\Notification\Tests\Fixtures\TestEmailNotification;
+use AdvisingApp\StudentDataModel\Models\Student;
+use Illuminate\Notifications\SendQueuedNotifications;
+use Illuminate\Support\Facades\Queue;
+
+it('modifies the SendQueuedNotifications job properly', function () {
+    Queue::fake();
+
+    $recipient = Student::factory()->create();
+    $notification = new TestEmailNotification();
+
+    $recipient->notify($notification);
+
+    Queue::assertPushed(SendQueuedNotifications::class, function ($job) use ($recipient, $notification) {
+        return $job->notification::class === $notification::class
+            && $job->notifiables->count() === 1
+            && $job->notifiables->first()->is($recipient)
+            && $job->channels === ['mail']
+            && $job->tries === 15
+            && $job->maxExceptions === 3;
+    });
+});

--- a/app-modules/notification/tests/Tenant/Notifications/ChannelManagerTest.php
+++ b/app-modules/notification/tests/Tenant/Notifications/ChannelManagerTest.php
@@ -2,8 +2,11 @@
 
 use AdvisingApp\Notification\Tests\Fixtures\TestEmailNotification;
 use AdvisingApp\StudentDataModel\Models\Student;
+use Carbon\Carbon;
 use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Support\Facades\Queue;
+
+use function Pest\Laravel\freezeTime;
 
 it('modifies the SendQueuedNotifications job properly', function () {
     Queue::fake();
@@ -11,14 +14,16 @@ it('modifies the SendQueuedNotifications job properly', function () {
     $recipient = Student::factory()->create();
     $notification = new TestEmailNotification();
 
-    $recipient->notify($notification);
+    freezeTime(function () use ($recipient, $notification) {
+        $recipient->notify($notification);
 
-    Queue::assertPushed(SendQueuedNotifications::class, function ($job) use ($recipient, $notification) {
-        return $job->notification::class === $notification::class
-            && $job->notifiables->count() === 1
-            && $job->notifiables->first()->is($recipient)
-            && $job->channels === ['mail']
-            && $job->tries === 15
-            && $job->maxExceptions === 3;
+        Queue::assertPushed(SendQueuedNotifications::class, function ($job) use ($recipient, $notification) {
+            return $job->notification::class === $notification::class
+                && $job->notifiables->count() === 1
+                && $job->notifiables->first()->is($recipient)
+                && $job->channels === ['mail']
+                && $job->retryUntil() instanceof Carbon && $job->retryUntil()->equalTo(now()->addHours(2))
+                && $job->maxExceptions === 3;
+        }); 
     });
 });

--- a/app-modules/notification/tests/Tenant/Vendor/laravel/SendQueuedNotificationsTest.php
+++ b/app-modules/notification/tests/Tenant/Vendor/laravel/SendQueuedNotificationsTest.php
@@ -7,7 +7,6 @@ use Illuminate\Cache\RateLimiter;
 use Illuminate\Cache\RateLimiting\Unlimited;
 use Illuminate\Container\Container;
 use Illuminate\Notifications\SendQueuedNotifications;
-use Illuminate\Support\Facades\Queue;
 
 it('has the notification rate limiting applied properly for email notifications', function () {
     $recipient = Student::factory()->create();
@@ -74,23 +73,4 @@ it('has the notification rate limiting applied properly for notifications that s
             ->decaySeconds->toEqual(1)
         ->and($limits[1])
             ->toBeInstanceOf(Unlimited::class);
-});
-
-// Should we move this to a test file for the Channel Manager?
-it('modifies the SendQueuedNotifications job properly', function () {
-    Queue::fake();
-
-    $recipient = Student::factory()->create();
-    $notification = new TestEmailNotification();
-
-    $recipient->notify($notification);
-
-    Queue::assertPushed(SendQueuedNotifications::class, function ($job) use ($recipient, $notification) {
-        return $job->notification::class === $notification::class
-            && $job->notifiables->count() === 1
-            && $job->notifiables->first()->is($recipient)
-            && $job->channels === ['mail']
-            && $job->tries === 15
-            && $job->maxExceptions === 3;
-    });
 });

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -193,8 +193,8 @@ class AppServiceProvider extends ServiceProvider
                 }
 
                 return match ($channel) {
-                    'mail', 'email' => Limit::perSecond(14)->by('notifications-mail'),
-                    'sms' => Limit::none()->by('notifications-sms'),
+                    'mail', 'email' => Limit::perSecond(14)->by('mail'),
+                    'sms' => Limit::none()->by('sms'),
                     default => throw new Exception('Invalid channel'),
                 };
             })

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -36,6 +36,7 @@
 
 namespace App\Providers;
 
+use AdvisingApp\Engagement\Jobs\CreateBatchedEngagement;
 use AdvisingApp\Prospect\Models\Pipeline;
 use AdvisingApp\Prospect\Models\PipelineStage;
 use App\Models\SystemUser;
@@ -50,6 +51,7 @@ use App\Overrides\Laravel\PermissionMigrationCreator;
 use App\Overrides\Laravel\StartSession as OverrideStartSession;
 use App\Overrides\LastDragon_ru\LaraASP\GraphQL\SearchBy\Definitions\SearchByDirective as GraphQLSearchByDirectiveOverride;
 use App\Overrides\LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition as GraphQLSearchByTypesConditionOverride;
+use Exception;
 use Filament\Actions\Exports\Jobs\CreateXlsxFile;
 use Filament\Actions\Exports\Jobs\ExportCompletion;
 use Filament\Actions\Exports\Jobs\ExportCsv;
@@ -57,21 +59,24 @@ use Filament\Actions\Exports\Jobs\PrepareCsvExport;
 use Filament\Actions\Imports\Jobs\ImportCsv;
 use Filament\Notifications\Auth\ResetPassword;
 use Filament\Tables\Table;
+use function Sentry\configureScope;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Notifications\SendQueuedNotifications;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Session\SessionManager;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Octane\Commands\ReloadCommand;
 use Laravel\Pennant\Feature;
 use LastDragon_ru\LaraASP\GraphQL\SearchBy\Definitions\SearchByDirective as GraphQLSearchByDirectiveAlias;
+
 use LastDragon_ru\LaraASP\GraphQL\SearchBy\Types\Condition\Condition as GraphQLSearchByTypesCondition;
+
 use Rector\Caching\CacheFactory;
-
-use function Sentry\configureScope;
-
 use Sentry\State\Scope;
 
 class AppServiceProvider extends ServiceProvider
@@ -172,6 +177,23 @@ class AppServiceProvider extends ServiceProvider
             $scope->setTags([
                 'service' => config('app.service'),
             ]);
+        });
+
+        RateLimiter::for('notifications', function (object $job) {
+            $channels = match (true) {
+                $job instanceof CreateBatchedEngagement => [$job->engagementBatch->channel],
+                $job instanceof SendQueuedNotifications => $job->channels,
+                default => throw new Exception('Invalid job type'),
+            };
+
+            return collect($channels)->map(function (string $channel) {
+                return match ($channel) {
+                    'mail' => Limit::perSecond(14)->by('notifications-mail'),
+                    'sms' => Limit::none()->by('notifications-sms'),
+                    default => throw new Exception('Invalid channel'),
+                };
+            })
+                ->toArray();
         });
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -37,6 +37,7 @@
 namespace App\Providers;
 
 use AdvisingApp\Engagement\Jobs\CreateBatchedEngagement;
+use AdvisingApp\Notification\Enums\NotificationChannel;
 use AdvisingApp\Prospect\Models\Pipeline;
 use AdvisingApp\Prospect\Models\PipelineStage;
 use App\Models\SystemUser;
@@ -186,9 +187,13 @@ class AppServiceProvider extends ServiceProvider
                 default => throw new Exception('Invalid job type'),
             };
 
-            return collect($channels)->map(function (string $channel) {
+            return collect($channels)->map(function (string|NotificationChannel $channel) {
+                if ($channel instanceof NotificationChannel) {
+                    $channel = $channel->value;
+                }
+
                 return match ($channel) {
-                    'mail' => Limit::perSecond(14)->by('notifications-mail'),
+                    'mail', 'email' => Limit::perSecond(14)->by('notifications-mail'),
                     'sms' => Limit::none()->by('notifications-sms'),
                     default => throw new Exception('Invalid channel'),
                 };


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1337

### Technical Description

Introduces rate limiting for email notifications to stop us from sending our current limit of 14/s.

I also changed all email jobs to not limit by attempts, but instead `retryUntil` 2 hours.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
