### PR TITLE
[ADVAPP-1438]: Improve the display status of outbound emails by including a badge of scheduled, failed, delivered, read, and clicked.

### DIFF
--- a/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
+++ b/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace AdvisingApp\Notification\Enums;
+
+use AdvisingApp\Notification\Models\EmailMessage;
+use Filament\Support\Contracts\HasLabel;
+use Illuminate\Support\Facades\Log;
+
+enum EmailMessageDisplayStatus
+{
+  case Complaint;
+  case Bounced;
+  case Failed;
+  case Clicked;
+  case Read;
+  case Delivered;
+  case Delayed;
+  case Unsubscribed;
+  case Sent;
+
+    public function getLabel(): ?string
+    {
+        return str($this->name)->headline();
+    }
+
+    public static function getStatusFromEmailMessage($message) :string {
+        if (!$message) {
+            return '';
+        }
+
+        return match (true) {
+            $message->events()->where('type', EmailMessageEventType::Complaint->value)->exists() => 'Complaint',
+            $message->events()->where('type', EmailMessageEventType::Bounce->value)->exists() => 'Bounced',
+            $message->events()->where('type', EmailMessageEventType::Reject->value)->orWhere('type', EmailMessageEventType::RenderingFailure->value)->exists() => 'Failed',
+            $message->events()->where('type', EmailMessageEventType::Click->value)->exists() => 'Clicked',
+            $message->events()->where('type', EmailMessageEventType::Open->value)->exists() => 'Read',
+            $message->events()->where('type', EmailMessageEventType::Delivery->value)->exists() => 'Delivered',
+            $message->events()->where('type', EmailMessageEventType::DeliveryDelay->value)->exists() => 'Delayed',
+            $message->events()->where('type', EmailMessageEventType::Subscription->value)->exists() => 'Unsubscribed',
+            $message->events()->where('type', EmailMessageEventType::Send->value)->exists() => 'Sent',
+            default => '',
+        };
+    }
+    public function color(): string
+    {
+        return match ($this) {
+            self::Delivered, self::Read, self::Clicked => 'success',
+            self::Delayed => 'primary',
+            self::Failed, self::Bounced, self::Complaint => 'danger',
+            self::Sent, self::Unsubscribed => 'gray',
+            default => 'gray',
+        };
+    }
+}

--- a/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
+++ b/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Notification\Enums;
 
 use AdvisingApp\Notification\Models\EmailMessage;

--- a/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
+++ b/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
@@ -36,6 +36,8 @@
 
 namespace AdvisingApp\Notification\Enums;
 
+use AdvisingApp\Notification\Models\EmailMessage;
+
 enum EmailMessageDisplayStatus
 {
     case Complaint;
@@ -48,39 +50,38 @@ enum EmailMessageDisplayStatus
     case Unsubscribed;
     case Sent;
 
-    public function getLabel(): ?string
+    public function getLabel(): string
     {
         return str($this->name)->headline();
     }
 
-    public static function getStatusFromEmailMessage($message): string
+    public static function getStatusFromEmailMessage(?EmailMessage $message): ?self
     {
-        if (! $message) {
-            return '';
-        }
+      if (! $message) {
+        return null;
+      }
 
-        return match (true) {
-            $message->events()->where('type', EmailMessageEventType::Complaint->value)->exists() => 'Complaint',
-            $message->events()->where('type', EmailMessageEventType::Bounce->value)->exists() => 'Bounced',
-            $message->events()->where('type', EmailMessageEventType::Reject->value)->orWhere('type', EmailMessageEventType::RenderingFailure->value)->exists() => 'Failed',
-            $message->events()->where('type', EmailMessageEventType::Click->value)->exists() => 'Clicked',
-            $message->events()->where('type', EmailMessageEventType::Open->value)->exists() => 'Read',
-            $message->events()->where('type', EmailMessageEventType::Delivery->value)->exists() => 'Delivered',
-            $message->events()->where('type', EmailMessageEventType::DeliveryDelay->value)->exists() => 'Delayed',
-            $message->events()->where('type', EmailMessageEventType::Subscription->value)->exists() => 'Unsubscribed',
-            $message->events()->where('type', EmailMessageEventType::Send->value)->exists() => 'Sent',
-            default => '',
-        };
+      return match (true) {
+        $message->events()->where('type', EmailMessageEventType::Complaint->value)->exists() => self::Complaint,
+        $message->events()->where('type', EmailMessageEventType::Bounce->value)->exists() => self::Bounced,
+        $message->events()->where('type', EmailMessageEventType::Reject->value)->orWhere('type', EmailMessageEventType::RenderingFailure->value)->exists() => self::Failed,
+        $message->events()->where('type', EmailMessageEventType::Click->value)->exists() => self::Clicked,
+        $message->events()->where('type', EmailMessageEventType::Open->value)->exists() => self::Read,
+        $message->events()->where('type', EmailMessageEventType::Delivery->value)->exists() => self::Delivered,
+        $message->events()->where('type', EmailMessageEventType::DeliveryDelay->value)->exists() => self::Delayed,
+        $message->events()->where('type', EmailMessageEventType::Subscription->value)->exists() => self::Unsubscribed,
+        $message->events()->where('type', EmailMessageEventType::Send->value)->exists() => self::Sent,
+        default => null,
+      };
     }
 
-    public function color(): string
+    public function getColor(): string
     {
         return match ($this) {
-            self::Delivered, self::Read, self::Clicked => 'success',
+            self::Delivered, self::Read, self::Clicked => 'danger',
             self::Delayed => 'primary',
-            self::Failed, self::Bounced, self::Complaint => 'danger',
+            self::Failed, self::Bounced, self::Complaint => 'success',
             self::Sent, self::Unsubscribed => 'gray',
-            default => 'gray',
         };
     }
 }

