### PR TITLE
[ADVAPP-1572]: Display the primary email and phone number in a second location on the prospect profile

### DIFF
--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Schemas/ProspectProfileInfolist.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Schemas/ProspectProfileInfolist.php
@@ -76,6 +76,10 @@ class ProspectProfileInfolist
                                     ->all())
                                 ->listWithLineBreaks()
                                 ->visible(fn (?array $state): bool => filled($state)),
+                            TextEntry::make('primaryEmailAddress')
+                                ->label('Primary Email Address')
+                                ->state(fn (Prospect $record): View => view('student-data-model::components.filament.resources.educatable-resource.view-educatable.email-address-detail', ['emailAddress' => $record->primaryEmailAddress]))
+                                ->visible(fn (?View $state): bool => filled($state)),
                             TextEntry::make('additionalEmailAddresses')
                                 ->label(fn (?array $state): string => Str::plural('Other email address', count($state ?? [])))
                                 ->state(fn (Prospect $record): array => array_map(
@@ -84,6 +88,10 @@ class ProspectProfileInfolist
                                 ))
                                 ->listWithLineBreaks()
                                 ->visible(fn (?array $state): bool => filled($state)),
+                            TextEntry::make('primaryPhoneNumber')
+                                ->label('Primary Phone Number')
+                                ->state(fn (Prospect $record): View => view('student-data-model::components.filament.resources.educatable-resource.view-educatable.phone-number-detail', ['phoneNumber' => $record->primaryPhoneNumber]))
+                                ->visible(fn (?View $state): bool => filled($state)),
                             TextEntry::make('additionalPhoneNumbers')
                                 ->label(fn (?array $state): string => Str::plural('Other phone number', count($state ?? [])))
                                 ->state(fn (Prospect $record): array => array_map(


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1572

### Technical Description

Display the primary email and phone number in a second location on the prospect profile

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
