### PR TITLE
[ADVAPP-1525]: Update all factories to use the local usage of faker and enforce this as an architecture test

### DIFF
--- a/app-modules/ai/database/factories/AiAssistantFactory.php
+++ b/app-modules/ai/database/factories/AiAssistantFactory.php
@@ -53,9 +53,9 @@ class AiAssistantFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
             'application' => AiAssistantApplication::PersonalAssistant,
-            'model' => fake()->randomElement(
+            'model' => $this->faker->randomElement(
                 array_filter(
                     AiModel::cases(),
                     fn (AiModel $case) => $case !== AiModel::JinaDeepSearchV1

--- a/app-modules/ai/database/factories/AiAssistantFileFactory.php
+++ b/app-modules/ai/database/factories/AiAssistantFileFactory.php
@@ -51,7 +51,7 @@ class AiAssistantFileFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/app-modules/ai/database/factories/AiMessageFactory.php
+++ b/app-modules/ai/database/factories/AiMessageFactory.php
@@ -53,10 +53,10 @@ class AiMessageFactory extends Factory
     public function definition(): array
     {
         return [
-            'message_id' => fake()->uuid(),
-            'content' => fake()->sentence(),
-            'context' => fake()->word(),
-            'request' => fake()->word(),
+            'message_id' => $this->faker->uuid(),
+            'content' => $this->faker->sentence(),
+            'context' => $this->faker->word(),
+            'request' => $this->faker->word(),
             'thread_id' => AiThread::factory(),
             'user_id' => User::factory(),
         ];

--- a/app-modules/ai/database/factories/AiMessageFileFactory.php
+++ b/app-modules/ai/database/factories/AiMessageFileFactory.php
@@ -53,10 +53,10 @@ class AiMessageFileFactory extends Factory
     {
         return [
             'message_id' => AiMessage::factory(),
-            'file_id' => fake()->uuid(),
-            'name' => fake()->word(),
-            'temporary_url' => fake()->url(),
-            'mime_type' => fake()->mimeType(),
+            'file_id' => $this->faker->uuid(),
+            'name' => $this->faker->word(),
+            'temporary_url' => $this->faker->url(),
+            'mime_type' => $this->faker->mimeType(),
         ];
     }
 }

--- a/app-modules/ai/database/factories/AiThreadFactory.php
+++ b/app-modules/ai/database/factories/AiThreadFactory.php
@@ -53,8 +53,8 @@ class AiThreadFactory extends Factory
     public function definition(): array
     {
         return [
-            'thread_id' => fake()->uuid(),
-            'name' => fake()->word(),
+            'thread_id' => $this->faker->uuid(),
+            'name' => $this->faker->word(),
             'assistant_id' => AiAssistant::factory(),
             'user_id' => User::factory(),
         ];
@@ -64,8 +64,8 @@ class AiThreadFactory extends Factory
     {
         return $this->state(function (array $attributes) {
             return [
-                'name' => fake()->word(),
-                'saved_at' => fake()->dateTime(),
+                'name' => $this->faker->word(),
+                'saved_at' => $this->faker->dateTime(),
             ];
         });
     }

--- a/app-modules/ai/database/factories/AiThreadFolderFactory.php
+++ b/app-modules/ai/database/factories/AiThreadFolderFactory.php
@@ -51,7 +51,7 @@ class AiThreadFolderFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->word(),
+            'name' => $this->faker->unique()->word(),
         ];
     }
 }

--- a/app-modules/ai/database/factories/PromptFactory.php
+++ b/app-modules/ai/database/factories/PromptFactory.php
@@ -51,9 +51,9 @@ class PromptFactory extends Factory
     public function definition(): array
     {
         return [
-            'title' => str(fake()->unique()->words(asText: true))->ucfirst()->toString(),
-            'description' => fake()->optional()->sentences(asText: true),
-            'prompt' => fake()->sentences(asText: true),
+            'title' => str($this->faker->unique()->words(asText: true))->ucfirst()->toString(),
+            'description' => $this->faker->optional()->sentences(asText: true),
+            'prompt' => $this->faker->sentences(asText: true),
             'type_id' => PromptType::query()->inRandomOrder()->first() ?? PromptType::factory()->create(),
         ];
     }

--- a/app-modules/ai/database/factories/PromptTypeFactory.php
+++ b/app-modules/ai/database/factories/PromptTypeFactory.php
@@ -50,8 +50,8 @@ class PromptTypeFactory extends Factory
     public function definition(): array
     {
         return [
-            'title' => str(fake()->unique()->words(asText: true))->ucfirst()->toString(),
-            'description' => fake()->optional()->sentences(asText: true),
+            'title' => str($this->faker->unique()->words(asText: true))->ucfirst()->toString(),
+            'description' => $this->faker->optional()->sentences(asText: true),
         ];
     }
 }

--- a/app-modules/alert/database/factories/AlertFactory.php
+++ b/app-modules/alert/database/factories/AlertFactory.php
@@ -52,7 +52,7 @@ class AlertFactory extends Factory
     public function definition(): array
     {
         return [
-            'concern_type' => fake()->randomElement([(new Student())->getMorphClass(), (new Prospect())->getMorphClass()]),
+            'concern_type' => $this->faker->randomElement([(new Student())->getMorphClass(), (new Prospect())->getMorphClass()]),
             'concern_id' => function (array $attributes) {
                 $concernClass = Relation::getMorphedModel($attributes['concern_type']);
 
@@ -65,10 +65,10 @@ class AlertFactory extends Factory
 
                 return $concern->getKey();
             },
-            'description' => fake()->sentence(),
-            'severity' => fake()->randomElement(AlertSeverity::cases()),
+            'description' => $this->faker->sentence(),
+            'severity' => $this->faker->randomElement(AlertSeverity::cases()),
             'status_id' => AlertStatus::factory(),
-            'suggested_intervention' => fake()->sentence(),
+            'suggested_intervention' => $this->faker->sentence(),
         ];
     }
 }

