### PR TITLE
[ADVAPP-1566]: Certain Engagement records are throwing errors for Product Student records

### DIFF
--- a/app-modules/engagement/resources/views/components/engagement-timeline-item.blade.php
+++ b/app-modules/engagement/resources/views/components/engagement-timeline-item.blade.php
@@ -71,7 +71,7 @@
 
     <div
         class="my-4 rounded-lg border-2 border-gray-200 p-2 text-base font-normal text-gray-500 dark:border-gray-800 dark:text-gray-400">
-        @if ($record->channel === NotificationChannel::Email && ! blank($record->subject))
+        @if ($record->channel === NotificationChannel::Email && !blank($record->subject))
             <div class="mb-2 flex flex-col">
                 <p class="text-xs text-gray-400 dark:text-gray-500">Subject:</p>
 

--- a/app-modules/engagement/resources/views/components/engagement-timeline-item.blade.php
+++ b/app-modules/engagement/resources/views/components/engagement-timeline-item.blade.php
@@ -71,7 +71,7 @@
 
     <div
         class="my-4 rounded-lg border-2 border-gray-200 p-2 text-base font-normal text-gray-500 dark:border-gray-800 dark:text-gray-400">
-        @if (!blank($record->subject))
+        @if ($record->channel === NotificationChannel::Email && ! blank($record->subject))
             <div class="mb-2 flex flex-col">
                 <p class="text-xs text-gray-400 dark:text-gray-500">Subject:</p>
 

--- a/app-modules/interaction/src/Filament/Concerns/HasManyMorphedInteractionsTrait.php
+++ b/app-modules/interaction/src/Filament/Concerns/HasManyMorphedInteractionsTrait.php
@@ -101,7 +101,7 @@ trait HasManyMorphedInteractionsTrait
             ->defaultSort('end_datetime', 'desc')
             ->columns([
                 TextColumn::make('subject')
-                    ->description(fn ($record) => $record->initiative->name . ' (' . $record->driver->name . ')')
+                    ->description(fn ($record) => $record->initiative?->name . ' (' . $record->driver?->name . ')')
                     ->icon(fn ($record) => $record->is_confidential ? 'heroicon-m-lock-closed' : null)
                     ->tooltip(fn ($record) => $record->is_confidential ? 'Confidential' : null),
                 TextColumn::make('type.name')

--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/EngagementsRelationManager.php
@@ -95,12 +95,13 @@ class EngagementsRelationManager extends RelationManager
                                             ->getStateUsing(function (Timeline $record): ?string {
                                                 $model = $record->timelineable;
 
-                                                if ($model instanceof Engagement) {
+                                                if ($model instanceof Engagement && $model->channel === NotificationChannel::Email) {
                                                     return (string) $model->getSubject();
                                                 }
 
                                                 return null;
                                             })
+                                            ->visible(fn (Timeline $record): bool => $record->timelineable instanceof Engagement && $record->timelineable->channel === NotificationChannel::Email)
                                             ->columnSpanFull(),
                                         EngagementBody::make('body')
                                             ->getStateUsing(fn (Timeline $record): HtmlString => $record->timelineable->getBody())

--- a/app-modules/timeline/src/Timelines/EngagementTimeline.php
+++ b/app-modules/timeline/src/Timelines/EngagementTimeline.php
@@ -86,7 +86,7 @@ class EngagementTimeline extends CustomTimeline
                 Fieldset::make('Content')
                     ->schema([
                         TextEntry::make('subject')
-                            ->hidden(fn ($state): bool => blank($state))
+                            ->visible(fn (Engagement $engagement): bool => $engagement->channel === NotificationChannel::Email)
                             ->getStateUsing(fn (Engagement $engagement): HtmlString => $engagement->getSubject())
                             ->columnSpanFull(),
                         EngagementBody::make('body')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1566

### Technical Description

Prevents issues with an SMS Engagement attempting to render subject even when it is null.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
