### PR TITLE
[ADVAPP-1543]: Introduce the model configuration for the custom advisor in global settings

### DIFF
--- a/app-modules/ai/database/migrations/2025_06_06_203819_add_ai_custom_advisor_settings.php
+++ b/app-modules/ai/database/migrations/2025_06_06_203819_add_ai_custom_advisor_settings.php
@@ -1,0 +1,32 @@
+<?php
+
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        $this->migrator->inGroup('ai-custom-advisor', function (SettingsBlueprint $blueprint) {
+            try {
+                $blueprint->add('allow_selection_of_model', true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $blueprint->add('preselected_model', null);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        $this->migrator->inGroup('ai-custom-advisor', function (SettingsBlueprint $blueprint) {
+            $blueprint->delete('allow_selection_of_model');
+            $blueprint->delete('preselected_model');
+        });
+    }
+};

--- a/app-modules/ai/src/Filament/Pages/ManageAiICustomAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiICustomAdvisorSettings.php
@@ -36,6 +36,8 @@
 
 namespace AdvisingApp\Ai\Filament\Pages;
 
+use AdvisingApp\Ai\Actions\ReInitializeAiServiceAssistant;
+use AdvisingApp\Ai\Actions\ResetAiServiceIdsForAssistant;
 use AdvisingApp\Ai\Enums\AiModel;
 use AdvisingApp\Ai\Enums\AiModelApplicabilityFeature;
 use AdvisingApp\Ai\Models\AiAssistant;
@@ -50,7 +52,9 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Pages\SettingsPage;
+use Filament\Support\Enums\MaxWidth;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
 
 class ManageAiICustomAdvisorSettings extends SettingsPage
@@ -97,6 +101,47 @@ class ManageAiICustomAdvisorSettings extends SettingsPage
             ->disabled(! Auth::user()->isSuperAdmin());
     }
 
+    public function getSaveFormAction(): Action
+    {
+        return parent::getSaveFormAction()
+            ->submit(null)
+            ->requiresConfirmation()
+            ->modalHeading('Sync all chats to this new service?')
+            ->modalDescription('If you are moving to a new account, you will need to sync all the data to the new service to minimize disruption. Advising App can do this for you, but if you just want to save the settings and do it yourself, you can choose to do so.')
+            ->modalWidth(MaxWidth::ThreeExtraLarge)
+            ->modalSubmitActionLabel('Save and sync all chats')
+            ->extraModalFooterActions([
+                Action::make('justSave')
+                    ->label('Just save the settings')
+                    ->color('gray')
+                    ->action(fn () => $this->save())
+                    ->cancelParentActions(),
+            ])
+            ->action(function (ResetAiServiceIdsForAssistant $resetAiServiceIds) {
+                $settings = app(AiCustomAdvisorSettings::class);
+
+                $model = ($settings->allow_selection_of_model) ? $this->form->getState()['model'] : $settings->preselected_model;
+
+                $newModel = AiModel::parse($model);
+
+                AiAssistant::query()
+                    ->where('is_default', false)
+                    ->each(function (AiAssistant $assistant) use ($newModel, $resetAiServiceIds) {
+                        $modelDeploymentIsShared = $assistant->model->isSharedDeployment($newModel);
+
+                        if (! $modelDeploymentIsShared) {
+                            DB::transaction(function () use ($assistant, $resetAiServiceIds) {
+                                $resetAiServiceIds($assistant);
+
+                                $assistant->save();
+                            });
+                        }
+                    });
+
+                $this->save();
+            });
+    }
+
     public function save(): void
     {
         if (! Auth::user()->isSuperAdmin()) {
@@ -129,8 +174,6 @@ class ManageAiICustomAdvisorSettings extends SettingsPage
 
     protected function afterSave(): void
     {
-        // TODO: Do I need to Reinitialize the AI Assistants
-
         $data = $this->mutateFormDataBeforeSave($this->form->getState());
 
         if (! ($data['allow_selection_of_model'] ?? true)) {
@@ -142,6 +185,12 @@ class ManageAiICustomAdvisorSettings extends SettingsPage
                     }
 
                     $assistant->update(['model' => $data['preselected_model']]);
+
+                    $modelDeploymentIsShared = $assistant->model->isSharedDeployment(AiModel::parse($data['preselected_model']));
+
+                    if (! $modelDeploymentIsShared) {
+                        app(ReInitializeAiServiceAssistant::class)($assistant);
+                    }
                 });
         }
     }