--- a/app-modules/alert/database/factories/AlertStatusFactory.php
+++ b/app-modules/alert/database/factories/AlertStatusFactory.php
@@ -54,7 +54,7 @@ class AlertStatusFactory extends Factory
     {
         return [
             'classification' => SystemAlertStatusClassification::Active,
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 

--- a/app-modules/application/database/factories/ApplicationAuthenticationFactory.php
+++ b/app-modules/application/database/factories/ApplicationAuthenticationFactory.php
@@ -52,7 +52,7 @@ class ApplicationAuthenticationFactory extends Factory
     public function definition(): array
     {
         return [
-            'author_type' => fake()->randomElement([
+            'author_type' => $this->faker->randomElement([
                 (new Student())->getMorphClass(),
                 (new Prospect())->getMorphClass(),
             ]),

--- a/app-modules/application/database/factories/ApplicationFactory.php
+++ b/app-modules/application/database/factories/ApplicationFactory.php
@@ -52,10 +52,10 @@ class ApplicationFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->word(),
-            'description' => fake()->sentences(asText: true),
-            'embed_enabled' => fake()->boolean(),
-            'allowed_domains' => [fake()->domainName()],
+            'name' => $this->faker->unique()->word(),
+            'description' => $this->faker->sentences(asText: true),
+            'embed_enabled' => $this->faker->boolean(),
+            'allowed_domains' => [$this->faker->domainName()],
         ];
     }
 
@@ -90,7 +90,7 @@ class ApplicationFactory extends Factory
                     foreach ($application->fields as $field) {
                         $submission->fields()->attach(
                             $field,
-                            ['id' => Str::orderedUuid(), 'response' => fake()->words(rand(1, 10), true)],
+                            ['id' => Str::orderedUuid(), 'response' => $this->faker->words(rand(1, 10), true)],
                         );
                     }
                 }

--- a/app-modules/application/database/factories/ApplicationFieldFactory.php
+++ b/app-modules/application/database/factories/ApplicationFieldFactory.php
@@ -49,7 +49,7 @@ class ApplicationFieldFactory extends Factory
      */
     public function definition(): array
     {
-        $type = fake()->randomElement(['text_input', 'text_area', 'select']);
+        $type = $this->faker->randomElement(['text_input', 'text_area', 'select']);
 
         $config = match ($type) {
             'select' => json_decode('{"options":{"us":"United States","ca":"Canada","uk":"United Kingdom"}}'),
@@ -57,8 +57,8 @@ class ApplicationFieldFactory extends Factory
         };
 
         return [
-            'label' => fake()->words(asText: true),
-            'is_required' => fake()->boolean(),
+            'label' => $this->faker->words(asText: true),
+            'is_required' => $this->faker->boolean(),
             'type' => $type,
             'config' => $config,
         ];

--- a/app-modules/application/database/factories/ApplicationSubmissionFactory.php
+++ b/app-modules/application/database/factories/ApplicationSubmissionFactory.php
@@ -53,7 +53,7 @@ class ApplicationSubmissionFactory extends Factory
     {
         return [
             'application_id' => Application::factory(),
-            'author_type' => fake()->randomElement([(new Student())->getMorphClass(), (new Prospect())->getMorphClass()]),
+            'author_type' => $this->faker->randomElement([(new Student())->getMorphClass(), (new Prospect())->getMorphClass()]),
             'author_id' => function (array $attributes) {
                 $authorClass = Relation::getMorphedModel($attributes['author_type']);
 

--- a/app-modules/application/database/factories/ApplicationSubmissionStateFactory.php
+++ b/app-modules/application/database/factories/ApplicationSubmissionStateFactory.php
@@ -52,10 +52,10 @@ class ApplicationSubmissionStateFactory extends Factory
     public function definition(): array
     {
         return [
-            'classification' => fake()->randomElement(ApplicationSubmissionStateClassification::cases()),
-            'name' => fake()->word,
-            'color' => fake()->randomElement(ApplicationSubmissionStateColorOptions::cases()),
-            'description' => fake()->sentence,
+            'classification' => $this->faker->randomElement(ApplicationSubmissionStateClassification::cases()),
+            'name' => $this->faker->word,
+            'color' => $this->faker->randomElement(ApplicationSubmissionStateColorOptions::cases()),
+            'description' => $this->faker->sentence,
         ];
     }
 }

--- a/app-modules/authorization/database/factories/PermissionFactory.php
+++ b/app-modules/authorization/database/factories/PermissionFactory.php
@@ -46,8 +46,8 @@ class PermissionFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word,
-            'guard_name' => fake()->randomElement(['web', 'api']),
+            'name' => $this->faker->word,
+            'guard_name' => $this->faker->randomElement(['web', 'api']),
         ];
     }
 }

--- a/app-modules/authorization/database/factories/RoleFactory.php
+++ b/app-modules/authorization/database/factories/RoleFactory.php
@@ -47,7 +47,7 @@ class RoleFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->text(25),
+            'name' => $this->faker->text(25),
             'guard_name' => 'web',
         ];
     }

--- a/app-modules/basic-needs/database/factories/BasicNeedsCategoryFactory.php
+++ b/app-modules/basic-needs/database/factories/BasicNeedsCategoryFactory.php
@@ -51,8 +51,8 @@ class BasicNeedsCategoryFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'description' => fake()->paragraph(),
+            'name' => $this->faker->name(),
+            'description' => $this->faker->paragraph(),
         ];
     }
 }

--- a/app-modules/basic-needs/database/factories/BasicNeedsProgramFactory.php
+++ b/app-modules/basic-needs/database/factories/BasicNeedsProgramFactory.php
@@ -52,16 +52,16 @@ class BasicNeedsProgramFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'description' => fake()->realText(255),
+            'name' => $this->faker->name(),
+            'description' => $this->faker->realText(255),
             'basic_needs_category_id' => BasicNeedsCategory::factory(),
-            'contact_person' => fake()->name(),
-            'contact_email' => fake()->email(),
-            'contact_phone' => fake()->e164PhoneNumber(),
-            'location' => fake()->city(),
-            'availability' => fake()->realText(255),
-            'eligibility_criteria' => fake()->realText(255),
-            'application_process' => fake()->realText(255),
+            'contact_person' => $this->faker->name(),
+            'contact_email' => $this->faker->email(),
+            'contact_phone' => $this->faker->e164PhoneNumber(),
+            'location' => $this->faker->city(),
+            'availability' => $this->faker->realText(255),
+            'eligibility_criteria' => $this->faker->realText(255),
+            'application_process' => $this->faker->realText(255),
         ];
     }
 }

--- a/app-modules/campaign/database/factories/CampaignActionEducatableFactory.php
+++ b/app-modules/campaign/database/factories/CampaignActionEducatableFactory.php
@@ -52,7 +52,7 @@ class CampaignActionEducatableFactory extends Factory
     {
         return [
             'campaign_action_id' => CampaignAction::factory(),
-            'educatable_type' => fake()->randomElement([
+            'educatable_type' => $this->faker->randomElement([
                 new Student()->getMorphClass(),
                 new Prospect()->getMorphClass(),
             ]),

--- a/app-modules/campaign/database/factories/CampaignActionFactory.php
+++ b/app-modules/campaign/database/factories/CampaignActionFactory.php
@@ -51,12 +51,12 @@ class CampaignActionFactory extends Factory
     {
         return [
             'campaign_id' => Campaign::factory(),
-            'type' => fake()->randomElement([
+            'type' => $this->faker->randomElement([
                 CampaignActionType::BulkEngagementEmail,
                 CampaignActionType::BulkEngagementSms,
             ]),
             'data' => [],
-            'execute_at' => fake()->dateTimeBetween('+1 week', '+1 year'),
+            'execute_at' => $this->faker->dateTimeBetween('+1 week', '+1 year'),
         ];
     }
 

--- a/app-modules/campaign/database/factories/CampaignFactory.php
+++ b/app-modules/campaign/database/factories/CampaignFactory.php
@@ -51,7 +51,7 @@ class CampaignFactory extends Factory
             'created_by_id' => User::factory(),
             'created_by_type' => 'user',
             'segment_id' => Segment::factory(),
-            'name' => fake()->catchPhrase(),
+            'name' => $this->faker->catchPhrase(),
             'enabled' => true,
         ];
     }

--- a/app-modules/care-team/database/factories/CareTeamRoleFactory.php
+++ b/app-modules/care-team/database/factories/CareTeamRoleFactory.php
@@ -53,8 +53,8 @@ class CareTeamRoleFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
-            'type' => fake()->randomElement(CareTeamRoleType::cases())->value,
+            'name' => $this->faker->word(),
+            'type' => $this->faker->randomElement(CareTeamRoleType::cases())->value,
             'is_default' => false,
         ];
     }

--- a/app-modules/case-management/database/factories/CaseAssignmentFactory.php
+++ b/app-modules/case-management/database/factories/CaseAssignmentFactory.php
@@ -52,7 +52,7 @@ class CaseAssignmentFactory extends Factory
             'case_model_id' => CaseModel::factory(),
             'user_id' => User::factory(),
             'assigned_by_id' => User::factory(),
-            'assigned_at' => fake()->dateTimeBetween('-1 year', now()),
+            'assigned_at' => $this->faker->dateTimeBetween('-1 year', now()),
         ];
     }
 

