### PR TITLE
[ADVAPP-1465]: Update the labeling of feature capabilities to be consistent for custom advisors

### DIFF
--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -77,7 +77,9 @@ class AiAssistantForm
                     ->maxLength(255)
                     ->columnSpanFull(),
                 Select::make('application')
-                    ->options(AiApplication::class)
+                    ->options([
+                        AiApplication::PersonalAssistant->value => 'Custom Advisor',
+                    ])
                     ->default(AiApplication::getDefault())
                     ->live()
                     ->afterStateUpdated(fn (Set $set, $state) => filled(AiApplication::parse($state)) ? $set('model', AiApplication::parse($state)->getDefaultModel()->value) : null)

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -114,11 +114,10 @@ class AiAssistantForm
                 Textarea::make('description')
                     ->columnSpanFull()
                     ->required(),
-                Section::make('Configure AI Assistant')
-                    ->description('The following information will be used to instruct your AI Assistant on how to respond.')
+                Section::make('Configure AI Advisor')
+                    ->description('Design the capability of your advisor by including detailed instructions below.')
                     ->schema([
                         Textarea::make('instructions')
-                            ->helperText('Instructions are used to provide context to the AI Assistant on how to respond to user queries.')
                             ->reactive()
                             ->required()
                             ->maxLength(fn (Get $get): int => (AiModel::parse($get('model')) ?? AiModel::OpenAiGpt35)->getService()->getMaxAssistantInstructionsLength()),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1465

### Technical Description

Updates the labels in the AI Advisor form and removes the "Test" option for application.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
