### PR TITLE
[ADVAPP-1485]: Relocate gender after the separator and before ethnicity

### DIFF
--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Schemas/StudentProfileInfolist.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Schemas/StudentProfileInfolist.php
@@ -81,9 +81,6 @@ class StudentProfileInfolist
                                 ))
                                 ->listWithLineBreaks()
                                 ->visible(fn (?array $state): bool => filled($state)),
-                            TextEntry::make('gender')
-                                ->placeholder('-')
-                                ->visible(StudentGender::active()),
                             TextEntry::make('additionalPhoneNumbers')
                                 ->label(fn (?array $state): string => Str::plural('Other phone number', count($state ?? [])))
                                 ->state(fn (Student $record): array => array_map(
@@ -94,6 +91,9 @@ class StudentProfileInfolist
                                 ->visible(fn (?array $state): bool => filled($state)),
                         ]),
                         Subsection::make([
+                            TextEntry::make('gender')
+                                ->placeholder('-')
+                                ->visible(StudentGender::active()),
                             TextEntry::make('ethnicity')
                                 ->placeholder('-'),
                             TextEntry::make('birthdate')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1485

### Technical Description

Relocate gender after the separator and before ethnicity

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
