### PR TITLE
[ADVAPP-1487]: AAn error is thrown to Sentry if an Azure SSO login does not have a profile photo

### DIFF
--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -96,6 +96,7 @@ class SocialiteController extends Controller
         if ($provider === SocialiteProvider::Azure) {
             try {
                 $request = Http::withToken($socialiteUser->token)
+                    ->retry(3, 500)
                     ->get('https://graph.microsoft.com/v1.0/me/photo/$value')
                     ->throw();
 

--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -44,6 +44,7 @@ use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
@@ -98,7 +99,7 @@ class SocialiteController extends Controller
                 $request = Http::withToken($socialiteUser->token)
                     ->retry(3, 500)
                     ->get('https://graph.microsoft.com/v1.0/me/photo/$value')
-                    ->throw();
+                    ->throwIf(fn (Response $response) => $response->failed() && $response->status() !== 404);
 
                 $mimeType = $request->header('Content-Type');
 

--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -43,7 +43,7 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Query\Expression;
-use Illuminate\Http\Client\Response;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
@@ -96,9 +96,8 @@ class SocialiteController extends Controller
         if ($provider === SocialiteProvider::Azure) {
             try {
                 $request = Http::withToken($socialiteUser->token)
-                    ->retry(3, 500)
                     ->get('https://graph.microsoft.com/v1.0/me/photo/$value')
-                    ->throwIf(fn (Response $response) => $response->failed() && $response->status() !== 404);
+                    ->throw();
 
                 $mimeType = $request->header('Content-Type');
 
@@ -112,6 +111,10 @@ class SocialiteController extends Controller
                     }
                 } else {
                     throw new InvalidUserAvatarMimeType($mimeType, $user);
+                }
+            } catch (RequestException $e) {
+                if (! str_contains($e->getMessage(), 'Microsoft.Fast.Profile.Core.Exception.ImageNotFoundException')) {
+                    report($e);
                 }
             } catch (Throwable $e) {
                 report($e);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1487

### Technical Description

> An error is thrown to Sentry if an Azure SSO login does not have a profile photo.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