--- a/app-modules/consent/database/factories/ConsentAgreementFactory.php
+++ b/app-modules/consent/database/factories/ConsentAgreementFactory.php
@@ -48,10 +48,10 @@ class ConsentAgreementFactory extends Factory
     public function definition(): array
     {
         return [
-            'type' => fake()->randomElement(ConsentAgreementType::cases())->value,
-            'title' => fake()->catchPhrase(),
-            'description' => fake()->paragraph(),
-            'body' => fake()->paragraphs(3, true),
+            'type' => $this->faker->randomElement(ConsentAgreementType::cases())->value,
+            'title' => $this->faker->catchPhrase(),
+            'description' => $this->faker->paragraph(),
+            'body' => $this->faker->paragraphs(3, true),
         ];
     }
 }

--- a/app-modules/division/database/factories/DivisionFactory.php
+++ b/app-modules/division/database/factories/DivisionFactory.php
@@ -51,9 +51,9 @@ class DivisionFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->company(),
-            'code' => fake()->unique()->word(),
-            'description' => fake()->optional()->sentences(asText: true),
+            'name' => $this->faker->unique()->company(),
+            'code' => $this->faker->unique()->word(),
+            'description' => $this->faker->optional()->sentences(asText: true),
             'is_default' => false,
         ];
     }
@@ -70,8 +70,8 @@ class DivisionFactory extends Factory
     public function configure(): DivisionFactory|Factory
     {
         return $this->afterMaking(function (Division $division) {
-            $division->createdBy()->associate(fake()->randomElement([User::inRandomOrder()->first(), null]));
-            $division->lastUpdatedBy()->associate(fake()->randomElement([User::inRandomOrder()->first(), null]));
+            $division->createdBy()->associate($this->faker->randomElement([User::inRandomOrder()->first(), null]));
+            $division->lastUpdatedBy()->associate($this->faker->randomElement([User::inRandomOrder()->first(), null]));
         });
     }
 }

--- a/app-modules/engagement/database/factories/EmailTemplateFactory.php
+++ b/app-modules/engagement/database/factories/EmailTemplateFactory.php
@@ -47,9 +47,9 @@ class EmailTemplateFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
-            'description' => fake()->sentence(),
-            'content' => fake()->paragraph(),
+            'name' => $this->faker->word(),
+            'description' => $this->faker->sentence(),
+            'content' => $this->faker->paragraph(),
         ];
     }
 }

--- a/app-modules/engagement/database/factories/EngagementBatchFactory.php
+++ b/app-modules/engagement/database/factories/EngagementBatchFactory.php
@@ -49,10 +49,10 @@ class EngagementBatchFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
-            'subject' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->sentence]]]]],
-            'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->paragraph]]]]],
-            'scheduled_at' => fake()->dateTimeBetween('-1 year', '-1 day'),
-            'channel' => fake()->randomElement([NotificationChannel::Email, NotificationChannel::Sms]),
+            'subject' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->sentence]]]]],
+            'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->paragraph]]]]],
+            'scheduled_at' => $this->faker->dateTimeBetween('-1 year', '-1 day'),
+            'channel' => $this->faker->randomElement([NotificationChannel::Email, NotificationChannel::Sms]),
         ];
     }
 
@@ -66,7 +66,7 @@ class EngagementBatchFactory extends Factory
     public function deliverLater(): self
     {
         return $this->state([
-            'scheduled_at' => fake()->dateTimeBetween('+1 day', '+1 week'),
+            'scheduled_at' => $this->faker->dateTimeBetween('+1 day', '+1 week'),
         ]);
     }
 

--- a/app-modules/engagement/database/factories/EngagementFactory.php
+++ b/app-modules/engagement/database/factories/EngagementFactory.php
@@ -54,7 +54,7 @@ class EngagementFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
-            'recipient_type' => fake()->randomElement([
+            'recipient_type' => $this->faker->randomElement([
                 (new Student())->getMorphClass(),
                 (new Prospect())->getMorphClass(),
             ]),
@@ -70,10 +70,10 @@ class EngagementFactory extends Factory
 
                 return $sender->getKey();
             },
-            'subject' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->sentence]]]]],
-            'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->paragraph]]]]],
-            'scheduled_at' => fake()->dateTimeBetween('-1 year', '-1 day'),
-            'channel' => fake()->randomElement([NotificationChannel::Email, NotificationChannel::Sms]),
+            'subject' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->sentence]]]]],
+            'body' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->paragraph]]]]],
+            'scheduled_at' => $this->faker->dateTimeBetween('-1 year', '-1 day'),
+            'channel' => $this->faker->randomElement([NotificationChannel::Email, NotificationChannel::Sms]),
         ];
     }
 
@@ -103,7 +103,7 @@ class EngagementFactory extends Factory
     public function deliverLater(): self
     {
         return $this->state([
-            'scheduled_at' => fake()->dateTimeBetween('+1 day', '+1 week'),
+            'scheduled_at' => $this->faker->dateTimeBetween('+1 day', '+1 week'),
         ]);
     }
 

--- a/app-modules/engagement/database/factories/EngagementResponseFactory.php
+++ b/app-modules/engagement/database/factories/EngagementResponseFactory.php
@@ -52,7 +52,7 @@ class EngagementResponseFactory extends Factory
     public function definition(): array
     {
         return [
-            'sender_type' => fake()->randomElement([
+            'sender_type' => $this->faker->randomElement([
                 (new Student())->getMorphClass(),
                 (new Prospect())->getMorphClass(),
             ]),
@@ -68,12 +68,12 @@ class EngagementResponseFactory extends Factory
 
                 return $sender->getKey();
             },
-            'content' => fake()->sentence(),
-            'sent_at' => fake()->dateTimeBetween('-1 year', '-1 day'),
-            'type' => fake()->randomElement(EngagementResponseType::cases()),
+            'content' => $this->faker->sentence(),
+            'sent_at' => $this->faker->dateTimeBetween('-1 year', '-1 day'),
+            'type' => $this->faker->randomElement(EngagementResponseType::cases()),
             'subject' => function ($attributes) {
                 return match ($attributes['type']) {
-                    EngagementResponseType::Email => fake()->sentence(),
+                    EngagementResponseType::Email => $this->faker->sentence(),
                     EngagementResponseType::Sms => null,
                 };
             },

--- a/app-modules/engagement/database/factories/SmsTemplateFactory.php
+++ b/app-modules/engagement/database/factories/SmsTemplateFactory.php
@@ -46,9 +46,9 @@ class SmsTemplateFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
-            'description' => fake()->sentence(),
-            'content' => fake()->paragraph(),
+            'name' => $this->faker->word(),
+            'description' => $this->faker->sentence(),
+            'content' => $this->faker->paragraph(),
         ];
     }
 }

