### PR TITLE
[ADVAPP-1591]: Users not having profile images causes Azure to throw error to Sentry unnecessarily

### DIFF
--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -97,6 +97,7 @@ class SocialiteController extends Controller
         if ($provider === SocialiteProvider::Azure) {
             try {
                 $request = Http::withToken($socialiteUser->token)
+                    ->dontTruncateExceptions()
                     ->retry(3, 500)
                     ->get('https://graph.microsoft.com/v1.0/me/photo/$value')
                     ->throwIf(fn (Response $response) => $response->failed() && $response->status() !== 404);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1591

### Technical Description

Stops truncating the full exception so we can properly match and ignore the error.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
