### PR TITLE
[ADVAPP-1617]: Resolve the security issue tracked under CVE-2025-6545 & [ADVAPP-1618]: Resolve the security issue tracked under CVE-2025-6547

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         "tapp/filament-timezone-field": "^3.0",
         "tpetry/laravel-postgresql-enhanced": "^3.0",
         "twilio/sdk": "^8.5.0",
-        "ysfkaya/filament-phone-input": "^3.1"
+        "ysfkaya/filament-phone-input": "^3.2.2"
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a2d90c21d654200ae61eaf45d7b0428",
+    "content-hash": "d63a62d5775bc43e4482c890f7d800a9",
     "packages": [
         {
             "name": "amphp/amp",
@@ -19164,36 +19164,36 @@
         },
         {
             "name": "ysfkaya/filament-phone-input",
-            "version": "v3.1.9",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ysfkaya/filament-phone-input.git",
-                "reference": "346c63ced11585c580cb46d588275d72238ca0dd"
+                "reference": "797b8826b0defc646969cb4146b5a31b84652c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ysfkaya/filament-phone-input/zipball/346c63ced11585c580cb46d588275d72238ca0dd",
-                "reference": "346c63ced11585c580cb46d588275d72238ca0dd",
+                "url": "https://api.github.com/repos/ysfkaya/filament-phone-input/zipball/797b8826b0defc646969cb4146b5a31b84652c3c",
+                "reference": "797b8826b0defc646969cb4146b5a31b84652c3c",
                 "shasum": ""
             },
             "require": {
                 "filament/filament": "^3.0",
                 "php": "^8.1",
-                "propaganistas/laravel-phone": "^5.0",
-                "spatie/laravel-package-tools": "^1.16"
+                "propaganistas/laravel-phone": "^5.0|^6.0",
+                "spatie/laravel-package-tools": "^1.92"
             },
             "require-dev": {
                 "laravel/pint": "^1.0",
-                "nunomaduro/collision": "^7.9",
-                "nunomaduro/larastan": "^2.0.1",
-                "orchestra/testbench-dusk": "^8.0",
-                "pestphp/pest": "^2.0",
-                "pestphp/pest-plugin-arch": "^2.0",
-                "pestphp/pest-plugin-laravel": "^2.0",
-                "pestphp/pest-plugin-livewire": "^2.1",
+                "nunomaduro/collision": "^7.9|^8.1",
+                "nunomaduro/larastan": "^2.0|^3.0",
+                "orchestra/testbench-dusk": "^8.0|^9.0|^10.0",
+                "pestphp/pest": "^2.0|^3.0",
+                "pestphp/pest-plugin-arch": "^2.0|^3.0",
+                "pestphp/pest-plugin-laravel": "^2.0|^3.0",
+                "pestphp/pest-plugin-livewire": "^2.1|^3.0",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.0"
+                "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
+                "phpstan/phpstan-phpunit": "^1.0|^2.0"
             },
             "type": "library",
             "extra": {
@@ -19222,9 +19222,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ysfkaya/filament-phone-input/issues",
-                "source": "https://github.com/ysfkaya/filament-phone-input/tree/v3.1.9"
+                "source": "https://github.com/ysfkaya/filament-phone-input/tree/v3.2.2"
             },
-            "time": "2025-05-28T09:13:32+00:00"
+            "time": "2025-06-29T11:33:18+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1617
- https://canyongbs.atlassian.net/browse/ADVAPP-1618

### Technical Description

Update `ysfkaya/filament-phone-input` in `composer.json` and our lock file to go to the updated version without a reference to a package with CVE within its JavaScript developer dependencies.

We were not vulnerable to this vulnerability, as it was not installed on our system; it was only referenced in this downstream dependency as a JavaScript developer dependency. Updating to silence scanners.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