--- a/app-modules/form/database/factories/FormFactory.php
+++ b/app-modules/form/database/factories/FormFactory.php
@@ -51,10 +51,10 @@ class FormFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->word(),
-            'description' => fake()->sentences(asText: true),
-            'embed_enabled' => fake()->boolean(),
-            'allowed_domains' => [fake()->domainName()],
+            'name' => $this->faker->unique()->word(),
+            'description' => $this->faker->sentences(asText: true),
+            'embed_enabled' => $this->faker->boolean(),
+            'allowed_domains' => [$this->faker->domainName()],
         ];
     }
 

--- a/app-modules/form/database/factories/FormFieldFactory.php
+++ b/app-modules/form/database/factories/FormFieldFactory.php
@@ -49,7 +49,7 @@ class FormFieldFactory extends Factory
      */
     public function definition(): array
     {
-        $type = fake()->randomElement(['text_input', 'text_area', 'select']);
+        $type = $this->faker->randomElement(['text_input', 'text_area', 'select']);
 
         $config = match ($type) {
             'select' => json_decode('{"options":{"us":"United States","ca":"Canada","uk":"United Kingdom"}}'),
@@ -57,8 +57,8 @@ class FormFieldFactory extends Factory
         };
 
         return [
-            'label' => fake()->words(asText: true),
-            'is_required' => fake()->boolean(),
+            'label' => $this->faker->words(asText: true),
+            'is_required' => $this->faker->boolean(),
             'type' => $type,
             'config' => $config,
         ];

--- a/app-modules/form/database/factories/FormSubmissionFactory.php
+++ b/app-modules/form/database/factories/FormSubmissionFactory.php
@@ -55,7 +55,7 @@ class FormSubmissionFactory extends Factory
     {
         return [
             'form_id' => Form::factory(),
-            'author_type' => fake()->randomElement([(new Student())->getMorphClass(), (new Prospect())->getMorphClass()]),
+            'author_type' => $this->faker->randomElement([(new Student())->getMorphClass(), (new Prospect())->getMorphClass()]),
             'author_id' => function (array $attributes) {
                 $authorClass = Relation::getMorphedModel($attributes['author_type']);
 

--- a/app-modules/interaction/database/factories/InteractionDriverFactory.php
+++ b/app-modules/interaction/database/factories/InteractionDriverFactory.php
@@ -47,7 +47,7 @@ class InteractionDriverFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/app-modules/interaction/database/factories/InteractionFactory.php
+++ b/app-modules/interaction/database/factories/InteractionFactory.php
@@ -57,7 +57,7 @@ class InteractionFactory extends Factory
 {
     public function definition(): array
     {
-        $interactable = fake()->randomElement([
+        $interactable = $this->faker->randomElement([
             Student::class,
             Prospect::class,
             CaseModel::class,
@@ -67,12 +67,12 @@ class InteractionFactory extends Factory
             Student::class => Student::inRandomOrder()->first() ?? Student::factory()->create(),
             Prospect::class => Prospect::factory()->create(),
             CaseModel::class => CaseModel::factory()->create([
-                'case_number' => fake()->randomNumber(8),
+                'case_number' => $this->faker->randomNumber(8),
             ]),
         };
 
         return [
-            'description' => fake()->paragraph(),
+            'description' => $this->faker->paragraph(),
             'division_id' => Division::factory(),
             'end_datetime' => now()->addMinutes(5),
             'interactable_id' => $interactable->getKey(),
@@ -84,7 +84,7 @@ class InteractionFactory extends Factory
             'interaction_status_id' => InteractionStatus::factory(),
             'interaction_type_id' => InteractionType::factory(),
             'start_datetime' => now(),
-            'subject' => fake()->sentence(),
+            'subject' => $this->faker->sentence(),
             'user_id' => User::factory(),
         ];
     }

--- a/app-modules/interaction/database/factories/InteractionInitiativeFactory.php
+++ b/app-modules/interaction/database/factories/InteractionInitiativeFactory.php
@@ -47,7 +47,7 @@ class InteractionInitiativeFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->word(),
+            'name' => $this->faker->unique()->word(),
         ];
     }
 }

--- a/app-modules/interaction/database/factories/InteractionOutcomeFactory.php
+++ b/app-modules/interaction/database/factories/InteractionOutcomeFactory.php
@@ -47,7 +47,7 @@ class InteractionOutcomeFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/app-modules/interaction/database/factories/InteractionRelationFactory.php
+++ b/app-modules/interaction/database/factories/InteractionRelationFactory.php
@@ -47,7 +47,7 @@ class InteractionRelationFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/app-modules/interaction/database/factories/InteractionStatusFactory.php
+++ b/app-modules/interaction/database/factories/InteractionStatusFactory.php
@@ -48,7 +48,7 @@ class InteractionStatusFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
             'color' => $this->faker->randomElement(ColumnColorOptions::cases())->value,
         ];
     }

--- a/app-modules/interaction/database/factories/InteractionTypeFactory.php
+++ b/app-modules/interaction/database/factories/InteractionTypeFactory.php
@@ -47,7 +47,7 @@ class InteractionTypeFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
         ];
     }
 }

--- a/app-modules/meeting-center/database/factories/CalendarEventFactory.php
+++ b/app-modules/meeting-center/database/factories/CalendarEventFactory.php
@@ -51,9 +51,9 @@ class CalendarEventFactory extends Factory
     public function definition(): array
     {
         return [
-            'title' => fake()->catchPhrase(),
-            'description' => fake()->optional()->sentence(),
-            'starts_at' => fake()->dateTimeBetween('+1 hour', '+1 day'),
+            'title' => $this->faker->catchPhrase(),
+            'description' => $this->faker->optional()->sentence(),
+            'starts_at' => $this->faker->dateTimeBetween('+1 hour', '+1 day'),
             'ends_at' => fn (array $attributes) => Carbon::parse($attributes['starts_at'])->add('1 hour'),
         ];
     }

--- a/app-modules/meeting-center/database/factories/EventAttendeeFactory.php
+++ b/app-modules/meeting-center/database/factories/EventAttendeeFactory.php
@@ -52,8 +52,8 @@ class EventAttendeeFactory extends Factory
     public function definition(): array
     {
         return [
-            'status' => fake()->randomElement(EventAttendeeStatus::class),
-            'email' => fake()->unique()->email(),
+            'status' => $this->faker->randomElement(EventAttendeeStatus::class),
+            'email' => $this->faker->unique()->email(),
             'event_id' => Event::inRandomOrder()->first() ?? Event::factory()->create(),
         ];
     }

--- a/app-modules/meeting-center/database/factories/EventFactory.php
+++ b/app-modules/meeting-center/database/factories/EventFactory.php
@@ -52,11 +52,11 @@ class EventFactory extends Factory
     public function definition(): array
     {
         return [
-            'title' => fake()->catchPhrase(),
-            'description' => fake()->optional()->paragraphs(asText: true),
-            'location' => fake()->address(),
-            'capacity' => fake()->numberBetween(1, 5000),
-            'starts_at' => fake()->dateTimeBetween('-1 week', '+1 week'),
+            'title' => $this->faker->catchPhrase(),
+            'description' => $this->faker->optional()->paragraphs(asText: true),
+            'location' => $this->faker->address(),
+            'capacity' => $this->faker->numberBetween(1, 5000),
+            'starts_at' => $this->faker->dateTimeBetween('-1 week', '+1 week'),
             'ends_at' => fn (array $attributes) => Carbon::parse($attributes['starts_at'])->add('1 hour'),
         ];
     }

