### PR TITLE
[ADVAPP-1541]: Single or bulk Engagement body saves as an empty array Tests

### DIFF
--- a/app-modules/engagement/tests/Tenant/Filament/Actions/BulkEngagementActionTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Actions/BulkEngagementActionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use AdvisingApp\Engagement\Jobs\CreateBatchedEngagement;
+use AdvisingApp\Engagement\Models\EngagementBatch;
+use AdvisingApp\Notification\Enums\NotificationChannel;
+use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\Pages\ListStudents;
+use AdvisingApp\StudentDataModel\Models\Student;
+use Illuminate\Support\Facades\Queue;
+
+use function Pest\Faker\fake;
+use function Pest\Laravel\assertDatabaseCount;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can create an Email Engagement properly', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $students = Student::factory()->count(3)->create();
+
+    $faker = fake();
+
+    $subject = ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $faker->sentence()]]]]];
+    $body = ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $faker->paragraph()]]]]];
+
+    livewire(ListStudents::class)
+        ->mountTableBulkAction('engage', $students->pluck('sisid')->toArray())
+        ->setTableBulkActionData([
+            'channel' => NotificationChannel::Email->value,
+            'subject' => $subject,
+            'body' => $body,
+        ])
+        ->callMountedTableBulkAction()
+        ->assertHasNoTableBulkActionErrors();
+
+    assertDatabaseCount(EngagementBatch::class, 1);
+
+    $engagementBatch = EngagementBatch::first();
+
+    expect($engagementBatch->channel)->toEqual(NotificationChannel::Email);
+    expect($engagementBatch->subject)->toEqual($subject);
+    expect($engagementBatch->body)->toEqual($body);
+    Queue::assertPushed(CreateBatchedEngagement::class, 3);
+});
+
+it('can create an SMS Engagement properly', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $students = Student::factory()->count(3)->create();
+
+    $faker = fake();
+
+    $body = ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $faker->paragraph()]]]]];
+
+    livewire(ListStudents::class)
+        ->mountTableBulkAction('engage', $students->pluck('sisid')->toArray())
+        ->setTableBulkActionData([
+            'channel' => NotificationChannel::Sms->value,
+            'body' => $body,
+        ])
+        ->callMountedTableBulkAction()
+        ->assertHasNoTableBulkActionErrors();
+
+    assertDatabaseCount(EngagementBatch::class, 1);
+
+    $engagementBatch = EngagementBatch::first();
+
+    expect($engagementBatch->channel)->toEqual(NotificationChannel::Sms);
+    expect($engagementBatch->body)->toEqual($body);
+    Queue::assertPushed(CreateBatchedEngagement::class, 3);
+});

--- a/app-modules/engagement/tests/Tenant/Filament/Actions/BulkEngagementActionTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Actions/BulkEngagementActionTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Engagement\Jobs\CreateBatchedEngagement;
 use AdvisingApp\Engagement\Models\EngagementBatch;
 use AdvisingApp\Notification\Enums\NotificationChannel;

--- a/app-modules/engagement/tests/Tenant/Filament/Actions/RelationManagerSendEngagementActionTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Actions/RelationManagerSendEngagementActionTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Notification\Enums\NotificationChannel;
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\Pages\ViewStudent;
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\RelationManagers\EngagementsRelationManager;

