### PR TITLE
[ADVAPP-1535]: Introduce reasoning effort as a configuration parameter for global administrators for the research advisor

### DIFF
--- a/app-modules/ai/database/migrations/2025_05_30_132953_add_research_assisstant_reasoning_effort_settings.php
+++ b/app-modules/ai/database/migrations/2025_05_30_132953_add_research_assisstant_reasoning_effort_settings.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 

--- a/app-modules/ai/database/migrations/2025_05_30_132953_add_research_assisstant_reasoning_effort_settings.php
+++ b/app-modules/ai/database/migrations/2025_05_30_132953_add_research_assisstant_reasoning_effort_settings.php
@@ -1,0 +1,20 @@
+<?php
+
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        try {
+            $this->migrator->add('ai_research_assistant.reasoning_effort', 'high');
+        } catch (SettingAlreadyExists $exception) {
+            // do nothing
+        }
+    }
+
+    public function down(): void
+    {
+        $this->migrator->deleteIfExists('ai_research_assistant.reasoning_effort');
+    }
+};

--- a/app-modules/ai/database/migrations/2025_05_30_132953_add_research_assisstant_reasoning_effort_settings.php
+++ b/app-modules/ai/database/migrations/2025_05_30_132953_add_research_assisstant_reasoning_effort_settings.php
@@ -41,7 +41,7 @@ return new class () extends SettingsMigration {
     public function up(): void
     {
         try {
-            $this->migrator->add('ai_research_assistant.reasoning_effort', 'high');
+            $this->migrator->add('ai_research_assistant.reasoning_effort', 'High');
         } catch (SettingAlreadyExists $exception) {
             // do nothing
         }

--- a/app-modules/ai/database/migrations/2025_05_30_132953_add_research_assisstant_reasoning_effort_settings.php
+++ b/app-modules/ai/database/migrations/2025_05_30_132953_add_research_assisstant_reasoning_effort_settings.php
@@ -41,7 +41,7 @@ return new class () extends SettingsMigration {
     public function up(): void
     {
         try {
-            $this->migrator->add('ai_research_assistant.reasoning_effort', 'High');
+            $this->migrator->add('ai_research_assistant.reasoning_effort', 'high');
         } catch (SettingAlreadyExists $exception) {
             // do nothing
         }

--- a/app-modules/ai/src/Enums/AiResearchReasoningEffort.php
+++ b/app-modules/ai/src/Enums/AiResearchReasoningEffort.php
@@ -40,11 +40,11 @@ use Filament\Support\Contracts\HasLabel;
 
 enum AiResearchReasoningEffort: string implements HasLabel
 {
-    case High = 'High';
+    case High = 'high';
 
-    case Medium = 'Medium';
+    case Medium = 'medium';
 
-    case Low = 'Low';
+    case Low = 'low';
 
     public function getLabel(): string
     {

--- a/app-modules/ai/src/Enums/AiResearchReasoningEffort.php
+++ b/app-modules/ai/src/Enums/AiResearchReasoningEffort.php
@@ -34,23 +34,20 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Ai\Settings;
+namespace AdvisingApp\Ai\Enums;
 
-use AdvisingApp\Ai\Enums\AiModel;
-use Spatie\LaravelSettings\Settings;
+use Filament\Support\Contracts\HasLabel;
 
-class AiResearchAssistantSettings extends Settings
+enum AiResearchReasoningEffort: string implements HasLabel
 {
-    public ?AiModel $discovery_model = null;
+    case High = 'High';
 
-    public ?AiModel $research_model = null;
+    case Medium = 'Medium';
 
-    public ?string $context = null;
+    case Low = 'Low';
 
-    public ?string $reasoning_effort = null;
-
-    public static function group(): string
+    public function getLabel(): string
     {
-        return 'ai_research_assistant';
+        return $this->name;
     }
 }

--- a/app-modules/ai/src/Filament/Pages/ManageAiResearchAssistantSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiResearchAssistantSettings.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Ai\Filament\Pages;
 
 use AdvisingApp\Ai\Enums\AiModel;
 use AdvisingApp\Ai\Enums\AiModelApplicabilityFeature;
+use AdvisingApp\Ai\Enums\AiResearchReasoningEffort;
 use AdvisingApp\Ai\Settings\AiResearchAssistantSettings;
 use App\Filament\Clusters\GlobalArtificialIntelligence;
 use App\Models\User;
@@ -80,6 +81,10 @@ class ManageAiResearchAssistantSettings extends SettingsPage
                     ->searchable()
                     ->helperText('Used for the generation of the research report.')
                     ->required(),
+                Select::make('reasoning_effort')
+                    ->options(AiResearchReasoningEffort::class)
+                    ->searchable()
+                    ->helperText('Constrains effort on reasoning for reasoning models. Currently supported values are low, medium, and high. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response.'),
                 Textarea::make('context')
                     ->rows(10)
                     ->label('Institutional Context'),

--- a/app-modules/ai/src/Settings/AiResearchAssistantSettings.php
+++ b/app-modules/ai/src/Settings/AiResearchAssistantSettings.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\Ai\Settings;
 
 use AdvisingApp\Ai\Enums\AiModel;
+use AdvisingApp\Ai\Enums\AiResearchReasoningEffort;
 use Spatie\LaravelSettings\Settings;
 
 class AiResearchAssistantSettings extends Settings
@@ -47,7 +48,7 @@ class AiResearchAssistantSettings extends Settings
 
     public ?string $context = null;
 
-    public ?string $reasoning_effort = null;
+    public AiResearchReasoningEffort $reasoning_effort = AiResearchReasoningEffort::High;
 
     public static function group(): string
     {

--- a/app-modules/research/src/Jobs/Research.php
+++ b/app-modules/research/src/Jobs/Research.php
@@ -78,6 +78,7 @@ class Research implements ShouldQueue
                         ['role' => 'user', 'content' => $this->getContent()],
                     ],
                     'temperature' => app(AiSettings::class)->temperature,
+                    'reasoning_effort' => app(AiResearchAssistantSettings::class)->reasoning_effort,
                 ],
                 'stream' => true,
                 'no_direct_answer' => true,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1535

### Technical Description

> Introduce reasoning effort as a configuration parameter for global administrators for the research advisor

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No
_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
