### PR TITLE
[ADVAPP-1602]: Enhance security by eliminating reveal ability on previously entered API keys for cognitive services as a global administrator

### DIFF
--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
@@ -342,7 +342,9 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->maxLength(255)
                                     ->nullable(),
                                 TextInput::make('jina_deepsearch_v1_api_key')
-                                    ->label('API Key'),
+                                    ->label('API Key')
+                                    ->password()
+                                    ->autocomplete(false),
                                 Select::make('jina_deepsearch_v1_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1602

### Technical Description

> Enhance security by eliminating reveal ability on previously entered API keys for cognitive services as a global administrator.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
