### PR TITLE
[ADVAPP-1625]: Replace theiconic/name-parser implementation with our implementation in common

### DIFF
--- a/app-modules/engagement/src/Models/Engagement.php
+++ b/app-modules/engagement/src/Models/Engagement.php
@@ -57,6 +57,7 @@ use AdvisingApp\Timeline\Models\Timeline;
 use AdvisingApp\Timeline\Timelines\EngagementTimeline;
 use App\Models\BaseModel;
 use App\Models\User;
+use CanyonGBS\Common\Parser\Parser;
 use Exception;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
@@ -72,7 +73,6 @@ use League\HTMLToMarkdown\HtmlConverter;
 use OwenIt\Auditing\Contracts\Auditable;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
-use TheIconic\NameParser\Parser;
 
 /**
  * @property-read ?Educatable $recipient

--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,6 @@
         "stechstudio/filament-impersonate": "^3.5",
         "talkroute/message-segment-calculator": "^1.0",
         "tapp/filament-timezone-field": "^3.0",
-        "theiconic/name-parser": "^1.2",
         "tpetry/laravel-postgresql-enhanced": "^3.0",
         "twilio/sdk": "^8.5.0",
         "ysfkaya/filament-phone-input": "^3.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e57e8e06bd98c5b3ab17664e45491411",
+    "content-hash": "3a2d90c21d654200ae61eaf45d7b0428",
     "packages": [
         {
             "name": "amphp/amp",
@@ -18699,54 +18699,6 @@
                 "source": "https://github.com/TappNetwork/filament-timezone-field"
             },
             "time": "2025-04-02T20:08:38+00:00"
-        },
-        {
-            "name": "theiconic/name-parser",
-            "version": "v1.2.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theiconic/name-parser.git",
-                "reference": "9a54a713bf5b2e7fd990828147d42de16bf8a253"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theiconic/name-parser/zipball/9a54a713bf5b2e7fd990828147d42de16bf8a253",
-                "reference": "9a54a713bf5b2e7fd990828147d42de16bf8a253",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "php-mock/php-mock-phpunit": "^2.1",
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "TheIconic\\NameParser\\": [
-                        "src/",
-                        "tests/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "The Iconic",
-                    "email": "engineering@theiconic.com.au"
-                }
-            ],
-            "description": "PHP library for parsing a string containing a full name into its parts",
-            "support": {
-                "issues": "https://github.com/theiconic/name-parser/issues",
-                "source": "https://github.com/theiconic/name-parser/tree/v1.2.11"
-            },
-            "time": "2019-11-14T14:08:48+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1625

### Technical Description

> Remove TheIconic NameParser dependency as it's added in common package.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
