### PR TITLE
[ADVAPP-1537]: Not having a primary phone or email results in errors thrown on Student records

### DIFF
--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/Schemas/StudentProfileInfolist.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/Schemas/StudentProfileInfolist.php
@@ -75,7 +75,7 @@ class StudentProfileInfolist
                             TextEntry::make('primaryEmailAddress')
                                 ->label('Primary Email Address')
                                 ->state(fn (Student $record): View => view('student-data-model::components.filament.resources.educatable-resource.view-educatable.email-address-detail', ['emailAddress' => $record->primaryEmailAddress]))
-                                ->visible(fn (?View $state): bool => filled($state)),
+                                ->visible(fn (Student $record): bool => filled($record->primaryEmailAddress)),
                             TextEntry::make('additionalEmailAddresses')
                                 ->label(fn (?array $state): string => Str::plural('Other Email Address', count($state ?? [])))
                                 ->state(fn (Student $record): array => array_map(
@@ -83,11 +83,11 @@ class StudentProfileInfolist
                                     $record->additionalEmailAddresses->all(),
                                 ))
                                 ->listWithLineBreaks()
-                                ->visible(fn (?array $state): bool => filled($state)),
+                                ->visible(fn (Student $record): bool => filled($record->additionalEmailAddresses)),
                             TextEntry::make('primaryPhoneNumber')
                                 ->label('Primary Phone Number')
                                 ->state(fn (Student $record): View => view('student-data-model::components.filament.resources.educatable-resource.view-educatable.phone-number-detail', ['phoneNumber' => $record->primaryPhoneNumber]))
-                                ->visible(fn (?View $state): bool => filled($state)),
+                                ->visible(fn (Student $record): bool => filled($record->primaryPhoneNumber)),
                             TextEntry::make('additionalPhoneNumbers')
                                 ->label(fn (?array $state): string => Str::plural('Other Phone Number', count($state ?? [])))
                                 ->state(fn (Student $record): array => array_map(
@@ -95,7 +95,7 @@ class StudentProfileInfolist
                                     $record->additionalPhoneNumbers->all(),
                                 ))
                                 ->listWithLineBreaks()
-                                ->visible(fn (?array $state): bool => filled($state)),
+                                ->visible(fn (Student $record): bool => filled($record->additionalPhoneNumbers)),
                         ]),
                         Subsection::make([
                             TextEntry::make('gender')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1537

### Technical Description

Fixes errors thrown when a Student does not have a primary phone or email sent.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