--- a/app-modules/engagement/tests/Tenant/Filament/Actions/RelationManagerSendEngagementActionTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Actions/RelationManagerSendEngagementActionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use AdvisingApp\Notification\Enums\NotificationChannel;
+use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\Pages\ViewStudent;
+use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\RelationManagers\EngagementsRelationManager;
+use AdvisingApp\StudentDataModel\Models\Student;
+use Illuminate\Support\Facades\Queue;
+
+use function Pest\Faker\fake;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can create an Email Engagement properly', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    /** @var Student $student */
+    $student = Student::factory()->create();
+
+    $faker = fake();
+
+    $subject = ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $faker->sentence()]]]]];
+    $body = ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $faker->paragraph()]]]]];
+
+    livewire(EngagementsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->mountTableAction('engage')
+        ->setTableActionData([
+            'channel' => NotificationChannel::Email->value,
+            'recipient_route_id' => $student->primaryEmailAddress?->getKey(),
+            'subject' => $subject,
+            'body' => $body,
+        ])
+        ->callMountedTableAction()
+        ->assertHasNoTableActionErrors();
+
+    expect($student->engagements()->count())->toBe(1);
+    expect($student->engagements()->first()->channel)->toEqual(NotificationChannel::Email);
+    expect($student->engagements()->first()->subject)->toEqual($subject);
+    expect($student->engagements()->first()->body)->toEqual($body);
+});
+
+it('can create an SMS Engagement properly', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    /** @var Student $student */
+    $student = Student::factory()->create();
+
+    $faker = fake();
+
+    $body = ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $faker->paragraph()]]]]];
+
+    livewire(EngagementsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->mountTableAction('engage')
+        ->setTableActionData([
+            'channel' => NotificationChannel::Sms->value,
+            'recipient_route_id' => $student->primaryPhoneNumber?->getKey(),
+            'body' => $body,
+        ])
+        ->callMountedTableAction()
+        ->assertHasNoTableActionErrors();
+
+    expect($student->engagements()->count())->toBe(1);
+    expect($student->engagements()->first()->channel)->toEqual(NotificationChannel::Sms);
+    expect($student->engagements()->first()->body)->toEqual($body);
+});

--- a/app-modules/engagement/tests/Tenant/Filament/Actions/SendEngagementActionTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Actions/SendEngagementActionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use AdvisingApp\Notification\Enums\NotificationChannel;
+use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\Pages\ViewStudent;
+use AdvisingApp\StudentDataModel\Models\Student;
+use Illuminate\Support\Facades\Queue;
+
+use function Pest\Faker\fake;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can create an Email Engagement properly', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    /** @var Student $student */
+    $student = Student::factory()->create();
+
+    $faker = fake();
+
+    $subject = ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $faker->sentence()]]]]];
+    $body = ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $faker->paragraph()]]]]];
+
+    livewire(ViewStudent::class, [
+        'record' => $student->getKey(),
+    ])
+        ->mountAction('engage')
+        ->setActionData([
+            'channel' => NotificationChannel::Email->value,
+            'recipient_route_id' => $student->primaryEmailAddress?->getKey(),
+            'subject' => $subject,
+            'body' => $body,
+        ])
+        ->callMountedAction()
+        ->assertHasNoActionErrors();
+
+    expect($student->engagements()->count())->toBe(1);
+    expect($student->engagements()->first()->channel)->toEqual(NotificationChannel::Email);
+    expect($student->engagements()->first()->subject)->toEqual($subject);
+    expect($student->engagements()->first()->body)->toEqual($body);
+});
+
+it('can create an SMS Engagement properly', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    /** @var Student $student */
+    $student = Student::factory()->create();
+
+    $faker = fake();
+
+    $body = ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $faker->paragraph()]]]]];
+
+    livewire(ViewStudent::class, [
+        'record' => $student->getKey(),
+    ])
+        ->mountAction('engage')
+        ->setActionData([
+            'channel' => NotificationChannel::Sms->value,
+            'recipient_route_id' => $student->primaryPhoneNumber?->getKey(),
+            'body' => $body,
+        ])
+        ->callMountedAction()
+        ->assertHasNoActionErrors();
+
+    expect($student->engagements()->count())->toBe(1);
+    expect($student->engagements()->first()->channel)->toEqual(NotificationChannel::Sms);
+    expect($student->engagements()->first()->body)->toEqual($body);
+});

--- a/app-modules/engagement/tests/Tenant/Filament/Actions/SendEngagementActionTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Actions/SendEngagementActionTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Notification\Enums\NotificationChannel;
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource\Pages\ViewStudent;
 use AdvisingApp\StudentDataModel\Models\Student;

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -61,6 +61,7 @@ class UserFactory extends Factory
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'phone_number' => fake()->phoneNumber(),
             'remember_token' => Str::random(10),
+            'is_signature_enabled' => false,
         ];
     }
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1541

### Technical Description

Adds tests for the fix that went out to fix Engagement creation.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