--- a/app-modules/meeting-center/database/factories/EventRegistrationFormFactory.php
+++ b/app-modules/meeting-center/database/factories/EventRegistrationFormFactory.php
@@ -57,14 +57,14 @@ class EventRegistrationFormFactory extends Factory
     public function definition(): array
     {
         return [
-            'embed_enabled' => fake()->boolean(),
+            'embed_enabled' => $this->faker->boolean(),
             'allowed_domains' => fn ($attributes) => $attributes['embed_enabled'] ? [
                 parse_url(config('app.url'), PHP_URL_HOST),
-                parse_url(fake()->url(), PHP_URL_HOST),
+                parse_url($this->faker->url(), PHP_URL_HOST),
             ] : [],
-            'primary_color' => fake()->randomElement(collect(Color::all())->keys()),
-            'rounding' => fake()->randomElement(Rounding::class),
-            'is_wizard' => fake()->boolean(),
+            'primary_color' => $this->faker->randomElement(collect(Color::all())->keys()),
+            'rounding' => $this->faker->randomElement(Rounding::class),
+            'is_wizard' => $this->faker->boolean(),
             'event_id' => fn (array $attributes) => $attributes['event_id'] ??= Event::factory()->create()->getKey(),
         ];
     }

--- a/app-modules/meeting-center/database/factories/EventRegistrationFormFieldFactory.php
+++ b/app-modules/meeting-center/database/factories/EventRegistrationFormFieldFactory.php
@@ -52,9 +52,9 @@ class EventRegistrationFormFieldFactory extends Factory
     public function definition(): array
     {
         return [
-            'label' => str(fake()->word())->ucfirst(),
-            'type' => fake()->randomElement(['text_input', 'text_area']),
-            'is_required' => fake()->boolean(),
+            'label' => str($this->faker->word())->ucfirst(),
+            'type' => $this->faker->randomElement(['text_input', 'text_area']),
+            'is_required' => $this->faker->boolean(),
             'config' => [],
         ];
     }

--- a/app-modules/meeting-center/database/factories/EventRegistrationFormStepFactory.php
+++ b/app-modules/meeting-center/database/factories/EventRegistrationFormStepFactory.php
@@ -51,7 +51,7 @@ class EventRegistrationFormStepFactory extends Factory
     public function definition(): array
     {
         return [
-            'label' => str(fake()->word())->ucfirst(),
+            'label' => str($this->faker->word())->ucfirst(),
         ];
     }
 

--- a/app-modules/meeting-center/database/factories/EventRegistrationFormSubmissionFactory.php
+++ b/app-modules/meeting-center/database/factories/EventRegistrationFormSubmissionFactory.php
@@ -55,8 +55,8 @@ class EventRegistrationFormSubmissionFactory extends Factory
     public function definition(): array
     {
         return [
-            'attendee_status' => fake()->randomElement(EventAttendeeStatus::class),
-            'submitted_at' => fake()->dateTime(),
+            'attendee_status' => $this->faker->randomElement(EventAttendeeStatus::class),
+            'submitted_at' => $this->faker->dateTime(),
             'form_id' => EventRegistrationForm::inRandomOrder()->first() ?? EventRegistrationForm::factory()->create(),
             'event_attendee_id' => EventAttendee::inRandomOrder()->first() ?? EventAttendee::factory()->create(),
         ];
@@ -73,7 +73,7 @@ class EventRegistrationFormSubmissionFactory extends Factory
                         ->fields()
                         ->attach($eventRegistrationFormField->getKey(), [
                             'id' => Str::orderedUuid(),
-                            'response' => fake()->optional($eventRegistrationFormField->is_required, '')->words(asText: true),
+                            'response' => $this->faker->optional($eventRegistrationFormField->is_required, '')->words(asText: true),
                         ]);
                 });
         });

--- a/app-modules/notification/database/factories/EmailMessageEventFactory.php
+++ b/app-modules/notification/database/factories/EmailMessageEventFactory.php
@@ -48,7 +48,7 @@ class EmailMessageEventFactory extends Factory
     public function definition(): array
     {
         return [
-            'type' => fake()->randomElement(EmailMessageEventType::cases()),
+            'type' => $this->faker->randomElement(EmailMessageEventType::cases()),
             'payload' => [],
             'occurred_at' => now(),
         ];

--- a/app-modules/notification/database/factories/SmsMessageEventFactory.php
+++ b/app-modules/notification/database/factories/SmsMessageEventFactory.php
@@ -48,7 +48,7 @@ class SmsMessageEventFactory extends Factory
     public function definition(): array
     {
         return [
-            'type' => fake()->randomElement(SmsMessageEventType::cases()),
+            'type' => $this->faker->randomElement(SmsMessageEventType::cases()),
             'payload' => [],
             'occurred_at' => now(),
         ];

--- a/app-modules/prospect/database/factories/PipelineFactory.php
+++ b/app-modules/prospect/database/factories/PipelineFactory.php
@@ -53,8 +53,8 @@ class PipelineFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
-            'description' => fake()->paragraph(),
+            'name' => $this->faker->word(),
+            'description' => $this->faker->paragraph(),
             'user_id' => User::factory(),
         ];
     }

--- a/app-modules/prospect/database/factories/PipelineStageFactory.php
+++ b/app-modules/prospect/database/factories/PipelineStageFactory.php
@@ -53,9 +53,9 @@ class PipelineStageFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->word(),
+            'name' => $this->faker->word(),
             'pipeline_id' => Pipeline::factory(),
-            'order' => fake()->numberBetween(1, 5),
+            'order' => $this->faker->numberBetween(1, 5),
         ];
     }
 }

--- a/app-modules/prospect/database/factories/ProspectAddressFactory.php
+++ b/app-modules/prospect/database/factories/ProspectAddressFactory.php
@@ -52,14 +52,14 @@ class ProspectAddressFactory extends Factory
     public function definition(): array
     {
         return [
-            'line_1' => fake()->streetAddress(),
-            'line_2' => fake()->optional()->streetAddress(),
-            'line_3' => fake()->optional()->citySuffix(),
-            'city' => fake()->city(),
-            'state' => fake()->state(),
-            'postal' => fake()->postcode(),
-            'country' => fake()->country(),
-            'type' => fake()->randomElement(['Home', 'Institutional', 'Work']),
+            'line_1' => $this->faker->streetAddress(),
+            'line_2' => $this->faker->optional()->streetAddress(),
+            'line_3' => $this->faker->optional()->citySuffix(),
+            'city' => $this->faker->city(),
+            'state' => $this->faker->state(),
+            'postal' => $this->faker->postcode(),
+            'country' => $this->faker->country(),
+            'type' => $this->faker->randomElement(['Home', 'Institutional', 'Work']),
         ];
     }
 }

