### PR TITLE
[ADVAPP-1560]: Some users are reporting the holistic profile generating exceptions, as well as a failure to display interaction data in the interactions tab

### DIFF
--- a/app-modules/interaction/src/Filament/Concerns/HasManyMorphedInteractionsTrait.php
+++ b/app-modules/interaction/src/Filament/Concerns/HasManyMorphedInteractionsTrait.php
@@ -121,7 +121,7 @@ trait HasManyMorphedInteractionsTrait
                     ->label('Duration'),
                 TextColumn::make('user.name')
                     ->label('Created By')
-                    ->description(fn ($record) => $record->user->job_title)
+                    ->description(fn ($record) => $record->user?->job_title)
                     ->sortable(),
                 TextColumn::make('initiative.name')
                     ->toggleable(isToggledHiddenByDefault: true),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1560

### Technical Description

Fix bug where we did not account for an Interaction User to not exist either in general or having been deleted.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
