### PR TITLE
[ADVAPP-1461]: Improve the language used on the duplicate role modal overlay

### DIFF
--- a/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
@@ -100,14 +100,14 @@ class ListRoles extends ListRecords
             ])
             ->actions([
                 Action::make('duplicateRole')
-                    ->label('Duplicate')
                     ->icon('heroicon-o-document-duplicate')
                     ->requiresConfirmation()
+                    ->modalDescription('This action will make a copy of the role and all associate permissions. This action will not, however, automatically attach any users to that role. To continue, please enter a name for the new role and then select the "Duplicate" option below.')
                     ->modalHeading('Duplicate Role')
                     ->modalSubmitActionLabel('Duplicate')
                     ->form([
                         TextInput::make('name')
-                            ->label('Name')
+                            ->label('New Role Name')
                             ->required(),
                     ])
                     ->action(function (Role $record, array $data) {

--- a/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
@@ -100,6 +100,7 @@ class ListRoles extends ListRecords
             ])
             ->actions([
                 Action::make('duplicateRole')
+                    ->label('Duplicate')
                     ->icon('heroicon-o-document-duplicate')
                     ->requiresConfirmation()
                     ->modalDescription('This action will make a copy of the role and all associate permissions. This action will not, however, automatically attach any users to that role. To continue, please enter a name for the new role and then select the "Duplicate" option below.')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1461

### Technical Description

> Improve the language used on the duplicate role modal overlay

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
