### PR TITLE
[ADVAPP-1558]: Customer reporting issue of unexpected html tags in sms

### DIFF
--- a/app-modules/engagement/src/Notifications/EngagementNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementNotification.php
@@ -81,7 +81,7 @@ class EngagementNotification extends Notification implements ShouldQueue, HasBef
     {
         return MailMessage::make()
             ->to($this->engagement->recipient_route)
-            ->subject($this->engagement->getSubject())
+            ->subject(strip_tags($this->engagement->getSubject()))
             ->greeting("Hello {$this->engagement->recipient->display_name}!")
             ->content($this->engagement->getBody());
     }
@@ -90,7 +90,7 @@ class EngagementNotification extends Notification implements ShouldQueue, HasBef
     {
         return TwilioMessage::make($notifiable)
             ->to($this->engagement->recipient_route)
-            ->content($this->engagement->getBodyMarkdown());
+            ->content(strip_tags($this->engagement->getBodyMarkdown()));
     }
 
     public function failed(?Throwable $exception): void


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1558

### Technical Description

Strips HTML tags when sending Enagements subjects and when sending SMS content.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
