### PR TITLE
[ADVAPP-1593]: When sending a message to the Response API ensure the Response object exists

### DIFF
--- a/app-modules/integration-open-ai/src/Services/OpenAiResponsesGptTestService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiResponsesGptTestService.php
@@ -55,6 +55,6 @@ class OpenAiResponsesGptTestService extends BaseOpenAiResponsesService
 
     public function getDeployment(): ?string
     {
-        return null;
+        return 'https://api.openai.com/v1';
     }
 }

--- a/app-modules/integration-open-ai/tests/Tenant/Feature/Services/OpenAiResponsesGptTestServiceTest.php
+++ b/app-modules/integration-open-ai/tests/Tenant/Feature/Services/OpenAiResponsesGptTestServiceTest.php
@@ -223,7 +223,7 @@ it('can complete a prompt', function () {
 
 it('can fetch a valid previous response ID for a message', function () {
     Http::fake([
-        '*/responses/resp_12345' => Http::response(['id' => 'resp_12345'], 200),
+        '*/responses/*' => Http::response(['id' => 'resp_12345'], 200),
     ]);
 
     asSuperAdmin();
@@ -256,7 +256,7 @@ it('can fetch a valid previous response ID for a message', function () {
 
 it('can discard an invalid previous response ID for a message', function () {
     Http::fake([
-        '*/responses/resp_12345' => Http::response(null, 404),
+        '*/responses/*' => Http::response(null, 404),
     ]);
 
     asSuperAdmin();

--- a/app-modules/integration-open-ai/tests/Tenant/Feature/Services/OpenAiResponsesGptTestServiceTest.php
+++ b/app-modules/integration-open-ai/tests/Tenant/Feature/Services/OpenAiResponsesGptTestServiceTest.php
@@ -42,6 +42,7 @@ use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiResponsesGptTestService;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Jobs\RecordTrackedEvent;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
 use Prism\Prism\Enums\FinishReason;
@@ -218,4 +219,70 @@ it('can complete a prompt', function () {
         ->toHaveCount(1)
         ->each
         ->toHaveProperties(['type' => TrackedEventType::AiExchange]);
+});
+
+it('can fetch a valid previous response ID for a message', function () {
+    Http::fake([
+        '*/responses/resp_12345' => Http::response(['id' => 'resp_12345'], 200),
+    ]);
+
+    asSuperAdmin();
+
+    $service = app(OpenAiResponsesGptTestService::class);
+
+    $previousAssistantResponse = AiMessage::factory()
+        ->for(AiThread::factory()
+            ->for(AiAssistant::factory()->state([
+                'application' => AiAssistantApplication::PersonalAssistant,
+                'is_default' => true,
+                'model' => AiModel::OpenAiGptTest,
+            ]), 'assistant'), 'thread')
+        ->create([
+            'message_id' => 'resp_12345',
+            'user_id' => null,
+        ]);
+
+    $message = AiMessage::factory()
+        ->for($previousAssistantResponse->thread, 'thread')
+        ->make();
+
+    $previousResponseId = $service->getMessagePreviousResponseId($message);
+
+    Http::assertSentCount(1);
+
+    expect($previousResponseId)
+        ->toBe('resp_12345');
+});
+
+it('can discard an invalid previous response ID for a message', function () {
+    Http::fake([
+        '*/responses/resp_12345' => Http::response(null, 404),
+    ]);
+
+    asSuperAdmin();
+
+    $service = app(OpenAiResponsesGptTestService::class);
+
+    $previousAssistantResponse = AiMessage::factory()
+        ->for(AiThread::factory()
+            ->for(AiAssistant::factory()->state([
+                'application' => AiAssistantApplication::PersonalAssistant,
+                'is_default' => true,
+                'model' => AiModel::OpenAiGptTest,
+            ]), 'assistant'), 'thread')
+        ->create([
+            'message_id' => 'resp_12345',
+            'user_id' => null,
+        ]);
+
+    $message = AiMessage::factory()
+        ->for($previousAssistantResponse->thread, 'thread')
+        ->make();
+
+    $previousResponseId = $service->getMessagePreviousResponseId($message);
+
+    Http::assertSentCount(1);
+
+    expect($previousResponseId)
+        ->toBeNull();
 });


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1593

### Technical Description

Makes an API request to check the validity of a response before using it for the next request.

Fixes an issue where user messages are not saved correctly when using the responses API.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
