### PR TITLE
[ADVAPP-1678]: Add a Custom Advisors report as coming soon under Artificial Intelligence following the Utilization report

### DIFF
--- a/app-modules/report/src/Filament/Pages/CustomAdvisorReport.php
+++ b/app-modules/report/src/Filament/Pages/CustomAdvisorReport.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Report\Filament\Pages;
+
+use AdvisingApp\Report\Abstract\AiReport;
+use App\Filament\Clusters\ReportLibrary;
+
+class CustomAdvisorReport extends AiReport
+{
+    protected static ?string $cluster = ReportLibrary::class;
+
+    protected static ?string $navigationGroup = 'Artificial Intelligence';
+
+    protected static ?string $title = 'Custom Advisor';
+
+    protected static string $routePath = 'custom-advisor-report';
+
+    protected static ?int $navigationSort = 30;
+
+    protected string $cacheTag = 'custom-advisor-report';
+
+    protected static string $view = 'filament.pages.coming-soon';
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1678

### Technical Description

> Add a Custom Advisors report as coming soon under Artificial Intelligence following the Utilization report

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