--- a/app-modules/prospect/database/factories/ProspectEmailAddressFactory.php
+++ b/app-modules/prospect/database/factories/ProspectEmailAddressFactory.php
@@ -52,8 +52,8 @@ class ProspectEmailAddressFactory extends Factory
     public function definition(): array
     {
         return [
-            'address' => fake()->email(),
-            'type' => fake()->randomElement(['Personal', 'Work', 'Institutional']),
+            'address' => $this->faker->email(),
+            'type' => $this->faker->randomElement(['Personal', 'Work', 'Institutional']),
         ];
     }
 }

--- a/app-modules/prospect/database/factories/ProspectFactory.php
+++ b/app-modules/prospect/database/factories/ProspectFactory.php
@@ -52,9 +52,9 @@ class ProspectFactory extends Factory
 {
     public function definition(): array
     {
-        $firstName = fake()->firstName();
-        $lastName = fake()->lastName();
-        $address3 = fake()->optional()->words(asText: true);
+        $firstName = $this->faker->firstName();
+        $lastName = $this->faker->lastName();
+        $address3 = $this->faker->optional()->words(asText: true);
 
         return [
             'status_id' => ProspectStatus::inRandomOrder()->first() ?? ProspectStatus::factory(),
@@ -62,12 +62,12 @@ class ProspectFactory extends Factory
             'first_name' => $firstName,
             'last_name' => $lastName,
             'full_name' => "{$firstName} {$lastName}",
-            'preferred' => fake()->firstName(),
-            'description' => fake()->paragraph(),
-            'sms_opt_out' => fake()->boolean(),
-            'email_bounce' => fake()->boolean(),
-            'birthdate' => fake()->date(),
-            'hsgrad' => fake()->year(),
+            'preferred' => $this->faker->firstName(),
+            'description' => $this->faker->paragraph(),
+            'sms_opt_out' => $this->faker->boolean(),
+            'email_bounce' => $this->faker->boolean(),
+            'birthdate' => $this->faker->date(),
+            'hsgrad' => $this->faker->year(),
             'created_by_id' => User::factory(),
         ];
     }
@@ -77,22 +77,22 @@ class ProspectFactory extends Factory
         return $this->afterCreating(function (Prospect $prospect) {
             $prospect->primaryEmailAddress()->associate(ProspectEmailAddress::factory()->create([
                 'prospect_id' => $prospect->getKey(),
-                'address' => fake()->unique()->email(),
+                'address' => $this->faker->unique()->email(),
                 'order' => 1,
             ]));
             $prospect->primaryPhoneNumber()->associate(ProspectPhoneNumber::factory()->canReceiveSms()->create([
                 'prospect_id' => $prospect->getKey(),
-                'number' => fake()->e164PhoneNumber(),
+                'number' => $this->faker->e164PhoneNumber(),
                 'order' => 1,
             ]));
             $prospect->primaryAddress()->associate(ProspectAddress::factory()->create([
                 'prospect_id' => $prospect->getKey(),
-                'line_1' => fake()->streetAddress(),
-                'line_2' => fake()->secondaryAddress(),
-                'line_3' => fake()->optional()->words(asText: true) ?? null,
-                'city' => fake()->city(),
-                'state' => fake()->stateAbbr(),
-                'postal' => str(fake()->postcode())->before('-')->toString(),
+                'line_1' => $this->faker->streetAddress(),
+                'line_2' => $this->faker->secondaryAddress(),
+                'line_3' => $this->faker->optional()->words(asText: true) ?? null,
+                'city' => $this->faker->city(),
+                'state' => $this->faker->stateAbbr(),
+                'postal' => str($this->faker->postcode())->before('-')->toString(),
                 'order' => 1,
             ]));
 

--- a/app-modules/prospect/database/factories/ProspectPhoneNumberFactory.php
+++ b/app-modules/prospect/database/factories/ProspectPhoneNumberFactory.php
@@ -52,10 +52,10 @@ class ProspectPhoneNumberFactory extends Factory
     public function definition(): array
     {
         return [
-            'number' => fake()->phoneNumber(),
+            'number' => $this->faker->phoneNumber(),
             'ext' => null,
-            'type' => fake()->randomElement(['Mobile', 'Home', 'Work']),
-            'can_receive_sms' => fake()->boolean(),
+            'type' => $this->faker->randomElement(['Mobile', 'Home', 'Work']),
+            'can_receive_sms' => $this->faker->boolean(),
         ];
     }
 
@@ -81,7 +81,7 @@ class ProspectPhoneNumberFactory extends Factory
     {
         return $this->state(function (array $attributes) {
             return [
-                'ext' => fake()->randomNumber(),
+                'ext' => $this->faker->randomNumber(),
             ];
         });
     }

--- a/app-modules/report/database/factories/ReportFactory.php
+++ b/app-modules/report/database/factories/ReportFactory.php
@@ -52,8 +52,8 @@ class ReportFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->words(asText: true),
-            'model' => fake()->randomElement(ReportModel::cases()),
+            'name' => $this->faker->words(asText: true),
+            'model' => $this->faker->randomElement(ReportModel::cases()),
             'user_id' => User::inRandomOrder()->first()?->getKey() ?? User::factory()->create()?->getKey(),
         ];
     }

--- a/app-modules/report/database/factories/TrackedEventCountFactory.php
+++ b/app-modules/report/database/factories/TrackedEventCountFactory.php
@@ -48,9 +48,9 @@ class TrackedEventCountFactory extends Factory
     public function definition(): array
     {
         return [
-            'type' => fake()->unique()->randomElement(TrackedEventType::cases()),
-            'count' => fake()->numberBetween(1, 100),
-            'last_occurred_at' => fake()->dateTime(),
+            'type' => $this->faker->unique()->randomElement(TrackedEventType::cases()),
+            'count' => $this->faker->numberBetween(1, 100),
+            'last_occurred_at' => $this->faker->dateTime(),
         ];
     }
 }

--- a/app-modules/report/database/factories/TrackedEventFactory.php
+++ b/app-modules/report/database/factories/TrackedEventFactory.php
@@ -48,8 +48,8 @@ class TrackedEventFactory extends Factory
     public function definition(): array
     {
         return [
-            'type' => fake()->randomElement(TrackedEventType::cases()),
-            'occurred_at' => fake()->dateTime(),
+            'type' => $this->faker->randomElement(TrackedEventType::cases()),
+            'occurred_at' => $this->faker->dateTime(),
         ];
     }
 }

--- a/app-modules/resource-hub/database/factories/ResourceHubArticleFactory.php
+++ b/app-modules/resource-hub/database/factories/ResourceHubArticleFactory.php
@@ -51,10 +51,10 @@ class ResourceHubArticleFactory extends Factory
     public function definition(): array
     {
         return [
-            'public' => fake()->boolean(),
-            'title' => fake()->sentence(),
-            'article_details' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => fake()->paragraph()]]]]],
-            'notes' => fake()->paragraph(),
+            'public' => $this->faker->boolean(),
+            'title' => $this->faker->sentence(),
+            'article_details' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->paragraph()]]]]],
+            'notes' => $this->faker->paragraph(),
             'quality_id' => ResourceHubQuality::inRandomOrder()->first() ?? ResourceHubQuality::factory(),
             'status_id' => ResourceHubStatus::inRandomOrder()->first() ?? ResourceHubStatus::factory(),
             'category_id' => ResourceHubCategory::inRandomOrder()->first() ?? ResourceHubCategory::factory(),