--- a/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
+++ b/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
@@ -36,29 +36,26 @@
 
 namespace AdvisingApp\Notification\Enums;
 
-use AdvisingApp\Notification\Models\EmailMessage;
-use Filament\Support\Contracts\HasLabel;
-use Illuminate\Support\Facades\Log;
-
 enum EmailMessageDisplayStatus
 {
-  case Complaint;
-  case Bounced;
-  case Failed;
-  case Clicked;
-  case Read;
-  case Delivered;
-  case Delayed;
-  case Unsubscribed;
-  case Sent;
+    case Complaint;
+    case Bounced;
+    case Failed;
+    case Clicked;
+    case Read;
+    case Delivered;
+    case Delayed;
+    case Unsubscribed;
+    case Sent;
 
     public function getLabel(): ?string
     {
         return str($this->name)->headline();
     }
 
-    public static function getStatusFromEmailMessage($message) :string {
-        if (!$message) {
+    public static function getStatusFromEmailMessage($message): string
+    {
+        if (! $message) {
             return '';
         }
 
@@ -75,6 +72,7 @@ enum EmailMessageDisplayStatus
             default => '',
         };
     }
+
     public function color(): string
     {
         return match ($this) {

--- a/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
+++ b/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
@@ -40,19 +40,21 @@ use AdvisingApp\Notification\Models\EmailMessage;
 
 enum EmailMessageDisplayStatus
 {
-    case Complaint;
-    case Bounced;
-    case Failed;
-    case Clicked;
-    case Read;
-    case Delivered;
-    case Delayed;
-    case Unsubscribed;
+    case Scheduled;
+    case Processing;
     case Sent;
+    case Failed;
+    case Bounced;
+    case Delayed;
+    case Delivered;
+    case Read;
+    case Clicked;
+    case Complaint;
+    case Unsubscribed;
 
     public function getLabel(): string
     {
-        return str($this->name)->headline();
+        return $this->name;
     }
 
     public static function getStatusFromEmailMessage(?EmailMessage $message): ?self

--- a/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
+++ b/app-modules/notification/src/Enums/EmailMessageDisplayStatus.php
@@ -57,22 +57,22 @@ enum EmailMessageDisplayStatus
 
     public static function getStatusFromEmailMessage(?EmailMessage $message): ?self
     {
-      if (! $message) {
-        return null;
-      }
+        if (! $message) {
+            return null;
+        }
 
-      return match (true) {
-        $message->events()->where('type', EmailMessageEventType::Complaint->value)->exists() => self::Complaint,
-        $message->events()->where('type', EmailMessageEventType::Bounce->value)->exists() => self::Bounced,
-        $message->events()->where('type', EmailMessageEventType::Reject->value)->orWhere('type', EmailMessageEventType::RenderingFailure->value)->exists() => self::Failed,
-        $message->events()->where('type', EmailMessageEventType::Click->value)->exists() => self::Clicked,
-        $message->events()->where('type', EmailMessageEventType::Open->value)->exists() => self::Read,
-        $message->events()->where('type', EmailMessageEventType::Delivery->value)->exists() => self::Delivered,
-        $message->events()->where('type', EmailMessageEventType::DeliveryDelay->value)->exists() => self::Delayed,
-        $message->events()->where('type', EmailMessageEventType::Subscription->value)->exists() => self::Unsubscribed,
-        $message->events()->where('type', EmailMessageEventType::Send->value)->exists() => self::Sent,
-        default => null,
-      };
+        return match (true) {
+            $message->events()->where('type', EmailMessageEventType::Complaint->value)->exists() => self::Complaint,
+            $message->events()->where('type', EmailMessageEventType::Bounce->value)->exists() => self::Bounced,
+            $message->events()->where('type', EmailMessageEventType::Reject->value)->orWhere('type', EmailMessageEventType::RenderingFailure->value)->exists() => self::Failed,
+            $message->events()->where('type', EmailMessageEventType::Click->value)->exists() => self::Clicked,
+            $message->events()->where('type', EmailMessageEventType::Open->value)->exists() => self::Read,
+            $message->events()->where('type', EmailMessageEventType::Delivery->value)->exists() => self::Delivered,
+            $message->events()->where('type', EmailMessageEventType::DeliveryDelay->value)->exists() => self::Delayed,
+            $message->events()->where('type', EmailMessageEventType::Subscription->value)->exists() => self::Unsubscribed,
+            $message->events()->where('type', EmailMessageEventType::Send->value)->exists() => self::Sent,
+            default => null,
+        };
     }
 
     public function getColor(): string

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -65,7 +65,6 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\HtmlString;
 use Livewire\Attributes\On;
 

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -180,10 +180,11 @@ class EngagementsRelationManager extends RelationManager
                         ...($canAccessEngagements ? [Engagement::class] : []),
                         ...($canAccessEngagementResponses ? [EngagementResponse::class] : []),
                     ])
+                    // TODO: Is this correct?
                     ->with([
-                        'timelineable' => function ($morphQuery) {
+                        'timelineable' => function ($morphQuery) use ($canAccessEngagements) {
                             $morphQuery->when(
-                                $morphQuery->getModel() instanceof Engagement,
+                                $canAccessEngagements && $morphQuery->getModel() instanceof Engagement,
                                 fn ($query) => $query->with('latestEmailMessage')
                             );
                         },

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -41,6 +41,7 @@ use AdvisingApp\Engagement\Filament\Actions\RelationManagerSendEngagementAction;
 use AdvisingApp\Engagement\Models\Contracts\HasDeliveryMethod;
 use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\Engagement\Models\EngagementResponse;
+use AdvisingApp\Notification\Enums\EmailMessageDisplayStatus;
 use AdvisingApp\Notification\Enums\NotificationChannel;
 use AdvisingApp\Notification\Models\EmailMessageEvent;
 use AdvisingApp\Notification\Models\SmsMessageEvent;
@@ -64,6 +65,7 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\HtmlString;
 use Livewire\Attributes\On;
 
@@ -190,7 +192,7 @@ class EngagementsRelationManager extends RelationManager
                 TextColumn::make('status')
                     ->getStateUsing(fn (Timeline $record) => match ($record->timelineable::class) {
                         EngagementResponse::class => $record->timelineable->status,
-                        default => ''
+                        Engagement::class => EmailMessageDisplayStatus::getStatusFromEmailMessage($record->timelineable->latestEmailMessage)
                     })
                     ->badge(),
                 TextColumn::make('type')

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -174,26 +174,27 @@ class EngagementsRelationManager extends RelationManager
             ->emptyStateHeading('No email or text messages.')
             ->emptyStateDescription('Create an email or text message to get started.')
             ->defaultSort('record_sortable_date', 'desc')
-            ->modifyQueryUsing(fn (Builder $query) => $query
-            ->whereHasMorph('timelineable', [
-                ...($canAccessEngagements ? [Engagement::class] : []),
-                ...($canAccessEngagementResponses ? [EngagementResponse::class] : []),
-            ])
-            ->with([
-                'timelineable' => function ($morphQuery) {
-                    $morphQuery->when(
-                        $morphQuery->getModel() instanceof Engagement,
-                        fn ($query) => $query->with('latestEmailMessage')
-                    );
-                },
-            ])
-        )
+            ->modifyQueryUsing(
+                fn (Builder $query) => $query
+                    ->whereHasMorph('timelineable', [
+                        ...($canAccessEngagements ? [Engagement::class] : []),
+                        ...($canAccessEngagementResponses ? [EngagementResponse::class] : []),
+                    ])
+                    ->with([
+                        'timelineable' => function ($morphQuery) {
+                            $morphQuery->when(
+                                $morphQuery->getModel() instanceof Engagement,
+                                fn ($query) => $query->with('latestEmailMessage')
+                            );
+                        },
+                    ])
+            )
             ->columns([
                 TextColumn::make('direction')
                     ->getStateUsing(fn (Timeline $record) => match ($record->timelineable::class) {
                         Engagement::class => 'Outbound',
                         EngagementResponse::class => 'Inbound',
-                        default => '', 
+                        default => '',
                     })
                     ->icon(fn (string $state) => match ($state) {
                         'Outbound' => 'heroicon-o-arrow-up-tray',


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1438

### Technical Description

Improve the display status of outbound emails by including a badge of scheduled, failed, delivered, read, and clicked.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
