### PR TITLE
[ADVAPP-1412]: Some jobs that fail to suceed are not being reported to centralized error reporting system

### DIFF
--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -273,6 +273,10 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
 
     public function failed(?Throwable $exception): void
     {
+        if (app()->bound('sentry')) {
+            app('sentry')->captureException($exception);
+        }
+
         if ($exception === null) {
             $this->moveFile('/failed');
 

--- a/app-modules/engagement/src/Notifications/EngagementNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementNotification.php
@@ -96,6 +96,10 @@ class EngagementNotification extends Notification implements ShouldQueue, HasBef
 
     public function failed(?Throwable $exception): void
     {
+        if (app()->bound('sentry')) {
+            app('sentry')->captureException($exception);
+        }
+
         if (is_null($this->engagement->engagement_batch_id)) {
             $this->engagement->user->notify(new EngagementFailedNotification($this->engagement));
         }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1412

### Technical Description

Ensure jobs with a `failed` method send the exception to Sentry, per https://docs.sentry.io/platforms/php/guides/laravel/usage/#queue-jobs

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
