### PR TITLE
[ADVAPP-1442]: Certain reasoning models are generating an exception because they need reasoning effort be passed via the API

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2649,11 +2649,11 @@
             "dist": {
                 "type": "path",
                 "url": "app-modules/integration-open-ai",
-                "reference": "d0ce161a123ab5dc84105648b7adb32634a1edf3"
+                "reference": "62d3b8d09a947e8b4e2df9a950908e287e18bb74"
             },
             "require": {
                 "filament/filament": "^3.0.0",
-                "openai-php/client": "^v0.10"
+                "openai-php/client": "^v0.13"
             },
             "type": "library",
             "extra": {
@@ -10393,7 +10393,7 @@
         },
         {
             "name": "openai-php/client",
-            "version": "v0.10.3",
+            "version": "v0.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/openai-php/client.git",


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1442

### Technical Description

Upgrade `openai-php/client` to v0.13.0.

Add reasoning effort to institutional advisor.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
