### PR TITLE
[ADVAPP-1499]: Fix Advising App deployment jobs ending up in the Tenant table rather than the Landlord table

### DIFF
--- a/app-modules/theme/src/Jobs/UpdateTenantTheme.php
+++ b/app-modules/theme/src/Jobs/UpdateTenantTheme.php
@@ -62,7 +62,7 @@ class UpdateTenantTheme implements ShouldQueue, NotTenantAware
 
     public function handle(): void
     {
-        $this->tenant->execute(function () {
+        $this->tenant->executeWithLandlordJobFailureAndBatching(function () {
             $settings = app(ThemeSettings::class);
             $settings->color_overrides = $this->config->colorOverrides;
             $settings->has_dark_mode = $this->config->hasDarkMode;

--- a/app/Jobs/CreateTenantUser.php
+++ b/app/Jobs/CreateTenantUser.php
@@ -74,7 +74,7 @@ class CreateTenantUser implements ShouldQueue, NotTenantAware
 
     public function handle(): void
     {
-        $this->tenant->execute(function () {
+        $this->tenant->executeWithLandlordJobFailureAndBatching(function () {
             $user = User::create($this->data->toArray());
 
             foreach (Arr::wrap(LicenseType::cases()) as $licenseType) {

--- a/app/Jobs/MigrateTenantDatabase.php
+++ b/app/Jobs/MigrateTenantDatabase.php
@@ -37,6 +37,7 @@
 namespace App\Jobs;
 
 use App\Models\Tenant;
+use Exception;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -66,14 +67,23 @@ class MigrateTenantDatabase implements ShouldQueue, NotTenantAware
     {
         $this->tenant->execute(function () {
             $currentQueueFailedConnection = config('queue.failed.database');
+            // TODO: Apply this to all of the other jobs in this batch / chain, maybe reset `queue.failer` and what ever in the container refernced the batching config?
+            $currentBatchingConnection = config('queue.batching.database');
 
-            config(['queue.failed.database' => 'landlord']);
+            config([
+                'queue.failed.database' => 'landlord',
+                'queue.batching.database' => 'landlord',
+            ]);
 
+            throw new Exception('test');
             Artisan::call(
                 command: 'migrate:fresh --force'
             );
 
-            config(['queue.failed.database' => $currentQueueFailedConnection]);
+            config([
+                'queue.failed.database' => $currentQueueFailedConnection,
+                'queue.batching.database' => $currentBatchingConnection,
+            ]);
         });
     }
 }

--- a/app/Jobs/MigrateTenantDatabase.php
+++ b/app/Jobs/MigrateTenantDatabase.php
@@ -37,7 +37,6 @@
 namespace App\Jobs;
 
 use App\Models\Tenant;
-use Exception;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -65,25 +64,10 @@ class MigrateTenantDatabase implements ShouldQueue, NotTenantAware
 
     public function handle(): void
     {
-        $this->tenant->execute(function () {
-            $currentQueueFailedConnection = config('queue.failed.database');
-            // TODO: Apply this to all of the other jobs in this batch / chain, maybe reset `queue.failer` and what ever in the container refernced the batching config?
-            $currentBatchingConnection = config('queue.batching.database');
-
-            config([
-                'queue.failed.database' => 'landlord',
-                'queue.batching.database' => 'landlord',
-            ]);
-
-            throw new Exception('test');
+        $this->tenant->executeWithLandlordJobFailureAndBatching(function () {
             Artisan::call(
                 command: 'migrate:fresh --force'
             );
-
-            config([
-                'queue.failed.database' => $currentQueueFailedConnection,
-                'queue.batching.database' => $currentBatchingConnection,
-            ]);
         });
     }
 }

--- a/app/Jobs/SeedTenantDatabase.php
+++ b/app/Jobs/SeedTenantDatabase.php
@@ -66,16 +66,10 @@ class SeedTenantDatabase implements ShouldQueue, NotTenantAware
 
     public function handle(): void
     {
-        $this->tenant->execute(function () {
-            $currentQueueFailedConnection = config('queue.failed.database');
-
-            config(['queue.failed.database' => 'landlord']);
-
+        $this->tenant->executeWithLandlordJobFailureAndBatching(function () {
             Artisan::call(
                 command: 'db:seed --class=NewTenantSeeder --force'
             );
-
-            config(['queue.failed.database' => $currentQueueFailedConnection]);
         });
     }
 }

--- a/app/Jobs/UpdateTenantLicenseData.php
+++ b/app/Jobs/UpdateTenantLicenseData.php
@@ -64,7 +64,7 @@ class UpdateTenantLicenseData implements ShouldQueue, NotTenantAware
     {
         $licenseData = $this->data;
 
-        $this->tenant->execute(function () use ($licenseData) {
+        $this->tenant->executeWithLandlordJobFailureAndBatching(function () use ($licenseData) {
             $licenseSettings = app(LicenseSettings::class);
 
             // TODO: Determine how to handle and retrieve this key

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -94,4 +94,26 @@ class Tenant extends SpatieTenant
 
         return $current->updated_at->lessThan($this->updated_at);
     }
+
+    public function executeWithLandlordJobFailureAndBatching(callable $callback): void
+    {
+        $this->execute(function () use ($callback) {
+            $currentQueueFailedConnection = config('queue.failed.database');
+            $currentBatchingConnection = config('queue.batching.database');
+
+            config([
+                'queue.failed.database' => 'landlord',
+                'queue.batching.database' => 'landlord',
+            ]);
+
+            try {
+                $callback();
+            } finally {
+                config([
+                    'queue.failed.database' => $currentQueueFailedConnection,
+                    'queue.batching.database' => $currentBatchingConnection,
+                ]);
+            }
+        });
+    }
 }

--- a/app/Multitenancy/Actions/CreateTenant.php
+++ b/app/Multitenancy/Actions/CreateTenant.php
@@ -78,6 +78,7 @@ class CreateTenant
                 ...($licenseData ? [new UpdateTenantLicenseData($tenant, $licenseData)] : []),
                 ...($themeConfig ? [new UpdateTenantTheme($tenant, $themeConfig)] : []),
                 ...($user ? [new CreateTenantUser($tenant, $user)] : []),
+                // TODO: Move this out of a job to a finally
                 new DispatchTenantSetupCompleteEvent($tenant),
             ],
         ])

--- a/app/Multitenancy/Actions/CreateTenant.php
+++ b/app/Multitenancy/Actions/CreateTenant.php
@@ -78,7 +78,6 @@ class CreateTenant
                 ...($licenseData ? [new UpdateTenantLicenseData($tenant, $licenseData)] : []),
                 ...($themeConfig ? [new UpdateTenantTheme($tenant, $themeConfig)] : []),
                 ...($user ? [new CreateTenantUser($tenant, $user)] : []),
-                // TODO: Move this out of a job to a finally
                 new DispatchTenantSetupCompleteEvent($tenant),
             ],
         ])


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1499

### Technical Description

Ensures that the jobs that re run on behalf of a Tenant send job failure and batching inform back to the Landlord connection when appropriate.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
