### PR TITLE
[ADVAPP-1421]: Some users are reporting that campaigns involving care team journey steps are not always resulting in care team members being added to prospect and student records

### DIFF
--- a/app-modules/campaign/src/Actions/ExecuteCampaignAction.php
+++ b/app-modules/campaign/src/Actions/ExecuteCampaignAction.php
@@ -39,9 +39,11 @@ namespace AdvisingApp\Campaign\Actions;
 use AdvisingApp\Campaign\Models\CampaignAction;
 use App\Features\CancelCampaignAction;
 use App\Models\Tenant;
+use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Support\Facades\Auth;
 
 class ExecuteCampaignAction implements ShouldQueue, ShouldBeUnique
 {
@@ -67,6 +69,13 @@ class ExecuteCampaignAction implements ShouldQueue, ShouldBeUnique
         if (CancelCampaignAction::active() && $this->action->cancelled_at !== null) {
             return;
         }
+
+        // Required as some segment filters apply based on the logged in User.
+        // The campaign creator is the one who will be logged in.
+        if ($this->action->campaign->createdBy instanceof User) {
+            Auth::setUser($this->action->campaign->createdBy);
+        }
+
         $this->action->execute();
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1421

### Technical Description

During campaign action execution we now set he authed User as the User that created the Campaign so that segments based on the User calculate properly.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