--- a/app-modules/ai/src/Filament/Pages/ManageAiICustomAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiICustomAdvisorSettings.php
@@ -51,6 +51,7 @@ use Filament\Forms\Form;
 use Filament\Forms\Get;
 use Filament\Pages\SettingsPage;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 class ManageAiICustomAdvisorSettings extends SettingsPage
 {
@@ -90,11 +91,7 @@ class ManageAiICustomAdvisorSettings extends SettingsPage
                     ->searchable()
                     ->helperText('This model will be the model used for custom advisors.')
                     ->required()
-                    // TODO: Fix this validation
-                    // ->in(array_map(
-                    //     fn (AiModel $model): string => $model->value,
-                    //     AiModelApplicabilityFeature::CustomAdvisors->getModels(),
-                    // ))
+                    ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::CustomAdvisors->getModels()))
                     ->visible(fn (Get $get): bool => ! $get('allow_selection_of_model')),
             ])
             ->disabled(! Auth::user()->isSuperAdmin());

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -40,6 +40,7 @@ use AdvisingApp\Ai\Enums\AiAssistantApplication;
 use AdvisingApp\Ai\Enums\AiModel;
 use AdvisingApp\Ai\Enums\AiModelApplicabilityFeature;
 use AdvisingApp\Ai\Models\AiAssistant;
+use AdvisingApp\Ai\Settings\AiCustomAdvisorSettings;
 use Filament\Forms\Components\Actions\Action;
 use Filament\Forms\Components\Component;
 use Filament\Forms\Components\FileUpload;
@@ -94,7 +95,17 @@ class AiAssistantForm
                     ->searchable()
                     ->required()
                     ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::CustomAdvisors->getModels()))
-                    ->visible(fn (Get $get): bool => filled($get('application'))),
+                    ->visible(fn (Get $get): bool => filled($get('application')))
+                    ->disabled(fn (): bool => ! app(AiCustomAdvisorSettings::class)->allow_selection_of_model)
+                    ->default(function () {
+                        $settings = app(AiCustomAdvisorSettings::class);
+
+                        if ($settings->allow_selection_of_model) {
+                            return null;
+                        }
+
+                        return $settings->preselected_model;
+                    }),
                 Textarea::make('description')
                     ->columnSpanFull()
                     ->required(),

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Pages/CreateAiAssistant.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Pages/CreateAiAssistant.php
@@ -39,6 +39,9 @@ namespace AdvisingApp\Ai\Filament\Resources\AiAssistantResource\Pages;
 use AdvisingApp\Ai\Filament\Resources\AiAssistantResource;
 use AdvisingApp\Ai\Filament\Resources\AiAssistantResource\Concerns\HandlesFileUploads;
 use AdvisingApp\Ai\Filament\Resources\AiAssistantResource\Forms\AiAssistantForm;
+use AdvisingApp\Ai\Models\AiAssistant;
+use AdvisingApp\Ai\Settings\AiCustomAdvisorSettings;
+use Exception;
 use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\CreateRecord;
@@ -59,6 +62,17 @@ class CreateAiAssistant extends CreateRecord
     protected function handleRecordCreation(array $data): Model
     {
         $record = new ($this->getModel())($data);
+
+        throw_if(
+            ! $record instanceof AiAssistant,
+            new Exception('The model must be an instance of AiAssistant.')
+        );
+
+        $settings = app(AiCustomAdvisorSettings::class);
+
+        if (! $settings->allow_selection_of_model) {
+            $record->model = $settings->preselected_model ?? $record->model;
+        }
 
         $aiService = $record->model->getService();
 

--- a/app-modules/ai/src/Settings/AiCustomAdvisorSettings.php
+++ b/app-modules/ai/src/Settings/AiCustomAdvisorSettings.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Ai\Settings;
+
+use AdvisingApp\Ai\Enums\AiModel;
+use Spatie\LaravelSettings\Settings;
+
+class AiCustomAdvisorSettings extends Settings
+{
+    public bool $allow_selection_of_model = true;
+
+    public ?AiModel $preselected_model = null;
+
+    public static function group(): string
+    {
+        return 'ai-custom-advisor';
+    }
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1543

### Technical Description

Add the ability to restrict whether or not Users can define the Model for custom assistants.

If the setting is modified it will make all Assistants use the new Model.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