--- a/app-modules/segment/database/factories/SegmentFactory.php
+++ b/app-modules/segment/database/factories/SegmentFactory.php
@@ -53,8 +53,8 @@ class SegmentFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->words(asText: true),
-            'model' => fake()->randomElement(SegmentModel::cases()),
+            'name' => $this->faker->words(asText: true),
+            'model' => $this->faker->randomElement(SegmentModel::cases()),
             'type' => SegmentType::Dynamic, //TODO: add static later
             'user_id' => User::inRandomOrder()->first()?->getKey() ?? User::factory()->create()?->getKey(),
         ];

--- a/app-modules/student-data-model/database/factories/EnrollmentFactory.php
+++ b/app-modules/student-data-model/database/factories/EnrollmentFactory.php
@@ -51,33 +51,33 @@ class EnrollmentFactory extends Factory
     {
         return [
             'sisid' => Student::factory(),
-            'division' => fake()->randomElement(['ABC01', 'ABD02', 'ABE03']),
-            'class_nbr' => fake()->numerify('19###'),
-            'crse_grade_off' => fake()->randomElement(['A', 'B', 'C', 'D', 'W']),
-            'unt_taken' => fake()->numberBetween(1, 4),
+            'division' => $this->faker->randomElement(['ABC01', 'ABD02', 'ABE03']),
+            'class_nbr' => $this->faker->numerify('19###'),
+            'crse_grade_off' => $this->faker->randomElement(['A', 'B', 'C', 'D', 'W']),
+            'unt_taken' => $this->faker->numberBetween(1, 4),
             'unt_earned' => function (array $attributes) {
-                return $attributes['unt_taken'] - fake()->numberBetween(0, $attributes['unt_taken']);
+                return $attributes['unt_taken'] - $this->faker->numberBetween(0, $attributes['unt_taken']);
             },
-            'last_upd_dt_stmp' => fake()->dateTime(),
-            'section' => fake()->numerify('####'),
-            'name' => fake()->randomElement(['Introduction to Mathematics', 'College Algebra', 'Business Communication: Writing for the Workplace']),
-            'department' => fake()->optional(0.8)->randomElement(['Business', 'Business Administration', 'BA: Business Administration']),
-            'faculty_name' => fake()->name(),
-            'faculty_email' => fake()->safeEmail(),
-            'semester_code' => fake()->optional(0.8)->numerify('42##'),
-            'semester_name' => fake()->optional(0.8)->randomElement(['Fall 2006', 'Spring Cohort A 2006', 'Summer A 2006', 'Summer 2012']),
-            'start_date' => fake()->optional(0.8)->dateTime(),
+            'last_upd_dt_stmp' => $this->faker->dateTime(),
+            'section' => $this->faker->numerify('####'),
+            'name' => $this->faker->randomElement(['Introduction to Mathematics', 'College Algebra', 'Business Communication: Writing for the Workplace']),
+            'department' => $this->faker->optional(0.8)->randomElement(['Business', 'Business Administration', 'BA: Business Administration']),
+            'faculty_name' => $this->faker->name(),
+            'faculty_email' => $this->faker->safeEmail(),
+            'semester_code' => $this->faker->optional(0.8)->numerify('42##'),
+            'semester_name' => $this->faker->optional(0.8)->randomElement(['Fall 2006', 'Spring Cohort A 2006', 'Summer A 2006', 'Summer 2012']),
+            'start_date' => $this->faker->optional(0.8)->dateTime(),
             'end_date' => function (array $attributes) {
                 /** @var ?DateTime $start */
                 $start = $attributes['start_date'];
 
-                $days = fake()->numberBetween(1, 7);
+                $days = $this->faker->numberBetween(1, 7);
 
                 return $start
-                    ? fake()->boolean(80)
+                    ? $this->faker->boolean(80)
                         ? Carbon::make($start)->addDays($days)
                         : null
-                    : fake()->optional(0.8)->dateTime();
+                    : $this->faker->optional(0.8)->dateTime();
             },
         ];
     }

--- a/app-modules/student-data-model/database/factories/StudentAddressFactory.php
+++ b/app-modules/student-data-model/database/factories/StudentAddressFactory.php
@@ -52,14 +52,14 @@ class StudentAddressFactory extends Factory
     public function definition(): array
     {
         return [
-            'line_1' => fake()->streetAddress(),
-            'line_2' => fake()->optional()->streetAddress(),
-            'line_3' => fake()->optional()->citySuffix(),
-            'city' => fake()->city(),
-            'state' => fake()->state(),
-            'postal' => fake()->postcode(),
-            'country' => fake()->country(),
-            'type' => fake()->randomElement(['Home', 'Institutional', 'Work']),
+            'line_1' => $this->faker->streetAddress(),
+            'line_2' => $this->faker->optional()->streetAddress(),
+            'line_3' => $this->faker->optional()->citySuffix(),
+            'city' => $this->faker->city(),
+            'state' => $this->faker->state(),
+            'postal' => $this->faker->postcode(),
+            'country' => $this->faker->country(),
+            'type' => $this->faker->randomElement(['Home', 'Institutional', 'Work']),
         ];
     }
 }

--- a/app-modules/student-data-model/database/factories/StudentEmailAddressFactory.php
+++ b/app-modules/student-data-model/database/factories/StudentEmailAddressFactory.php
@@ -52,8 +52,8 @@ class StudentEmailAddressFactory extends Factory
     public function definition(): array
     {
         return [
-            'address' => fake()->email(),
-            'type' => fake()->randomElement(['Personal', 'Work', 'Institutional']),
+            'address' => $this->faker->email(),
+            'type' => $this->faker->randomElement(['Personal', 'Work', 'Institutional']),
         ];
     }
 }

