### PR TITLE
[ADVAPP-1531], [ADVAPP-1533] & [ADVAPP-1534]: Enhance the presentation of references in the Research Advisor, Enhance the approach the Research Advisor takes by increasing dependency on academically valid sources, and Enhance research advisor process for chain-of-thought prompt engineering

### DIFF
--- a/app-modules/research/resources/views/results.blade.php
+++ b/app-modules/research/resources/views/results.blade.php
@@ -48,7 +48,11 @@
                 <h1>{{ $researchRequest->title }}</h1>
             @endif
 
-            {!! str($researchRequest->results)->replace('<think>', '<details wire:ignore.self><summary>Reasoning</summary>')->replace('</think>', '</details>')->markdown(extensions: [app(FootnoteExtension::class)])->sanitizeHtml() !!}
+            {!! str($researchRequest->results)->replace('<think>', '<details wire:ignore.self><summary>Reasoning</summary>')->replace('</think>', '</details>')->markdown(options: [
+                'footnote' => [
+                    'container_add_hr' => false,
+                ],
+            ], extensions: [app(FootnoteExtension::class)])->replace('<div class="footnotes" role="doc-endnotes">', '<div class="footnotes" role="doc-endnotes"><h2>References</h2>')->sanitizeHtml() !!}
         </section>
     @endif
 </div>

--- a/app-modules/research/resources/views/results.blade.php
+++ b/app-modules/research/resources/views/results.blade.php
@@ -48,11 +48,17 @@
                 <h1>{{ $researchRequest->title }}</h1>
             @endif
 
-            {!! str($researchRequest->results)->replace('<think>', '<details wire:ignore.self><summary>Reasoning</summary>')->replace('</think>', '</details>')->markdown(options: [
-                'footnote' => [
-                    'container_add_hr' => false,
-                ],
-            ], extensions: [app(FootnoteExtension::class)])->replace('<div class="footnotes" role="doc-endnotes">', '<div class="footnotes" role="doc-endnotes"><h2>References</h2>')->sanitizeHtml() !!}
+            {!! str($researchRequest->results)->replace('<think>', '<details wire:ignore.self><summary>Reasoning</summary>')->replace('</think>', '</details>')->markdown(
+                    options: [
+                        'footnote' => [
+                            'container_add_hr' => false,
+                        ],
+                    ],
+                    extensions: [app(FootnoteExtension::class)],
+                )->replace(
+                    '<div class="footnotes" role="doc-endnotes">',
+                    '<div class="footnotes" role="doc-endnotes"><h2>References</h2>',
+                )->sanitizeHtml() !!}
         </section>
     @endif
 </div>

--- a/app-modules/research/src/Actions/GenerateResearchQuestion.php
+++ b/app-modules/research/src/Actions/GenerateResearchQuestion.php
@@ -88,7 +88,7 @@ class GenerateResearchQuestion
 
             **Instructions:**
             
-            Before the research is conducted, you need to help improve the chances that it will be relevant and useful to me. Using my research topic, respond with one relevant question that will help to clarify it. As you form your next question, to gain clarification on how to research this topic effectively, ensure that the question asked is materially different any previously asked clarification questions. You will be able to ask four questions in total, and you will know the answer to the previous question/s before you ask the next one. Do not respond with any greetings or salutations, and do not include any additional information or context. Just respond with your question:
+            Before the research is conducted, you need to help improve the chances that it will be relevant and useful to me. Using my research topic, respond with one relevant question that will help to clarify it. As you form your next question, to gain clarification on how to research this topic effectively, ensure that the question asked is materially different from any previously asked clarification questions. You will be able to ask four questions in total, and you will know the answer to the previous question/s before you ask the next one. Do not respond with any greetings or salutations, and do not include any additional information or context. Just respond with your question:
             EOD;
     }
 

--- a/app-modules/research/src/Actions/GenerateResearchQuestion.php
+++ b/app-modules/research/src/Actions/GenerateResearchQuestion.php
@@ -88,7 +88,7 @@ class GenerateResearchQuestion
 
             **Instructions:**
             
-            Before the research is conducted, you need to help improve the chances that it will be relevant and useful to me. Using my research topic, respond with one relevant question that will help to clarify it. You will be able to ask four questions in total, and you will know the answer to the previous question/s before you ask the next one. Do not respond with any greetings or salutations, and do not include any additional information or context. Just respond with your question:
+            Before the research is conducted, you need to help improve the chances that it will be relevant and useful to me. Using my research topic, respond with one relevant question that will help to clarify it. As you form your next question, to gain clarification on how to research this topic effectively, ensure that the question asked is materially different any previously asked clarification questions. You will be able to ask four questions in total, and you will know the answer to the previous question/s before you ask the next one. Do not respond with any greetings or salutations, and do not include any additional information or context. Just respond with your question:
             EOD;
     }
 

--- a/app-modules/research/src/Jobs/Research.php
+++ b/app-modules/research/src/Jobs/Research.php
@@ -190,15 +190,17 @@ class Research implements ShouldQueue
             ->implode(PHP_EOL . PHP_EOL);
 
         return <<<EOD
-            ## Requestor Information
+            **Requestor Information**
             
             This request is submitted by **{$userName}** who is an institutional staff member {$userJobTitle}.
 
             ---
 
-            ## Institutional Context
+            **Institutional Context**
 
             {$institutionalContext}
+
+            ---
 
             **Research topic:**
 


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1531
- https://canyongbs.atlassian.net/browse/ADVAPP-1533
- https://canyongbs.atlassian.net/browse/ADVAPP-1534

### Technical Description

Updates the prompt. Reformats the footnotes in Markdown. Removes use of system role when sending context.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