--- a/app-modules/student-data-model/database/factories/StudentFactory.php
+++ b/app-modules/student-data-model/database/factories/StudentFactory.php
@@ -91,22 +91,22 @@ class StudentFactory extends Factory
         return $this->afterCreating(function (Student $student) {
             $student->primaryEmailAddress()->associate(StudentEmailAddress::factory()->create([
                 'sisid' => $student->getKey(),
-                'address' => fake()->email(),
+                'address' => $this->faker->email(),
                 'order' => 1,
             ]));
             $student->primaryPhoneNumber()->associate(StudentPhoneNumber::factory()->canReceiveSms()->create([
                 'sisid' => $student->getKey(),
-                'number' => fake()->e164PhoneNumber(),
+                'number' => $this->faker->e164PhoneNumber(),
                 'order' => 1,
             ]));
             $student->primaryAddress()->associate(StudentAddress::factory()->create([
                 'sisid' => $student->getKey(),
-                'line_1' => fake()->buildingNumber() . ' ' . fake()->streetName(),
-                'line_2' => fake()->randomElement([null, Address::secondaryAddress()]),
+                'line_1' => $this->faker->buildingNumber() . ' ' . $this->faker->streetName(),
+                'line_2' => $this->faker->randomElement([null, Address::secondaryAddress()]),
                 'line_3' => null,
-                'city' => fake()->city(),
+                'city' => $this->faker->city(),
                 'state' => Address::stateAbbr(),
-                'postal' => fake()->postcode(),
+                'postal' => $this->faker->postcode(),
                 'order' => 1,
             ]));
 

--- a/app-modules/student-data-model/database/factories/StudentPhoneNumberFactory.php
+++ b/app-modules/student-data-model/database/factories/StudentPhoneNumberFactory.php
@@ -52,10 +52,10 @@ class StudentPhoneNumberFactory extends Factory
     public function definition(): array
     {
         return [
-            'number' => fake()->phoneNumber(),
+            'number' => $this->faker->phoneNumber(),
             'ext' => null,
-            'type' => fake()->randomElement(['Mobile', 'Home', 'Work']),
-            'can_receive_sms' => fake()->boolean(),
+            'type' => $this->faker->randomElement(['Mobile', 'Home', 'Work']),
+            'can_receive_sms' => $this->faker->boolean(),
         ];
     }
 
@@ -81,7 +81,7 @@ class StudentPhoneNumberFactory extends Factory
     {
         return $this->state(function (array $attributes) {
             return [
-                'ext' => fake()->randomNumber(),
+                'ext' => $this->faker->randomNumber(),
             ];
         });
     }

--- a/app-modules/survey/database/factories/SurveyFactory.php
+++ b/app-modules/survey/database/factories/SurveyFactory.php
@@ -51,10 +51,10 @@ class SurveyFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->word(),
-            'description' => fake()->sentences(asText: true),
-            'embed_enabled' => fake()->boolean(),
-            'allowed_domains' => [fake()->domainName()],
+            'name' => $this->faker->unique()->word(),
+            'description' => $this->faker->sentences(asText: true),
+            'embed_enabled' => $this->faker->boolean(),
+            'allowed_domains' => [$this->faker->domainName()],
         ];
     }
 

--- a/app-modules/survey/database/factories/SurveyFieldFactory.php
+++ b/app-modules/survey/database/factories/SurveyFieldFactory.php
@@ -49,7 +49,7 @@ class SurveyFieldFactory extends Factory
      */
     public function definition(): array
     {
-        $type = fake()->randomElement(['text_input', 'text_area', 'select']);
+        $type = $this->faker->randomElement(['text_input', 'text_area', 'select']);
 
         $config = match ($type) {
             'select' => json_decode('{"options":{"us":"United States","ca":"Canada","uk":"United Kingdom"}}'),
@@ -57,8 +57,8 @@ class SurveyFieldFactory extends Factory
         };
 
         return [
-            'label' => fake()->words(asText: true),
-            'is_required' => fake()->boolean(),
+            'label' => $this->faker->words(asText: true),
+            'is_required' => $this->faker->boolean(),
             'type' => $type,
             'config' => $config,
         ];

--- a/app-modules/survey/database/factories/SurveySubmissionFactory.php
+++ b/app-modules/survey/database/factories/SurveySubmissionFactory.php
@@ -55,7 +55,7 @@ class SurveySubmissionFactory extends Factory
     {
         return [
             'survey_id' => Survey::factory(),
-            'author_type' => fake()->randomElement([(new Student())->getMorphClass(), (new Prospect())->getMorphClass()]),
+            'author_type' => $this->faker->randomElement([(new Student())->getMorphClass(), (new Prospect())->getMorphClass()]),
             'author_id' => function (array $attributes) {
                 $authorClass = Relation::getMorphedModel($attributes['author_type']);
 

--- a/app-modules/task/database/factories/TaskFactory.php
+++ b/app-modules/task/database/factories/TaskFactory.php
@@ -51,9 +51,9 @@ class TaskFactory extends Factory
     public function definition(): array
     {
         return [
-            'title' => str(fake()->words(asText: 3))->title()->toString(),
-            'description' => fake()->sentence(),
-            'status' => fake()->randomElement(TaskStatus::cases())->value,
+            'title' => str($this->faker->words(asText: 3))->title()->toString(),
+            'description' => $this->faker->sentence(),
+            'status' => $this->faker->randomElement(TaskStatus::cases())->value,
             'due' => null,
             'assigned_to' => null,
             'created_by' => User::factory(),
@@ -88,14 +88,14 @@ class TaskFactory extends Factory
     public function pastDue(): self
     {
         return $this->state([
-            'due' => fake()->dateTimeBetween('-2 weeks', '-1 week'),
+            'due' => $this->faker->dateTimeBetween('-2 weeks', '-1 week'),
         ]);
     }
 
     public function dueLater(): self
     {
         return $this->state([
-            'due' => fake()->dateTimeBetween('+1 week', '+2 weeks'),
+            'due' => $this->faker->dateTimeBetween('+1 week', '+2 weeks'),
         ]);
     }
 }

--- a/app-modules/team/database/factories/TeamFactory.php
+++ b/app-modules/team/database/factories/TeamFactory.php
@@ -48,15 +48,15 @@ class TeamFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->unique()->catchPhrase(),
-            'description' => fake()->sentence(),
+            'name' => $this->faker->unique()->catchPhrase(),
+            'description' => $this->faker->sentence(),
         ];
     }
 
     public function configure(): TeamFactory|Factory
     {
         return $this->afterMaking(function (Team $team) {
-            $team->division()->associate(fake()->randomElement([Division::inRandomOrder()->first(), null]));
+            $team->division()->associate($this->faker->randomElement([Division::inRandomOrder()->first(), null]));
         });
     }
 }

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -51,7 +51,7 @@ class TagFactory extends Factory
     {
         return [
             'name' => $this->faker->name,
-            'type' => fake()->randomElement(TagType::cases())->value,
+            'type' => $this->faker->randomElement(TagType::cases())->value,
         ];
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -55,11 +55,11 @@ class UserFactory extends Factory
         return [
             'default_assistant_chat_folders_created' => false,
             'email_verified_at' => now(),
-            'email' => fake()->unique()->safeEmail(),
+            'email' => $this->faker->unique()->safeEmail(),
             'is_external' => false,
-            'name' => fake()->name(),
+            'name' => $this->faker->name(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-            'phone_number' => fake()->phoneNumber(),
+            'phone_number' => $this->faker->phoneNumber(),
             'remember_token' => Str::random(10),
         ];
     }

--- a/tests/Tenant/Unit/ArchTest.php
+++ b/tests/Tenant/Unit/ArchTest.php
@@ -51,6 +51,10 @@ arch('All Core Models should not use HasUuids trait')
     ->extending(Model::class)
     ->not->toUseTrait('Illuminate\Database\Eloquent\Concerns\HasUuids');
 
+arch('All Core Factories should not use the fake global function')
+    ->expect('Database\Factories')
+    ->not->toUse('fake');
+
 /** @var Collection<int, ModuleConfig> $modules */
 $modules = app(ModuleRegistry::class, [
     'modules_path' => 'app-modules',
@@ -66,6 +70,10 @@ $modules->each(function (ModuleConfig $module) {
         ->expect($module->namespace() . 'Models')
         ->extending(Model::class)
         ->not->toUseTrait('Illuminate\Database\Eloquent\Concerns\HasUuids');
+
+    arch("All {$module->name} Factories should not use the fake global function")
+        ->expect($module->namespace() . 'Database\Factories')
+        ->not->toUse('fake');
 });
 
 test('pages extending EditRecord have the EditPageRedirection test', function () {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1525

### Technical Description

Updates all factories to use the local usage of faker and gets rid of calls to `fake()`. Adds arch tests enforcing that `fake()` is no longer used in factories.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
