### PR TITLE
[ADVAPP-1667]: Improve the navigation by renaming product administration to a more commonly understood name of settings

### DIFF
--- a/app-modules/ai/src/Policies/PromptTypePolicy.php
+++ b/app-modules/ai/src/Policies/PromptTypePolicy.php
@@ -39,7 +39,7 @@ namespace AdvisingApp\Ai\Policies;
 use AdvisingApp\Ai\Models\PromptType;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use App\Concerns\PerformsLicenseChecks;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -59,7 +59,7 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view prompt types.'
@@ -74,7 +74,7 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, PromptType $promptType): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.view'],
                 denyResponse: 'You do not have permission to view this prompt type.'
@@ -89,7 +89,7 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create prompt types.'
@@ -108,7 +108,7 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
             return Response::deny('The prompt type cannot be updated because it has a smart prompt.');
         }
 
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.update'],
                 denyResponse: 'You do not have permission to update this prompt type.'
@@ -127,7 +127,7 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
             return Response::deny('The prompt type cannot be deleted because it is associated with a prompt.');
         }
 
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.delete'],
                 denyResponse: 'You do not have permission to delete this prompt type.'
@@ -142,7 +142,7 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, PromptType $promptType): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.restore'],
                 denyResponse: 'You do not have permission to restore this prompt type.'
@@ -161,7 +161,7 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
             return Response::deny('The prompt type cannot be deleted because it is associated with a prompt.');
         }
 
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.force-delete'],
                 denyResponse: 'You do not have permission to permanently delete this prompt type.'

--- a/app-modules/ai/src/Policies/PromptTypePolicy.php
+++ b/app-modules/ai/src/Policies/PromptTypePolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Ai\Policies;
 use AdvisingApp\Ai\Models\PromptType;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use App\Concerns\PerformsLicenseChecks;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -58,6 +59,13 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view prompt types.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view prompt types.'
@@ -66,6 +74,13 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, PromptType $promptType): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.view'],
+                denyResponse: 'You do not have permission to view this prompt type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$promptType->getKey()}.view"],
             denyResponse: 'You do not have permission to view this prompt type.'
@@ -74,6 +89,13 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create prompt types.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create prompt types.'
@@ -84,6 +106,13 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
     {
         if ($promptType->prompts()->where('is_smart', true)->exists()) {
             return Response::deny('The prompt type cannot be updated because it has a smart prompt.');
+        }
+
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update this prompt type.'
+            );
         }
 
         return $authenticatable->canOrElse(
@@ -98,6 +127,13 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
             return Response::deny('The prompt type cannot be deleted because it is associated with a prompt.');
         }
 
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permission to delete this prompt type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$promptType->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this prompt type.'
@@ -106,6 +142,13 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, PromptType $promptType): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permission to restore this prompt type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$promptType->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this prompt type.'
@@ -116,6 +159,13 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
     {
         if ($promptType->prompts()->exists()) {
             return Response::deny('The prompt type cannot be deleted because it is associated with a prompt.');
+        }
+
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permission to permanently delete this prompt type.'
+            );
         }
 
         return $authenticatable->canOrElse(

--- a/app-modules/ai/src/Policies/PromptTypePolicy.php
+++ b/app-modules/ai/src/Policies/PromptTypePolicy.php
@@ -65,7 +65,7 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
                 denyResponse: 'You do not have permission to view prompt types.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view prompt types.'

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptTypeResource/CreatePromptTypeTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptTypeResource/CreatePromptTypeTest.php
@@ -51,9 +51,9 @@ $licenses = [
 ];
 
 $permissions = [
-    'product_admin.view-any',
-    'product_admin.create',
-    'product_admin.*.view',
+    'settings.view-any',
+    'settings.create',
+    'settings.*.view',
 ];
 
 it('cannot render without a license', function () use ($permissions) {

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptTypeResource/EditPromptTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptTypeResource/EditPromptTest.php
@@ -53,11 +53,11 @@ $licenses = [
 ];
 
 $permissions = [
-    'product_admin.view-any',
-    'product_admin.create',
-    'product_admin.*.view',
-    'product_admin.*.update',
-    'product_admin.*.delete',
+    'settings.view-any',
+    'settings.create',
+    'settings.*.view',
+    'settings.*.update',
+    'settings.*.delete',
 ];
 
 it('cannot render without a license', function () use ($permissions) {

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptTypeResource/ListPromptTypesTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptTypeResource/ListPromptTypesTest.php
@@ -50,9 +50,9 @@ $licenses = [
 ];
 
 $permissions = [
-    'product_admin.view-any',
-    'product_admin.create',
-    'product_admin.*.view',
+    'settings.view-any',
+    'settings.create',
+    'settings.*.view',
 ];
 
 it('cannot render without a license', function () use ($permissions) {

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptTypeResource/ViewPromptTypeTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptTypeResource/ViewPromptTypeTest.php
@@ -51,9 +51,9 @@ $licenses = [
 ];
 
 $permissions = [
-    'product_admin.view-any',
-    'product_admin.create',
-    'product_admin.*.view',
+    'settings.view-any',
+    'settings.create',
+    'settings.*.view',
 ];
 
 it('cannot render without a license', function () use ($permissions) {

--- a/app-modules/alert/src/Policies/AlertStatusPolicy.php
+++ b/app-modules/alert/src/Policies/AlertStatusPolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Alert\Policies;
 use AdvisingApp\Alert\Models\AlertStatus;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,13 @@ class AlertStatusPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view alert statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view alert statuses.'
@@ -63,6 +71,13 @@ class AlertStatusPolicy
 
     public function view(Authenticatable $authenticatable, AlertStatus $alertStatus): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this alert status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$alertStatus->getKey()}.view"],
             denyResponse: 'You do not have permission to view this alert status.'
@@ -71,6 +86,13 @@ class AlertStatusPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create alert statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create alert statuses.'
@@ -79,6 +101,13 @@ class AlertStatusPolicy
 
     public function update(Authenticatable $authenticatable, AlertStatus $alertStatus): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update this alert status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$alertStatus->getKey()}.update"],
             denyResponse: 'You do not have permission to update this alert status.'
@@ -91,6 +120,13 @@ class AlertStatusPolicy
             return Response::deny('You cannot delete this alert status because this status is associated with active alerts.');
         }
 
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permission to delete this alert status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$alertStatus->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this alert status.'
@@ -99,6 +135,13 @@ class AlertStatusPolicy
 
     public function restore(Authenticatable $authenticatable, AlertStatus $alertStatus): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permission to restore this alert status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$alertStatus->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this alert status.'
@@ -109,6 +152,13 @@ class AlertStatusPolicy
     {
         if (count($alertStatus->alerts) > 0) {
             return Response::deny('You cannot delete this alert status because this status is associated with active alerts.');
+        }
+
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permission to permanently delete this alert status.'
+            );
         }
 
         return $authenticatable->canOrElse(

--- a/app-modules/application/src/Policies/ApplicationSubmissionStatePolicy.php
+++ b/app-modules/application/src/Policies/ApplicationSubmissionStatePolicy.php
@@ -39,7 +39,7 @@ namespace AdvisingApp\Application\Policies;
 use AdvisingApp\Application\Models\ApplicationSubmissionState;
 use App\Concerns\PerformsFeatureChecks;
 use App\Enums\Feature;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use App\Support\FeatureAccessResponse;
@@ -63,7 +63,7 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view states.'
@@ -78,7 +78,7 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function view(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this state.'
@@ -93,7 +93,7 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create states.'
@@ -108,7 +108,7 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function update(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this state.'
@@ -123,7 +123,7 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function delete(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this state.'
@@ -138,7 +138,7 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function restore(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this state.'
@@ -153,7 +153,7 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function forceDelete(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this state.'

--- a/app-modules/application/src/Policies/ApplicationSubmissionStatePolicy.php
+++ b/app-modules/application/src/Policies/ApplicationSubmissionStatePolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Application\Policies;
 use AdvisingApp\Application\Models\ApplicationSubmissionState;
 use App\Concerns\PerformsFeatureChecks;
 use App\Enums\Feature;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use App\Support\FeatureAccessResponse;
@@ -62,6 +63,13 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view states.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.view-any'],
             denyResponse: 'You do not have permission to view states.'
@@ -70,6 +78,13 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function view(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this state.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.view"],
             denyResponse: 'You do not have permission to view this state.'
@@ -78,6 +93,13 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create states.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create states.'
@@ -86,6 +108,13 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function update(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this state.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.update"],
             denyResponse: 'You do not have permission to update this state.'
@@ -94,6 +123,13 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function delete(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this state.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this state.'
@@ -102,6 +138,13 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function restore(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this state.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this state.'
@@ -110,6 +153,13 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
 
     public function forceDelete(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this state.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this state.'

--- a/app-modules/application/src/Policies/ApplicationSubmissionStatePolicy.php
+++ b/app-modules/application/src/Policies/ApplicationSubmissionStatePolicy.php
@@ -65,7 +65,7 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
     {
         if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: 'settings.*.view',
+                abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view states.'
             );
         }
@@ -159,7 +159,7 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
                 denyResponse: 'You do not have permission to permanently delete this state.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this state.'

--- a/app-modules/basic-needs/src/Policies/BasicNeedsCategoryPolicy.php
+++ b/app-modules/basic-needs/src/Policies/BasicNeedsCategoryPolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\BasicNeeds\Policies;
 use AdvisingApp\BasicNeeds\Models\BasicNeedsCategory;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,13 @@ class BasicNeedsCategoryPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view basic needs categories.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view basic needs categories.'
@@ -63,6 +71,13 @@ class BasicNeedsCategoryPolicy
 
     public function view(Authenticatable $authenticatable, BasicNeedsCategory $basicNeedsCategory): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this basic needs category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsCategory->getKey()}.view"],
             denyResponse: 'You do not have permission to view this basic needs category.'
@@ -71,6 +86,13 @@ class BasicNeedsCategoryPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create basic needs categories.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create basic needs categories.'
@@ -79,6 +101,13 @@ class BasicNeedsCategoryPolicy
 
     public function update(Authenticatable $authenticatable, BasicNeedsCategory $basicNeedsCategory): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update this basic needs category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsCategory->getKey()}.update"],
             denyResponse: 'You do not have permission to update this basic needs category.'
@@ -87,6 +116,13 @@ class BasicNeedsCategoryPolicy
 
     public function delete(Authenticatable $authenticatable, BasicNeedsCategory $basicNeedsCategory): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permission to delete this basic needs category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsCategory->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this basic needs category.'
@@ -95,6 +131,13 @@ class BasicNeedsCategoryPolicy
 
     public function restore(Authenticatable $authenticatable, BasicNeedsCategory $basicNeedsCategory): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permission to restore this basic needs category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsCategory->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this basic needs category.'
@@ -103,6 +146,13 @@ class BasicNeedsCategoryPolicy
 
     public function forceDelete(Authenticatable $authenticatable, BasicNeedsCategory $basicNeedsCategory): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permission to force delete this basic needs category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsCategory->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to force delete this basic needs category.'

--- a/app-modules/basic-needs/src/Policies/BasicNeedsProgramPolicy.php
+++ b/app-modules/basic-needs/src/Policies/BasicNeedsProgramPolicy.php
@@ -62,6 +62,7 @@ class BasicNeedsProgramPolicy
                 denyResponse: 'You do not have permission to view basic needs programs.'
             );
         }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view basic needs programs.'
@@ -76,6 +77,7 @@ class BasicNeedsProgramPolicy
                 denyResponse: 'You do not have permission to view this basic needs program.'
             );
         }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsProgram->getKey()}.view"],
             denyResponse: 'You do not have permission to view this basic needs program.'

--- a/app-modules/basic-needs/src/Policies/BasicNeedsProgramPolicy.php
+++ b/app-modules/basic-needs/src/Policies/BasicNeedsProgramPolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\BasicNeeds\Policies;
 use AdvisingApp\BasicNeeds\Models\BasicNeedsProgram;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,12 @@ class BasicNeedsProgramPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view basic needs programs.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view basic needs programs.'
@@ -63,6 +70,12 @@ class BasicNeedsProgramPolicy
 
     public function view(Authenticatable $authenticatable, BasicNeedsProgram $basicNeedsProgram): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this basic needs program.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsProgram->getKey()}.view"],
             denyResponse: 'You do not have permission to view this basic needs program.'
@@ -71,6 +84,13 @@ class BasicNeedsProgramPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create basic needs programs.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create basic needs programs.'
@@ -79,6 +99,13 @@ class BasicNeedsProgramPolicy
 
     public function update(Authenticatable $authenticatable, BasicNeedsProgram $basicNeedsProgram): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update this basic needs program.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsProgram->getKey()}.update"],
             denyResponse: 'You do not have permission to update this basic needs program.'
@@ -87,6 +114,13 @@ class BasicNeedsProgramPolicy
 
     public function delete(Authenticatable $authenticatable, BasicNeedsProgram $basicNeedsProgram): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permission to delete this basic needs program.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsProgram->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this basic needs program.'
@@ -95,6 +129,13 @@ class BasicNeedsProgramPolicy
 
     public function restore(Authenticatable $authenticatable, BasicNeedsProgram $basicNeedsProgram): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permission to restore this basic needs program.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsProgram->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this basic needs program.'
@@ -103,6 +144,13 @@ class BasicNeedsProgramPolicy
 
     public function forceDelete(Authenticatable $authenticatable, BasicNeedsProgram $basicNeedsProgram): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permission to force delete this basic needs program.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$basicNeedsProgram->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to force delete this basic needs program.'

--- a/app-modules/basic-needs/tests/Tenant/BasicNeedsCategory/BasicNeedsCategoryTest.php
+++ b/app-modules/basic-needs/tests/Tenant/BasicNeedsCategory/BasicNeedsCategoryTest.php
@@ -56,7 +56,7 @@ it('can render list page', function () {
             BasicNeedsCategoryResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)->get(BasicNeedsCategoryResource::getUrl('index'))
         ->assertSuccessful();
@@ -67,7 +67,7 @@ it('can render data in list page', function () {
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     $basicNeedsCategories = BasicNeedsCategory::factory()->count(10)->create();
 
@@ -84,8 +84,8 @@ it('can render create page', function () {
             BasicNeedsCategoryResource::getUrl('create')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)->get(BasicNeedsCategoryResource::getUrl('create'))
         ->assertSuccessful();
@@ -99,8 +99,8 @@ it('can validate input on create page', function () {
             BasicNeedsCategoryResource::getUrl('create')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     livewire(CreateBasicNeedsCategory::class)
         ->fillForm([
@@ -115,8 +115,8 @@ it('can create basic needs catgory', function () {
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     $basicNeedsCategory = BasicNeedsCategory::factory()->make();
 
@@ -144,8 +144,8 @@ it('can render edit page', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)->get(BasicNeedsCategoryResource::getUrl('edit', [
         'record' => $basicNeedsCategory->getRouteKey(),
@@ -162,8 +162,8 @@ it('can retrieve data', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     livewire(EditBasicNeedsCategory::class, [
         'record' => $basicNeedsCategory->getRouteKey(),
@@ -184,8 +184,8 @@ it('can validate input on edit page', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     livewire(EditBasicNeedsCategory::class, [
         'record' => $basicNeedsCategory->getRouteKey(),
@@ -208,8 +208,8 @@ it('can save basic needs category', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     livewire(EditBasicNeedsCategory::class, [
         'record' => $oldBasicNeedsCategory->getRouteKey(),
@@ -236,8 +236,8 @@ it('can render view page', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)->get(BasicNeedsCategoryResource::getUrl('view', [
         'record' => $basicNeedsCategory->getRouteKey(),
@@ -254,9 +254,9 @@ it('can delete basic needs category', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
-    $user->givePermissionTo('product_admin.*.delete');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
+    $user->givePermissionTo('settings.*.delete');
 
     livewire(EditBasicNeedsCategory::class, [
         'record' => $basicNeedsCategory->getRouteKey(),
@@ -277,9 +277,9 @@ it('can bulk delete basic needs categories', function () {
             BasicNeedsCategoryResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
-    $user->givePermissionTo('product_admin.*.delete');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
+    $user->givePermissionTo('settings.*.delete');
 
     livewire(ListBasicNeedsCategories::class)
         ->set('tableRecordsPerPage', 10)

--- a/app-modules/basic-needs/tests/Tenant/BasicNeedsProgram/BasicNeedsProgramTest.php
+++ b/app-modules/basic-needs/tests/Tenant/BasicNeedsProgram/BasicNeedsProgramTest.php
@@ -57,7 +57,7 @@ it('can render list page', function () {
             BasicNeedsProgramResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)->get(BasicNeedsProgramResource::getUrl('index'))
         ->assertSuccessful();
@@ -68,7 +68,7 @@ it('can render data in list page', function () {
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     $basicNeedsPrograms = BasicNeedsProgram::factory()->count(10)->create();
 
@@ -85,8 +85,8 @@ it('can render create page', function () {
             BasicNeedsProgramResource::getUrl('create')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)->get(BasicNeedsProgramResource::getUrl('create'))
         ->assertSuccessful();
@@ -100,8 +100,8 @@ it('can validate input on create page', function () {
             BasicNeedsProgramResource::getUrl('create')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     livewire(CreateBasicNeedsProgram::class)
         ->fillForm([
@@ -117,8 +117,8 @@ it('can create basic needs program', function () {
 
     actingAs($user);
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     $newBasicNeedsProgram = BasicNeedsProgram::factory()->make();
 
@@ -162,8 +162,8 @@ it('can render edit page', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)->get(BasicNeedsProgramResource::getUrl('edit', [
         'record' => $basicNeedsProgram->getRouteKey(),
@@ -180,8 +180,8 @@ it('can retrieve data', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     livewire(EditBasicNeedsProgram::class, [
         'record' => $basicNeedsProgram->getRouteKey(),
@@ -210,8 +210,8 @@ it('can validate input on edit page', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     livewire(EditBasicNeedsProgram::class, [
         'record' => $basicNeedsProgram->getRouteKey(),
@@ -235,8 +235,8 @@ it('can save basic needs program', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     livewire(EditBasicNeedsProgram::class, [
         'record' => $oldBasicNeedsProgram->getRouteKey(),
@@ -279,8 +279,8 @@ it('can render view page', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)->get(BasicNeedsProgramResource::getUrl('view', [
         'record' => $basicNeedsProgram->getRouteKey(),
@@ -297,9 +297,9 @@ it('can delete basic needs program', function () {
         ])
     )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
-    $user->givePermissionTo('product_admin.*.delete');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
+    $user->givePermissionTo('settings.*.delete');
 
     livewire(EditBasicNeedsProgram::class, [
         'record' => $basicNeedsProgram->getRouteKey(),
@@ -320,9 +320,9 @@ it('can bulk delete basic needs programs', function () {
             BasicNeedsProgramResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
-    $user->givePermissionTo('product_admin.*.delete');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
+    $user->givePermissionTo('settings.*.delete');
 
     livewire(ListBasicNeedsPrograms::class)
         ->set('tableRecordsPerPage', 10)
@@ -343,7 +343,7 @@ it('can filter basic needs program by `program category`', function () {
             BasicNeedsProgramResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     livewire(ListBasicNeedsPrograms::class)
         ->set('tableRecordsPerPage', 10)

--- a/app-modules/care-team/src/Filament/Resources/ProspectCareTeamRoleResource.php
+++ b/app-modules/care-team/src/Filament/Resources/ProspectCareTeamRoleResource.php
@@ -42,6 +42,7 @@ use AdvisingApp\CareTeam\Filament\Resources\ProspectCareTeamRoleResource\Pages\L
 use AdvisingApp\CareTeam\Filament\Resources\ProspectCareTeamRoleResource\Pages\ViewProspectCareTeamRole;
 use AdvisingApp\CareTeam\Models\CareTeamRole;
 use App\Enums\CareTeamRoleType;
+use App\Features\SettingsPermissions;
 use App\Filament\Clusters\ConstituentManagement;
 use App\Models\User;
 use Filament\Resources\Resource;
@@ -66,7 +67,7 @@ class ProspectCareTeamRoleResource extends Resource
         /** @var User $user */
         $user = auth()->user();
 
-        return $user->can(['product_admin.view-any']);
+        return SettingsPermissions::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
     }
 
     /**

--- a/app-modules/care-team/src/Filament/Resources/StudentCareTeamRoleResource.php
+++ b/app-modules/care-team/src/Filament/Resources/StudentCareTeamRoleResource.php
@@ -42,6 +42,7 @@ use AdvisingApp\CareTeam\Filament\Resources\StudentCareTeamRoleResource\Pages\Li
 use AdvisingApp\CareTeam\Filament\Resources\StudentCareTeamRoleResource\Pages\ViewStudentCareTeamRole;
 use AdvisingApp\CareTeam\Models\CareTeamRole;
 use App\Enums\CareTeamRoleType;
+use App\Features\SettingsPermissions;
 use App\Filament\Clusters\ConstituentManagement;
 use App\Models\User;
 use Filament\Resources\Resource;
@@ -66,7 +67,7 @@ class StudentCareTeamRoleResource extends Resource
         /** @var User $user */
         $user = auth()->user();
 
-        return $user->can(['product_admin.view-any']);
+        return SettingsPermissions::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
     }
 
     /**

--- a/app-modules/care-team/src/Policies/CareTeamRolePolicy.php
+++ b/app-modules/care-team/src/Policies/CareTeamRolePolicy.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\CareTeam\Policies;
 
 use AdvisingApp\CareTeam\Models\CareTeamRole;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -44,6 +45,13 @@ class CareTeamRolePolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view care team roles.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view care team roles.'
@@ -52,6 +60,13 @@ class CareTeamRolePolicy
 
     public function view(Authenticatable $authenticatable, CareTeamRole $careTeamRole): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this care team role.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.view'],
             denyResponse: 'You do not have permission to view this care team role.'
@@ -60,6 +75,13 @@ class CareTeamRolePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create care team roles.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create care team roles.'
@@ -68,6 +90,13 @@ class CareTeamRolePolicy
 
     public function update(Authenticatable $authenticatable, CareTeamRole $careTeamRole): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update this care team role.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.update'],
             denyResponse: 'You do not have permission to update this care team role.'
@@ -76,6 +105,13 @@ class CareTeamRolePolicy
 
     public function delete(Authenticatable $authenticatable, CareTeamRole $careTeamRole): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permission to delete this care team role.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.delete'],
             denyResponse: 'You do not have permission to delete this care team role.'
@@ -84,6 +120,13 @@ class CareTeamRolePolicy
 
     public function restore(Authenticatable $authenticatable, CareTeamRole $careTeamRole): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permission to restore this care team role.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.restore'],
             denyResponse: 'You do not have permission to restore this care team role.'
@@ -92,6 +135,13 @@ class CareTeamRolePolicy
 
     public function forceDelete(Authenticatable $authenticatable, CareTeamRole $careTeamRole): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permission to permanently delete this care team role.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this care team role.'

--- a/app-modules/care-team/src/Policies/CareTeamRolePolicy.php
+++ b/app-modules/care-team/src/Policies/CareTeamRolePolicy.php
@@ -51,7 +51,7 @@ class CareTeamRolePolicy
                 denyResponse: 'You do not have permission to view care team roles.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view care team roles.'
@@ -141,7 +141,7 @@ class CareTeamRolePolicy
                 denyResponse: 'You do not have permission to permanently delete this care team role.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this care team role.'

--- a/app-modules/care-team/tests/Tenant/ProspectCareTeamRole/CreateProspectCareTeamRoleTest.php
+++ b/app-modules/care-team/tests/Tenant/ProspectCareTeamRole/CreateProspectCareTeamRoleTest.php
@@ -60,8 +60,8 @@ test('CreateProspectCareTeamRole is gated with proper access control', function 
     livewire(CreateProspectCareTeamRole::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/care-team/tests/Tenant/ProspectCareTeamRole/EditProspectCareTeamRoleTest.php
+++ b/app-modules/care-team/tests/Tenant/ProspectCareTeamRole/EditProspectCareTeamRoleTest.php
@@ -65,8 +65,8 @@ test('EditProspectCareTeamRole is gated with proper access control', function ()
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/care-team/tests/Tenant/ProspectCareTeamRole/ListProspectCareTeamRoleTest.php
+++ b/app-modules/care-team/tests/Tenant/ProspectCareTeamRole/ListProspectCareTeamRoleTest.php
@@ -53,7 +53,7 @@ test('ListProspectCareTeamRole is gated with proper access control', function ()
             ProspectCareTeamRoleResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/care-team/tests/Tenant/ProspectCareTeamRole/ViewProspectCareTeamRoleTest.php
+++ b/app-modules/care-team/tests/Tenant/ProspectCareTeamRole/ViewProspectCareTeamRoleTest.php
@@ -55,8 +55,8 @@ test('ViewProspectCareTeamRole is gated with proper access control', function ()
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(

--- a/app-modules/care-team/tests/Tenant/StudentCareTeamRole/CreateStudentCareTeamRoleTest.php
+++ b/app-modules/care-team/tests/Tenant/StudentCareTeamRole/CreateStudentCareTeamRoleTest.php
@@ -60,8 +60,8 @@ test('CreateStudentCareTeamRole is gated with proper access control', function (
     livewire(CreateStudentCareTeamRole::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/care-team/tests/Tenant/StudentCareTeamRole/EditStudentCareTeamRoleTest.php
+++ b/app-modules/care-team/tests/Tenant/StudentCareTeamRole/EditStudentCareTeamRoleTest.php
@@ -65,8 +65,8 @@ test('EditStudentCareTeamRole is gated with proper access control', function () 
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/care-team/tests/Tenant/StudentCareTeamRole/ListStudentCareTeamRoleTest.php
+++ b/app-modules/care-team/tests/Tenant/StudentCareTeamRole/ListStudentCareTeamRoleTest.php
@@ -53,7 +53,7 @@ test('ListStudentCareTeamRole is gated with proper access control', function () 
             StudentCareTeamRoleResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/care-team/tests/Tenant/StudentCareTeamRole/ViewStudentCareTeamRoleTest.php
+++ b/app-modules/care-team/tests/Tenant/StudentCareTeamRole/ViewStudentCareTeamRoleTest.php
@@ -55,8 +55,8 @@ test('ViewStudentCareTeamRole is gated with proper access control', function () 
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(

--- a/app-modules/case-management/src/Policies/CaseFormPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseFormPolicy.php
@@ -41,6 +41,7 @@ use AdvisingApp\CaseManagement\Models\CaseForm;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -65,6 +66,13 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view case forms.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view case forms.'
@@ -73,6 +81,13 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.view'],
+                denyResponse: 'You do not have permission to view this case form.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseForm->getKey()}.view"],
             denyResponse: 'You do not have permission to view this case form.'
@@ -81,6 +96,13 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create case forms.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create case forms.'
@@ -89,6 +111,13 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update this case form.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseForm->getKey()}.update"],
             denyResponse: 'You do not have permission to update this case form.'
@@ -97,6 +126,13 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permission to delete this case form.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseForm->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this case form.'
@@ -105,6 +141,13 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permission to restore this case form.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseForm->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this case form.'
@@ -113,6 +156,13 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permission to permanently delete this case form.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseForm->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this case form.'

--- a/app-modules/case-management/src/Policies/CaseFormPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseFormPolicy.php
@@ -41,7 +41,7 @@ use AdvisingApp\CaseManagement\Models\CaseForm;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -66,7 +66,7 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view case forms.'
@@ -81,7 +81,7 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.view'],
                 denyResponse: 'You do not have permission to view this case form.'
@@ -96,7 +96,7 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create case forms.'
@@ -111,7 +111,7 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.update'],
                 denyResponse: 'You do not have permission to update this case form.'
@@ -126,7 +126,7 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.delete'],
                 denyResponse: 'You do not have permission to delete this case form.'
@@ -141,7 +141,7 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.restore'],
                 denyResponse: 'You do not have permission to restore this case form.'
@@ -156,7 +156,7 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.force-delete'],
                 denyResponse: 'You do not have permission to permanently delete this case form.'

--- a/app-modules/case-management/src/Policies/CaseFormPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseFormPolicy.php
@@ -72,7 +72,7 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
                 denyResponse: 'You do not have permission to view case forms.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view case forms.'

--- a/app-modules/case-management/src/Policies/CaseStatusPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseStatusPolicy.php
@@ -40,7 +40,7 @@ use AdvisingApp\CaseManagement\Models\CaseStatus;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Enums\Feature;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Support\FeatureAccessResponse;
 use Illuminate\Auth\Access\Response;
@@ -65,13 +65,13 @@ class CaseStatusPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
-                abilities: ['settings.*.view-any'],
+                abilities: ['settings.view-any'],
                 denyResponse: 'You do not have permissions to view case statuses.'
             );
         }
-
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permissions to view case statuses.'
@@ -80,7 +80,7 @@ class CaseStatusPolicy
 
     public function view(Authenticatable $authenticatable, CaseStatus $caseStatus): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.view'],
                 denyResponse: 'You do not have permissions to view this case status.'
@@ -95,7 +95,7 @@ class CaseStatusPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.create'],
                 denyResponse: 'You do not have permissions to create case statuses.'
@@ -110,7 +110,7 @@ class CaseStatusPolicy
 
     public function update(Authenticatable $authenticatable, CaseStatus $caseStatus): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.update'],
                 denyResponse: 'You do not have permissions to update this case status.'
@@ -125,7 +125,7 @@ class CaseStatusPolicy
 
     public function delete(Authenticatable $authenticatable, CaseStatus $caseStatus): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.delete'],
                 denyResponse: 'You do not have permissions to delete this case status.'
@@ -140,7 +140,7 @@ class CaseStatusPolicy
 
     public function restore(Authenticatable $authenticatable, CaseStatus $caseStatus): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.restore'],
                 denyResponse: 'You do not have permissions to restore this case status.'
@@ -159,7 +159,7 @@ class CaseStatusPolicy
             return Response::deny('You cannot force delete this case status because it has associated cases.');
         }
 
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.force-delete'],
                 denyResponse: 'You do not have permissions to force delete this case status.'

--- a/app-modules/case-management/src/Policies/CaseStatusPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseStatusPolicy.php
@@ -40,6 +40,7 @@ use AdvisingApp\CaseManagement\Models\CaseStatus;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Enums\Feature;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Support\FeatureAccessResponse;
 use Illuminate\Auth\Access\Response;
@@ -64,6 +65,13 @@ class CaseStatusPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.view-any'],
+                denyResponse: 'You do not have permissions to view case statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permissions to view case statuses.'
@@ -72,6 +80,13 @@ class CaseStatusPolicy
 
     public function view(Authenticatable $authenticatable, CaseStatus $caseStatus): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.view'],
+                denyResponse: 'You do not have permissions to view this case status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseStatus->getKey()}.view"],
             denyResponse: 'You do not have permissions to view this case status.'
@@ -80,6 +95,13 @@ class CaseStatusPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.create'],
+                denyResponse: 'You do not have permissions to create case statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permissions to create case statuses.'
@@ -88,6 +110,13 @@ class CaseStatusPolicy
 
     public function update(Authenticatable $authenticatable, CaseStatus $caseStatus): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permissions to update this case status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseStatus->getKey()}.update"],
             denyResponse: 'You do not have permissions to update this case status.'
@@ -96,6 +125,13 @@ class CaseStatusPolicy
 
     public function delete(Authenticatable $authenticatable, CaseStatus $caseStatus): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permissions to delete this case status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseStatus->getKey()}.delete"],
             denyResponse: 'You do not have permissions to delete this case status.'
@@ -104,6 +140,13 @@ class CaseStatusPolicy
 
     public function restore(Authenticatable $authenticatable, CaseStatus $caseStatus): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permissions to restore this case status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseStatus->getKey()}.restore"],
             denyResponse: 'You do not have permissions to restore this case status.'
@@ -114,6 +157,13 @@ class CaseStatusPolicy
     {
         if ($caseStatus->cases()->exists()) {
             return Response::deny('You cannot force delete this case status because it has associated cases.');
+        }
+
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permissions to force delete this case status.'
+            );
         }
 
         return $authenticatable->canOrElse(

--- a/app-modules/case-management/src/Policies/CaseStatusPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseStatusPolicy.php
@@ -71,7 +71,7 @@ class CaseStatusPolicy
                 denyResponse: 'You do not have permissions to view case statuses.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permissions to view case statuses.'

--- a/app-modules/case-management/src/Policies/CaseTypePolicy.php
+++ b/app-modules/case-management/src/Policies/CaseTypePolicy.php
@@ -40,6 +40,7 @@ use AdvisingApp\CaseManagement\Models\CaseType;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Enums\Feature;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Support\FeatureAccessResponse;
 use Illuminate\Auth\Access\Response;
@@ -64,6 +65,13 @@ class CaseTypePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permissions to view case types.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permissions to view case types.'
@@ -72,6 +80,13 @@ class CaseTypePolicy
 
     public function view(Authenticatable $authenticatable, CaseType $caseType): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permissions to view this case type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseType->getKey()}.view"],
             denyResponse: 'You do not have permissions to view this case type.'
@@ -80,6 +95,13 @@ class CaseTypePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permissions to create case types.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permissions to create case types.'
@@ -88,6 +110,13 @@ class CaseTypePolicy
 
     public function update(Authenticatable $authenticatable, CaseType $caseType): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permissions to update this case type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseType->getKey()}.update"],
             denyResponse: 'You do not have permissions to update this case type.'
@@ -96,6 +125,13 @@ class CaseTypePolicy
 
     public function delete(Authenticatable $authenticatable, CaseType $caseType): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permissions to delete this case type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseType->getKey()}.delete"],
             denyResponse: 'You do not have permissions to delete this case type.'
@@ -104,6 +140,13 @@ class CaseTypePolicy
 
     public function restore(Authenticatable $authenticatable, CaseType $caseType): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permissions to restore this case type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$caseType->getKey()}.restore"],
             denyResponse: 'You do not have permissions to restore this case type.'
@@ -114,6 +157,13 @@ class CaseTypePolicy
     {
         if ($caseType->cases()->exists()) {
             return Response::deny('You cannot force delete this case type because it has associated cases.');
+        }
+
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permissions to force-delete this case type.'
+            );
         }
 
         return $authenticatable->canOrElse(

--- a/app-modules/case-management/src/Policies/CaseTypePolicy.php
+++ b/app-modules/case-management/src/Policies/CaseTypePolicy.php
@@ -40,7 +40,7 @@ use AdvisingApp\CaseManagement\Models\CaseType;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Enums\Feature;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Support\FeatureAccessResponse;
 use Illuminate\Auth\Access\Response;
@@ -65,7 +65,7 @@ class CaseTypePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permissions to view case types.'
@@ -80,7 +80,7 @@ class CaseTypePolicy
 
     public function view(Authenticatable $authenticatable, CaseType $caseType): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permissions to view this case type.'
@@ -95,7 +95,7 @@ class CaseTypePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permissions to create case types.'
@@ -110,7 +110,7 @@ class CaseTypePolicy
 
     public function update(Authenticatable $authenticatable, CaseType $caseType): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.update'],
                 denyResponse: 'You do not have permissions to update this case type.'
@@ -125,7 +125,7 @@ class CaseTypePolicy
 
     public function delete(Authenticatable $authenticatable, CaseType $caseType): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.delete'],
                 denyResponse: 'You do not have permissions to delete this case type.'
@@ -140,7 +140,7 @@ class CaseTypePolicy
 
     public function restore(Authenticatable $authenticatable, CaseType $caseType): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.restore'],
                 denyResponse: 'You do not have permissions to restore this case type.'
@@ -159,7 +159,7 @@ class CaseTypePolicy
             return Response::deny('You cannot force delete this case type because it has associated cases.');
         }
 
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.force-delete'],
                 denyResponse: 'You do not have permissions to force-delete this case type.'

--- a/app-modules/case-management/src/Policies/SlaPolicy.php
+++ b/app-modules/case-management/src/Policies/SlaPolicy.php
@@ -71,7 +71,7 @@ class SlaPolicy
                 denyResponse: 'You do not have permission to view SLAs.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view SLAs.'

--- a/app-modules/case-management/src/Policies/SlaPolicy.php
+++ b/app-modules/case-management/src/Policies/SlaPolicy.php
@@ -40,6 +40,7 @@ use AdvisingApp\CaseManagement\Models\Sla;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Enums\Feature;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Support\FeatureAccessResponse;
 use Illuminate\Auth\Access\Response;
@@ -64,6 +65,13 @@ class SlaPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view SLAs.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view SLAs.'
@@ -72,6 +80,13 @@ class SlaPolicy
 
     public function view(Authenticatable $authenticatable, Sla $sla): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this SLA.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.view"],
             denyResponse: 'You do not have permission to view this SLA.'
@@ -80,6 +95,13 @@ class SlaPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create SLAs.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create SLAs.'
@@ -88,6 +110,13 @@ class SlaPolicy
 
     public function update(Authenticatable $authenticatable, Sla $sla): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update this SLA.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.update"],
             denyResponse: 'You do not have permission to update this SLA.'
@@ -96,6 +125,13 @@ class SlaPolicy
 
     public function delete(Authenticatable $authenticatable, Sla $sla): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permission to delete this SLA.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this SLA.'
@@ -104,6 +140,13 @@ class SlaPolicy
 
     public function restore(Authenticatable $authenticatable, Sla $sla): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permission to restore this SLA.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this SLA.'
@@ -112,6 +155,13 @@ class SlaPolicy
 
     public function forceDelete(Authenticatable $authenticatable, Sla $sla): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permission to permanently delete this SLA.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$sla->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this SLA.'

--- a/app-modules/case-management/src/Policies/SlaPolicy.php
+++ b/app-modules/case-management/src/Policies/SlaPolicy.php
@@ -40,7 +40,7 @@ use AdvisingApp\CaseManagement\Models\Sla;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Enums\Feature;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Support\FeatureAccessResponse;
 use Illuminate\Auth\Access\Response;
@@ -65,7 +65,7 @@ class SlaPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view SLAs.'
@@ -80,7 +80,7 @@ class SlaPolicy
 
     public function view(Authenticatable $authenticatable, Sla $sla): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this SLA.'
@@ -95,7 +95,7 @@ class SlaPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create SLAs.'
@@ -110,7 +110,7 @@ class SlaPolicy
 
     public function update(Authenticatable $authenticatable, Sla $sla): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.update'],
                 denyResponse: 'You do not have permission to update this SLA.'
@@ -125,7 +125,7 @@ class SlaPolicy
 
     public function delete(Authenticatable $authenticatable, Sla $sla): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.delete'],
                 denyResponse: 'You do not have permission to delete this SLA.'
@@ -140,7 +140,7 @@ class SlaPolicy
 
     public function restore(Authenticatable $authenticatable, Sla $sla): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.restore'],
                 denyResponse: 'You do not have permission to restore this SLA.'
@@ -155,7 +155,7 @@ class SlaPolicy
 
     public function forceDelete(Authenticatable $authenticatable, Sla $sla): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.force-delete'],
                 denyResponse: 'You do not have permission to permanently delete this SLA.'

--- a/app-modules/case-management/tests/Tenant/CaseStatus/CreateCaseStatusTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseStatus/CreateCaseStatusTest.php
@@ -101,8 +101,8 @@ test('CreateCaseStatus is gated with proper access control', function () {
     livewire(CreateCaseStatus::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -130,8 +130,8 @@ test('CreateCaseStatus is gated with proper feature access control', function ()
 
     $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/case-management/tests/Tenant/CaseStatus/EditCaseStatusTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseStatus/EditCaseStatusTest.php
@@ -126,8 +126,8 @@ test('EditCaseStatus is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -157,8 +157,8 @@ test('EditCaseStatus is gated with proper feature access control', function () {
 
     $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $caseStatus = CaseStatus::factory()->create();
 

--- a/app-modules/case-management/tests/Tenant/CaseStatus/ListCaseStatusesTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseStatus/ListCaseStatusesTest.php
@@ -102,7 +102,7 @@ test('ListCaseStatuses is gated with proper access control', function () {
             CaseStatusResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -119,7 +119,7 @@ test('ListCaseStatuses is gated with proper feature access control', function ()
 
     $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/case-management/tests/Tenant/CaseStatus/ViewCaseStatusTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseStatus/ViewCaseStatusTest.php
@@ -78,8 +78,8 @@ test('ViewCaseStatus is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(
@@ -98,8 +98,8 @@ test('ViewCaseStatus is gated with proper feature access control', function () {
 
     $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $caseStatus = CaseStatus::factory()->create();
 

--- a/app-modules/case-management/tests/Tenant/CaseType/CreateCaseTypeTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseType/CreateCaseTypeTest.php
@@ -98,8 +98,8 @@ test('CreateCaseType is gated with proper access control', function () {
     livewire(CreateCaseType::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -127,8 +127,8 @@ test('CreateCaseType is gated with proper feature access control', function () {
 
     $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/case-management/tests/Tenant/CaseType/EditCaseTypeAssignmentsTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseType/EditCaseTypeAssignmentsTest.php
@@ -149,8 +149,8 @@ test('EditCaseTypeAssignments is gated with proper access control', function () 
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -180,8 +180,8 @@ test('EditCaseTypeAssignments is gated with proper feature access control', func
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $caseType = CaseType::factory()->create();
 

--- a/app-modules/case-management/tests/Tenant/CaseType/EditCaseTypeTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseType/EditCaseTypeTest.php
@@ -117,8 +117,8 @@ test('EditCaseType is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -148,8 +148,8 @@ test('EditCaseType is gated with proper feature access control', function () {
 
     $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $caseType = CaseType::factory()->create();
 

--- a/app-modules/case-management/tests/Tenant/CaseType/ListCaseTypeTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseType/ListCaseTypeTest.php
@@ -92,7 +92,7 @@ test('ListCaseTypes is gated with proper access control', function () {
             CaseTypeResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -109,7 +109,7 @@ test('ListCaseTypes is gated with proper feature access control', function () {
 
     $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/case-management/tests/Tenant/CaseType/ViewCaseTypeTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseType/ViewCaseTypeTest.php
@@ -76,8 +76,8 @@ test('ViewCaseType is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(
@@ -96,8 +96,8 @@ test('ViewCaseType is gated with proper feature access control', function () {
 
     $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $caseType = CaseType::factory()->create();
 

--- a/app-modules/case-management/tests/Tenant/Filament/Resources/CaseTypeResource/Pages/EditCaseTypeNotificationsTest.php
+++ b/app-modules/case-management/tests/Tenant/Filament/Resources/CaseTypeResource/Pages/EditCaseTypeNotificationsTest.php
@@ -60,8 +60,8 @@ test('EditCaseTypeNotifications is gated with proper access control', function (
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/case-management/tests/Tenant/Filament/Resources/CaseTypeResource/Pages/ManageCaseTypeAuditorsTest.php
+++ b/app-modules/case-management/tests/Tenant/Filament/Resources/CaseTypeResource/Pages/ManageCaseTypeAuditorsTest.php
@@ -59,7 +59,7 @@ it('can attach audit member to case type', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
     $user->givePermissionTo('team.view-any');
 
     livewire(ManageCaseTypeAuditors::class, [

--- a/app-modules/case-management/tests/Tenant/Filament/Resources/CaseTypeResource/Pages/ManageCaseTypeManagersTest.php
+++ b/app-modules/case-management/tests/Tenant/Filament/Resources/CaseTypeResource/Pages/ManageCaseTypeManagersTest.php
@@ -59,7 +59,7 @@ it('can attach team member to case type', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
     $user->givePermissionTo('team.view-any');
 
     livewire(ManageCaseTypeManagers::class, [

--- a/app-modules/consent/src/Policies/ConsentAgreementPolicy.php
+++ b/app-modules/consent/src/Policies/ConsentAgreementPolicy.php
@@ -38,7 +38,7 @@ namespace AdvisingApp\Consent\Policies;
 
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Consent\Models\ConsentAgreement;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,7 +55,7 @@ class ConsentAgreementPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.view-any'],
                 denyResponse: 'You do not have permission to view consent agreements.'
@@ -70,7 +70,7 @@ class ConsentAgreementPolicy
 
     public function view(Authenticatable $authenticatable, ConsentAgreement $agreement): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.view'],
                 denyResponse: 'You do not have permission to view this consent agreement.'
@@ -90,7 +90,7 @@ class ConsentAgreementPolicy
 
     public function update(Authenticatable $authenticatable, ConsentAgreement $agreement): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: ['settings.*.update'],
                 denyResponse: 'You do not have permission to update this consent agreement.'

--- a/app-modules/consent/src/Policies/ConsentAgreementPolicy.php
+++ b/app-modules/consent/src/Policies/ConsentAgreementPolicy.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Consent\Policies;
 
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Consent\Models\ConsentAgreement;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -54,6 +55,13 @@ class ConsentAgreementPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.view-any'],
+                denyResponse: 'You do not have permission to view consent agreements.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.view-any'],
             denyResponse: 'You do not have permission to view consent agreements.'
@@ -62,6 +70,13 @@ class ConsentAgreementPolicy
 
     public function view(Authenticatable $authenticatable, ConsentAgreement $agreement): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.view'],
+                denyResponse: 'You do not have permission to view this consent agreement.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$agreement->getKey()}.view"],
             denyResponse: 'You do not have permission to view this consent agreement.'
@@ -75,6 +90,13 @@ class ConsentAgreementPolicy
 
     public function update(Authenticatable $authenticatable, ConsentAgreement $agreement): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update this consent agreement.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$agreement->getKey()}.update"],
             denyResponse: 'You do not have permission to update this consent agreement.'
@@ -92,7 +114,7 @@ class ConsentAgreementPolicy
     }
 
     public function forceDelete(Authenticatable $authenticatable, ConsentAgreement $agreement): Response
-    {
+    {   
         return Response::deny('Consent Agreements cannot be permanently deleted.');
     }
 }

--- a/app-modules/consent/src/Policies/ConsentAgreementPolicy.php
+++ b/app-modules/consent/src/Policies/ConsentAgreementPolicy.php
@@ -114,7 +114,7 @@ class ConsentAgreementPolicy
     }
 
     public function forceDelete(Authenticatable $authenticatable, ConsentAgreement $agreement): Response
-    {   
+    {
         return Response::deny('Consent Agreements cannot be permanently deleted.');
     }
 }

--- a/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
@@ -39,7 +39,7 @@ namespace AdvisingApp\Engagement\Policies;
 use AdvisingApp\Engagement\Models\EmailTemplate;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -56,7 +56,7 @@ class EmailTemplatePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view email templates.'
@@ -71,7 +71,7 @@ class EmailTemplatePolicy
 
     public function view(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this email template.'
@@ -86,7 +86,7 @@ class EmailTemplatePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create email templates.'
@@ -101,7 +101,7 @@ class EmailTemplatePolicy
 
     public function update(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this email template.'
@@ -116,7 +116,7 @@ class EmailTemplatePolicy
 
     public function delete(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this email template.'
@@ -131,7 +131,7 @@ class EmailTemplatePolicy
 
     public function restore(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this email template.'
@@ -146,7 +146,7 @@ class EmailTemplatePolicy
 
     public function forceDelete(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this email template.'

--- a/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
@@ -62,7 +62,7 @@ class EmailTemplatePolicy
                 denyResponse: 'You do not have permission to view email templates.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view email templates.'
@@ -152,7 +152,7 @@ class EmailTemplatePolicy
                 denyResponse: 'You do not have permission to permanently delete this email template.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$emailTemplate->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this email template.'

--- a/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Engagement\Policies;
 use AdvisingApp\Engagement\Models\EmailTemplate;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,13 @@ class EmailTemplatePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view email templates.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view email templates.'
@@ -63,6 +71,13 @@ class EmailTemplatePolicy
 
     public function view(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this email template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$emailTemplate->getKey()}.view"],
             denyResponse: 'You do not have permission to view this email template.'
@@ -71,6 +86,13 @@ class EmailTemplatePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create email templates.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create email templates.'
@@ -79,6 +101,13 @@ class EmailTemplatePolicy
 
     public function update(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this email template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$emailTemplate->getKey()}.update"],
             denyResponse: 'You do not have permission to update this email template.'
@@ -87,6 +116,13 @@ class EmailTemplatePolicy
 
     public function delete(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this email template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$emailTemplate->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this email template.'
@@ -95,6 +131,13 @@ class EmailTemplatePolicy
 
     public function restore(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this email template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$emailTemplate->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this email template.'
@@ -103,6 +146,13 @@ class EmailTemplatePolicy
 
     public function forceDelete(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this email template.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$emailTemplate->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this email template.'

--- a/app-modules/engagement/src/Policies/SmsTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/SmsTemplatePolicy.php
@@ -39,7 +39,7 @@ namespace AdvisingApp\Engagement\Policies;
 use AdvisingApp\Engagement\Models\SmsTemplate;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -56,7 +56,7 @@ class SmsTemplatePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view sms templates.'
@@ -71,7 +71,7 @@ class SmsTemplatePolicy
 
     public function view(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this sms template.'
@@ -86,7 +86,7 @@ class SmsTemplatePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create sms templates.'
@@ -101,7 +101,7 @@ class SmsTemplatePolicy
 
     public function update(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this sms template.'
@@ -116,7 +116,7 @@ class SmsTemplatePolicy
 
     public function delete(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this sms template.'
@@ -131,7 +131,7 @@ class SmsTemplatePolicy
 
     public function restore(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this sms template.'
@@ -146,7 +146,7 @@ class SmsTemplatePolicy
 
     public function forceDelete(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this sms template.'

--- a/app-modules/engagement/src/Policies/SmsTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/SmsTemplatePolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Engagement\Policies;
 use AdvisingApp\Engagement\Models\SmsTemplate;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,13 @@ class SmsTemplatePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view sms templates.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view sms templates.'
@@ -63,6 +71,13 @@ class SmsTemplatePolicy
 
     public function view(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this sms template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$smsTemplate->getKey()}.view"],
             denyResponse: 'You do not have permission to view this sms template.'
@@ -71,6 +86,13 @@ class SmsTemplatePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create sms templates.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create sms templates.'
@@ -79,6 +101,13 @@ class SmsTemplatePolicy
 
     public function update(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this sms template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$smsTemplate->getKey()}.update"],
             denyResponse: 'You do not have permission to update this sms template.'
@@ -87,6 +116,13 @@ class SmsTemplatePolicy
 
     public function delete(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this sms template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$smsTemplate->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this sms template.'
@@ -95,6 +131,13 @@ class SmsTemplatePolicy
 
     public function restore(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this sms template.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$smsTemplate->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this sms template.'
@@ -103,6 +146,13 @@ class SmsTemplatePolicy
 
     public function forceDelete(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this sms template.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$smsTemplate->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this sms template.'

--- a/app-modules/engagement/src/Policies/SmsTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/SmsTemplatePolicy.php
@@ -62,7 +62,7 @@ class SmsTemplatePolicy
                 denyResponse: 'You do not have permission to view sms templates.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view sms templates.'
@@ -152,7 +152,7 @@ class SmsTemplatePolicy
                 denyResponse: 'You do not have permission to permanently delete this sms template.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$smsTemplate->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this sms template.'

--- a/app-modules/interaction/src/Policies/InteractionDriverPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionDriverPolicy.php
@@ -122,6 +122,7 @@ class InteractionDriverPolicy
                 denyResponse: 'You do not have permission to delete this interaction driver.'
             );
         }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$driver->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this interaction driver.'
@@ -151,7 +152,7 @@ class InteractionDriverPolicy
                 denyResponse: 'You do not have permission to permanently delete this interaction driver.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$driver->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction driver.'

--- a/app-modules/interaction/src/Policies/InteractionDriverPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionDriverPolicy.php
@@ -39,7 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionDriver;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -56,7 +56,7 @@ class InteractionDriverPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view interaction drivers.'
@@ -71,7 +71,7 @@ class InteractionDriverPolicy
 
     public function view(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this interaction driver.'
@@ -86,7 +86,7 @@ class InteractionDriverPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create interaction drivers.'
@@ -101,7 +101,7 @@ class InteractionDriverPolicy
 
     public function update(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this interaction driver.'
@@ -116,7 +116,7 @@ class InteractionDriverPolicy
 
     public function delete(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this interaction driver.'
@@ -130,7 +130,7 @@ class InteractionDriverPolicy
 
     public function restore(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this interaction driver.'
@@ -145,7 +145,7 @@ class InteractionDriverPolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this interaction driver.'

--- a/app-modules/interaction/src/Policies/InteractionDriverPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionDriverPolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionDriver;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,13 @@ class InteractionDriverPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view interaction drivers.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view interaction drivers.'
@@ -63,6 +71,13 @@ class InteractionDriverPolicy
 
     public function view(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this interaction driver.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$driver->getKey()}.view"],
             denyResponse: 'You do not have permission to view this interaction driver.'
@@ -71,6 +86,13 @@ class InteractionDriverPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create interaction drivers.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create interaction drivers.'
@@ -79,6 +101,13 @@ class InteractionDriverPolicy
 
     public function update(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this interaction driver.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$driver->getKey()}.update"],
             denyResponse: 'You do not have permission to update this interaction driver.'
@@ -87,6 +116,12 @@ class InteractionDriverPolicy
 
     public function delete(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this interaction driver.'
+            );
+        }
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$driver->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this interaction driver.'
@@ -95,6 +130,13 @@ class InteractionDriverPolicy
 
     public function restore(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this interaction driver.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$driver->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this interaction driver.'
@@ -103,6 +145,13 @@ class InteractionDriverPolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this interaction driver.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$driver->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction driver.'

--- a/app-modules/interaction/src/Policies/InteractionInitiativePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionInitiativePolicy.php
@@ -39,7 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionInitiative;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -56,7 +56,7 @@ class InteractionInitiativePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view interaction initiatives.'
@@ -71,7 +71,7 @@ class InteractionInitiativePolicy
 
     public function view(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this interaction initiative.'
@@ -86,7 +86,7 @@ class InteractionInitiativePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create interaction initiatives.'
@@ -101,7 +101,7 @@ class InteractionInitiativePolicy
 
     public function update(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this interaction initiative.'
@@ -116,7 +116,7 @@ class InteractionInitiativePolicy
 
     public function delete(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this interaction initiative.'
@@ -131,7 +131,7 @@ class InteractionInitiativePolicy
 
     public function restore(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this interaction initiative.'
@@ -146,7 +146,7 @@ class InteractionInitiativePolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this interaction initiative.'

--- a/app-modules/interaction/src/Policies/InteractionInitiativePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionInitiativePolicy.php
@@ -92,7 +92,7 @@ class InteractionInitiativePolicy
                 denyResponse: 'You do not have permission to create interaction initiatives.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create interaction initiatives.'
@@ -152,7 +152,7 @@ class InteractionInitiativePolicy
                 denyResponse: 'You do not have permission to permanently delete this interaction initiative.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$initiative->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction initiative.'

--- a/app-modules/interaction/src/Policies/InteractionInitiativePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionInitiativePolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionInitiative;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,13 @@ class InteractionInitiativePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view interaction initiatives.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view interaction initiatives.'
@@ -63,6 +71,13 @@ class InteractionInitiativePolicy
 
     public function view(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this interaction initiative.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$initiative->getKey()}.view"],
             denyResponse: 'You do not have permission to view this interaction initiative.'
@@ -71,6 +86,13 @@ class InteractionInitiativePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create interaction initiatives.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create interaction initiatives.'
@@ -79,6 +101,13 @@ class InteractionInitiativePolicy
 
     public function update(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this interaction initiative.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$initiative->getKey()}.update"],
             denyResponse: 'You do not have permission to update this interaction initiative.'
@@ -87,6 +116,13 @@ class InteractionInitiativePolicy
 
     public function delete(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this interaction initiative.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$initiative->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this interaction initiative.'
@@ -95,6 +131,13 @@ class InteractionInitiativePolicy
 
     public function restore(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this interaction initiative.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$initiative->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this interaction initiative.'
@@ -103,6 +146,13 @@ class InteractionInitiativePolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this interaction initiative.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$initiative->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction initiative.'

--- a/app-modules/interaction/src/Policies/InteractionOutcomePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionOutcomePolicy.php
@@ -39,7 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionOutcome;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -56,7 +56,7 @@ class InteractionOutcomePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view interaction outcomes.'
@@ -71,7 +71,7 @@ class InteractionOutcomePolicy
 
     public function view(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this interaction outcome.'
@@ -86,7 +86,7 @@ class InteractionOutcomePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create interaction outcomes.'
@@ -101,7 +101,7 @@ class InteractionOutcomePolicy
 
     public function update(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this interaction outcome.'
@@ -116,7 +116,7 @@ class InteractionOutcomePolicy
 
     public function delete(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this interaction outcome.'
@@ -131,7 +131,7 @@ class InteractionOutcomePolicy
 
     public function restore(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this interaction outcome.'
@@ -146,7 +146,7 @@ class InteractionOutcomePolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this interaction outcome.'

--- a/app-modules/interaction/src/Policies/InteractionOutcomePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionOutcomePolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionOutcome;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,13 @@ class InteractionOutcomePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view interaction outcomes.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view interaction outcomes.'
@@ -63,6 +71,13 @@ class InteractionOutcomePolicy
 
     public function view(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this interaction outcome.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$outcome->getKey()}.view"],
             denyResponse: 'You do not have permission to view this interaction outcome.'
@@ -71,6 +86,13 @@ class InteractionOutcomePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create interaction outcomes.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create interaction outcomes.'
@@ -79,6 +101,13 @@ class InteractionOutcomePolicy
 
     public function update(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this interaction outcome.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$outcome->getKey()}.update"],
             denyResponse: 'You do not have permission to update this interaction outcome.'
@@ -87,6 +116,13 @@ class InteractionOutcomePolicy
 
     public function delete(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this interaction outcome.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$outcome->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this interaction outcome.'
@@ -95,6 +131,13 @@ class InteractionOutcomePolicy
 
     public function restore(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this interaction outcome.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$outcome->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this interaction outcome.'
@@ -103,6 +146,13 @@ class InteractionOutcomePolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this interaction outcome.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$outcome->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction outcome.'

--- a/app-modules/interaction/src/Policies/InteractionOutcomePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionOutcomePolicy.php
@@ -152,7 +152,7 @@ class InteractionOutcomePolicy
                 denyResponse: 'You do not have permission to permanently delete this interaction outcome.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$outcome->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction outcome.'

--- a/app-modules/interaction/src/Policies/InteractionRelationPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionRelationPolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionRelation;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,13 @@ class InteractionRelationPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view interaction relations.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view interaction relations.'
@@ -63,6 +71,13 @@ class InteractionRelationPolicy
 
     public function view(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this interaction relation.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$relation->getKey()}.view"],
             denyResponse: 'You do not have permission to view this interaction relation.'
@@ -71,6 +86,13 @@ class InteractionRelationPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create interaction relations.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create interaction relations.'
@@ -79,6 +101,13 @@ class InteractionRelationPolicy
 
     public function update(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this interaction relation.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$relation->getKey()}.update"],
             denyResponse: 'You do not have permission to update this interaction relation.'
@@ -87,6 +116,13 @@ class InteractionRelationPolicy
 
     public function delete(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this interaction relation.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$relation->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this interaction relation.'
@@ -95,6 +131,13 @@ class InteractionRelationPolicy
 
     public function restore(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this interaction relation.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$relation->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this interaction relation.'
@@ -103,6 +146,13 @@ class InteractionRelationPolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this interaction relation.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$relation->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction relation.'

--- a/app-modules/interaction/src/Policies/InteractionRelationPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionRelationPolicy.php
@@ -39,7 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionRelation;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -56,7 +56,7 @@ class InteractionRelationPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view interaction relations.'
@@ -71,7 +71,7 @@ class InteractionRelationPolicy
 
     public function view(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this interaction relation.'
@@ -86,7 +86,7 @@ class InteractionRelationPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create interaction relations.'
@@ -101,7 +101,7 @@ class InteractionRelationPolicy
 
     public function update(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this interaction relation.'
@@ -116,7 +116,7 @@ class InteractionRelationPolicy
 
     public function delete(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this interaction relation.'
@@ -131,7 +131,7 @@ class InteractionRelationPolicy
 
     public function restore(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this interaction relation.'
@@ -146,7 +146,7 @@ class InteractionRelationPolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this interaction relation.'

--- a/app-modules/interaction/src/Policies/InteractionRelationPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionRelationPolicy.php
@@ -62,7 +62,7 @@ class InteractionRelationPolicy
                 denyResponse: 'You do not have permission to view interaction relations.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view interaction relations.'
@@ -152,7 +152,7 @@ class InteractionRelationPolicy
                 denyResponse: 'You do not have permission to permanently delete this interaction relation.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$relation->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction relation.'

--- a/app-modules/interaction/src/Policies/InteractionStatusPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionStatusPolicy.php
@@ -152,7 +152,7 @@ class InteractionStatusPolicy
                 denyResponse: 'You do not have permission to permanently delete this interaction status.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$status->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction status.'

--- a/app-modules/interaction/src/Policies/InteractionStatusPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionStatusPolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionStatus;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,13 @@ class InteractionStatusPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view interaction statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view interaction statuses.'
@@ -63,6 +71,13 @@ class InteractionStatusPolicy
 
     public function view(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this interaction status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$status->getKey()}.view"],
             denyResponse: 'You do not have permission to view this interaction status.'
@@ -71,6 +86,13 @@ class InteractionStatusPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create interaction statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create interaction statuses.'
@@ -79,6 +101,13 @@ class InteractionStatusPolicy
 
     public function update(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this interaction status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$status->getKey()}.update"],
             denyResponse: 'You do not have permission to update this interaction status.'
@@ -87,6 +116,13 @@ class InteractionStatusPolicy
 
     public function delete(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this interaction status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$status->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this interaction status.'
@@ -95,6 +131,13 @@ class InteractionStatusPolicy
 
     public function restore(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this interaction status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$status->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this interaction status.'
@@ -103,6 +146,13 @@ class InteractionStatusPolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this interaction status.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$status->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction status.'

--- a/app-modules/interaction/src/Policies/InteractionStatusPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionStatusPolicy.php
@@ -39,7 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionStatus;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -56,7 +56,7 @@ class InteractionStatusPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view interaction statuses.'
@@ -71,7 +71,7 @@ class InteractionStatusPolicy
 
     public function view(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this interaction status.'
@@ -86,7 +86,7 @@ class InteractionStatusPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create interaction statuses.'
@@ -101,7 +101,7 @@ class InteractionStatusPolicy
 
     public function update(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this interaction status.'
@@ -116,7 +116,7 @@ class InteractionStatusPolicy
 
     public function delete(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this interaction status.'
@@ -131,7 +131,7 @@ class InteractionStatusPolicy
 
     public function restore(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this interaction status.'
@@ -146,7 +146,7 @@ class InteractionStatusPolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this interaction status.'

--- a/app-modules/interaction/src/Policies/InteractionTypePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionTypePolicy.php
@@ -39,7 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionType;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -56,7 +56,7 @@ class InteractionTypePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view interaction types.'
@@ -71,7 +71,7 @@ class InteractionTypePolicy
 
     public function view(Authenticatable $authenticatable, InteractionType $type): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this interaction type.'
@@ -86,7 +86,7 @@ class InteractionTypePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create interaction types.'
@@ -101,7 +101,7 @@ class InteractionTypePolicy
 
     public function update(Authenticatable $authenticatable, InteractionType $type): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this interaction type.'
@@ -116,7 +116,7 @@ class InteractionTypePolicy
 
     public function delete(Authenticatable $authenticatable, InteractionType $type): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this interaction type.'
@@ -131,7 +131,7 @@ class InteractionTypePolicy
 
     public function restore(Authenticatable $authenticatable, InteractionType $type): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this interaction type.'
@@ -146,7 +146,7 @@ class InteractionTypePolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionType $type): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this interaction type.'

--- a/app-modules/interaction/src/Policies/InteractionTypePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionTypePolicy.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Interaction\Policies;
 use AdvisingApp\Interaction\Models\InteractionType;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -55,6 +56,13 @@ class InteractionTypePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view interaction types.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view interaction types.'
@@ -63,6 +71,13 @@ class InteractionTypePolicy
 
     public function view(Authenticatable $authenticatable, InteractionType $type): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this interaction type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$type->getKey()}.view"],
             denyResponse: 'You do not have permission to view this interaction type.'
@@ -71,6 +86,13 @@ class InteractionTypePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create interaction types.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create interaction types.'
@@ -79,6 +101,13 @@ class InteractionTypePolicy
 
     public function update(Authenticatable $authenticatable, InteractionType $type): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this interaction type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$type->getKey()}.update"],
             denyResponse: 'You do not have permission to update this interaction type.'
@@ -87,6 +116,13 @@ class InteractionTypePolicy
 
     public function delete(Authenticatable $authenticatable, InteractionType $type): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this interaction type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$type->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this interaction type.'
@@ -95,6 +131,13 @@ class InteractionTypePolicy
 
     public function restore(Authenticatable $authenticatable, InteractionType $type): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this interaction type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$type->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this interaction type.'
@@ -103,6 +146,13 @@ class InteractionTypePolicy
 
     public function forceDelete(Authenticatable $authenticatable, InteractionType $type): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this interaction type.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$type->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this interaction type.'

--- a/app-modules/interaction/src/Policies/InteractionTypePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionTypePolicy.php
@@ -62,7 +62,7 @@ class InteractionTypePolicy
                 denyResponse: 'You do not have permission to view interaction types.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view interaction types.'

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionDriverResource/CreateInteractionDriverTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionDriverResource/CreateInteractionDriverTest.php
@@ -48,8 +48,8 @@ test('CreateInteractionDriver is gated with proper access control', function () 
             InteractionDriverResource::getUrl('create')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionDriverResource/EditInteractionDriverTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionDriverResource/EditInteractionDriverTest.php
@@ -51,8 +51,8 @@ test('EditInteractionDriver is gated with proper access control', function () {
             InteractionDriverResource::getUrl('edit', ['record' => $driver])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionDriverResource/ListInteractionDriversTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionDriverResource/ListInteractionDriversTest.php
@@ -48,7 +48,7 @@ test('ListInteractionDrivers is gated with proper access control', function () {
             InteractionDriverResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionInitiativeResource/CreateInteractionInitiativeTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionInitiativeResource/CreateInteractionInitiativeTest.php
@@ -48,8 +48,8 @@ test('CreateInteractionInitiative is gated with proper access control', function
             InteractionInitiativeResource::getUrl('create')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionInitiativeResource/ListInteractionInitiativesTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionInitiativeResource/ListInteractionInitiativesTest.php
@@ -48,7 +48,7 @@ test('ListInteractionInitiatives is gated with proper access control', function 
             InteractionInitiativeResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionOutcomeResource/CreateInteractionOutcomeTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionOutcomeResource/CreateInteractionOutcomeTest.php
@@ -48,8 +48,8 @@ test('CreateInteractionOutcome is gated with proper access control', function ()
             InteractionOutcomeResource::getUrl('create')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionOutcomeResource/EditInteractionOutcomeTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionOutcomeResource/EditInteractionOutcomeTest.php
@@ -51,8 +51,8 @@ test('EditInteractionOutcome is gated with proper access control', function () {
             InteractionOutcomeResource::getUrl('edit', ['record' => $outcome])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionOutcomeResource/ListInteractionOutcomesTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionOutcomeResource/ListInteractionOutcomesTest.php
@@ -48,7 +48,7 @@ test('ListInteractionOutcomes is gated with proper access control', function () 
             InteractionOutcomeResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionRelationResource/CreateInteractionRelationTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionRelationResource/CreateInteractionRelationTest.php
@@ -48,8 +48,8 @@ test('CreateInteractionRelation is gated with proper access control', function (
             InteractionRelationResource::getUrl('create')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionRelationResource/EditInteractionRelationTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionRelationResource/EditInteractionRelationTest.php
@@ -51,8 +51,8 @@ test('EditInteractionRelation is gated with proper access control', function () 
             InteractionRelationResource::getUrl('edit', ['record' => $relation])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionRelationResource/ListInteractionRelationsTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionRelationResource/ListInteractionRelationsTest.php
@@ -48,7 +48,7 @@ test('ListInteractionRelations is gated with proper access control', function ()
             InteractionRelationResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionStatusResource/CreateInteractionStatusTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionStatusResource/CreateInteractionStatusTest.php
@@ -48,8 +48,8 @@ test('CreateInteractionStatus is gated with proper access control', function () 
             InteractionStatusResource::getUrl('create')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionStatusResource/EditInteractionStatusTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionStatusResource/EditInteractionStatusTest.php
@@ -51,8 +51,8 @@ test('EditInteractionStatus is gated with proper access control', function () {
             InteractionStatusResource::getUrl('edit', ['record' => $status])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionStatusResource/ListInteractionStatusesTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionStatusResource/ListInteractionStatusesTest.php
@@ -48,7 +48,7 @@ test('ListInteractionStatuses is gated with proper access control', function () 
             InteractionStatusResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionTypeResource/CreateInteractionTypeTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionTypeResource/CreateInteractionTypeTest.php
@@ -48,8 +48,8 @@ test('CreateInteractionType is gated with proper access control', function () {
             InteractionTypeResource::getUrl('create')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionTypeResource/EditInteractionTypeTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionTypeResource/EditInteractionTypeTest.php
@@ -51,8 +51,8 @@ test('EditInteractionType is gated with proper access control', function () {
             InteractionTypeResource::getUrl('edit', ['record' => $type])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionTypeResource/ListInteractionTypesTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionTypeResource/ListInteractionTypesTest.php
@@ -48,7 +48,7 @@ test('ListInteractionTypes is gated with proper access control', function () {
             InteractionTypeResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/prospect/src/Filament/Pages/ManageProspectConversionSettings.php
+++ b/app-modules/prospect/src/Filament/Pages/ManageProspectConversionSettings.php
@@ -103,7 +103,7 @@ class ManageProspectConversionSettings extends SettingsPage
 
     public function save(): void
     {
-        if (!SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
+        if (! SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
             return;
         }
 
@@ -119,7 +119,7 @@ class ManageProspectConversionSettings extends SettingsPage
      */
     public function getFormActions(): array
     {
-        if (!SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
+        if (! SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
             return [];
         }
 

--- a/app-modules/prospect/src/Filament/Pages/ManageProspectConversionSettings.php
+++ b/app-modules/prospect/src/Filament/Pages/ManageProspectConversionSettings.php
@@ -37,9 +37,11 @@
 namespace AdvisingApp\Prospect\Filament\Pages;
 
 use AdvisingApp\Prospect\Models\Prospect;
+use App\Features\SettingsPermissions;
 use App\Filament\Clusters\ConstituentManagement;
 use App\Filament\Forms\Components\Heading;
 use App\Filament\Forms\Components\Paragraph;
+use App\Models\User;
 use App\Settings\ProspectConversionSettings;
 use Cknow\Money\Money;
 use Filament\Forms\Components\Section;
@@ -70,7 +72,7 @@ class ManageProspectConversionSettings extends SettingsPage
             return false;
         }
 
-        return $user->can(['product_admin.view-any']);
+        return SettingsPermissions::active() ? $user->can(['settings.view-any']) : $user->can('product_admin.view-any');
     }
 
     public function form(Form $form): Form
@@ -101,7 +103,11 @@ class ManageProspectConversionSettings extends SettingsPage
 
     public function save(): void
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (!SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
+            return;
+        }
+
+        if (SettingsPermissions::active() && ! auth()->user()->can('settings.*.update')) {
             return;
         }
 
@@ -113,7 +119,11 @@ class ManageProspectConversionSettings extends SettingsPage
      */
     public function getFormActions(): array
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (!SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
+            return [];
+        }
+
+        if (SettingsPermissions::active() && ! auth()->user()->can('settings.*.update')) {
             return [];
         }
 

--- a/app-modules/prospect/src/Filament/Pages/ManageProspectPipelineSettings.php
+++ b/app-modules/prospect/src/Filament/Pages/ManageProspectPipelineSettings.php
@@ -85,7 +85,7 @@ class ManageProspectPipelineSettings extends SettingsPage
 
     public function save(): void
     {
-        if (!SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
+        if (! SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
             return;
         }
 
@@ -101,7 +101,7 @@ class ManageProspectPipelineSettings extends SettingsPage
      */
     public function getFormActions(): array
     {
-        if (!SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
+        if (! SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
             return [];
         }
 

--- a/app-modules/prospect/src/Filament/Pages/ManageProspectPipelineSettings.php
+++ b/app-modules/prospect/src/Filament/Pages/ManageProspectPipelineSettings.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\Prospect\Filament\Pages;
 use AdvisingApp\Prospect\Filament\Resources\ProspectResource;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\Prospect\Settings\ProspectPipelineSettings;
+use App\Features\SettingsPermissions;
 use App\Filament\Clusters\ConstituentManagement;
 use App\Models\User;
 use Filament\Forms\Components\Toggle;
@@ -68,7 +69,7 @@ class ManageProspectPipelineSettings extends SettingsPage
             return false;
         }
 
-        return $user->can(['product_admin.view-any']);
+        return SettingsPermissions::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
     }
 
     public function form(Form $form): Form
@@ -79,12 +80,16 @@ class ManageProspectPipelineSettings extends SettingsPage
                 ->label('Is Enabled?')
                 ->columnSpanFull(),
         ])
-            ->disabled(! auth()->user()->can('product_admin.*.update'));
+            ->disabled(SettingsPermissions::active() ? ! auth()->user()->can('settings.*.update') : ! auth()->user()->can('product_admin.*.update'));
     }
 
     public function save(): void
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (!SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
+            return;
+        }
+
+        if (SettingsPermissions::active() && ! auth()->user()->can('settings.*.update')) {
             return;
         }
 
@@ -96,7 +101,11 @@ class ManageProspectPipelineSettings extends SettingsPage
      */
     public function getFormActions(): array
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (!SettingsPermissions::active() && ! auth()->user()->can('product_admin.*.update')) {
+            return [];
+        }
+
+        if (SettingsPermissions::active() && ! auth()->user()->can('settings.*.update')) {
             return [];
         }
 

--- a/app-modules/prospect/src/Policies/ProspectSourcePolicy.php
+++ b/app-modules/prospect/src/Policies/ProspectSourcePolicy.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Prospect\Policies;
 
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\Prospect\Models\ProspectSource;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -54,6 +55,13 @@ class ProspectSourcePolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view prospect sources.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view prospect sources.'
@@ -62,6 +70,13 @@ class ProspectSourcePolicy
 
     public function view(Authenticatable $authenticatable, ProspectSource $prospectSource): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this prospect source.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectSource->getKey()}.view"],
             denyResponse: 'You do not have permission to view this prospect source.'
@@ -70,6 +85,13 @@ class ProspectSourcePolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create prospect sources.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create prospect sources.'
@@ -78,6 +100,13 @@ class ProspectSourcePolicy
 
     public function update(Authenticatable $authenticatable, ProspectSource $prospectSource): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this prospect source.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectSource->getKey()}.update"],
             denyResponse: 'You do not have permission to update this prospect source.'
@@ -86,6 +115,13 @@ class ProspectSourcePolicy
 
     public function delete(Authenticatable $authenticatable, ProspectSource $prospectSource): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this prospect source.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectSource->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this prospect source.'
@@ -94,6 +130,13 @@ class ProspectSourcePolicy
 
     public function restore(Authenticatable $authenticatable, ProspectSource $prospectSource): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this prospect source.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectSource->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this prospect source.'
@@ -102,6 +145,13 @@ class ProspectSourcePolicy
 
     public function forceDelete(Authenticatable $authenticatable, ProspectSource $prospectSource): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to force delete this prospect source.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectSource->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to force delete this prospect source.'

--- a/app-modules/prospect/src/Policies/ProspectSourcePolicy.php
+++ b/app-modules/prospect/src/Policies/ProspectSourcePolicy.php
@@ -151,7 +151,7 @@ class ProspectSourcePolicy
                 denyResponse: 'You do not have permission to force delete this prospect source.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectSource->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to force delete this prospect source.'

--- a/app-modules/prospect/src/Policies/ProspectStatusPolicy.php
+++ b/app-modules/prospect/src/Policies/ProspectStatusPolicy.php
@@ -61,7 +61,7 @@ class ProspectStatusPolicy
                 denyResponse: 'You do not have permission to view prospect statuses.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view prospect statuses.'

--- a/app-modules/prospect/src/Policies/ProspectStatusPolicy.php
+++ b/app-modules/prospect/src/Policies/ProspectStatusPolicy.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Prospect\Policies;
 
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\Prospect\Models\ProspectStatus;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use Illuminate\Auth\Access\Response;
 
@@ -54,6 +55,13 @@ class ProspectStatusPolicy
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view prospect statuses.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view prospect statuses.'
@@ -62,14 +70,28 @@ class ProspectStatusPolicy
 
     public function view(Authenticatable $authenticatable, ProspectStatus $prospectStatus): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this prospect status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectStatus->getKey()}.view"],
-            denyResponse: 'You do not have permission to view prospect statuses.'
+            denyResponse: 'You do not have permission to view prospect status.'
         );
     }
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create prospect statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create prospect statuses.'
@@ -82,9 +104,16 @@ class ProspectStatusPolicy
             return Response::deny('You cannot update this prospect status because it is system protected.');
         }
 
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update prospect status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectStatus->getKey()}.update"],
-            denyResponse: 'You do not have permission to update prospect statuses.'
+            denyResponse: 'You do not have permission to update prospect status.'
         );
     }
 
@@ -94,17 +123,31 @@ class ProspectStatusPolicy
             return Response::deny('You cannot delete this prospect status because it is system protected.');
         }
 
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.delete'],
+                denyResponse: 'You do not have permission to delete prospect status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectStatus->getKey()}.delete"],
-            denyResponse: 'You do not have permission to delete prospect statuses.'
+            denyResponse: 'You do not have permission to delete prospect status.'
         );
     }
 
     public function restore(Authenticatable $authenticatable, ProspectStatus $prospectStatus): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.restore'],
+                denyResponse: 'You do not have permission to restore prospect status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectStatus->getKey()}.restore"],
-            denyResponse: 'You do not have permission to restore prospect statuses.'
+            denyResponse: 'You do not have permission to restore prospect status.'
         );
     }
 
@@ -114,9 +157,16 @@ class ProspectStatusPolicy
             return Response::deny('You cannot delete this prospect status because it is system protected.');
         }
 
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.force-delete'],
+                denyResponse: 'You do not have permission to force delete prospect status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$prospectStatus->getKey()}.force-delete"],
-            denyResponse: 'You do not have permission to force delete prospect statuses.'
+            denyResponse: 'You do not have permission to force delete prospect status.'
         );
     }
 }

--- a/app-modules/prospect/tests/Tenant/Prospect/ViewProspectTest.php
+++ b/app-modules/prospect/tests/Tenant/Prospect/ViewProspectTest.php
@@ -230,7 +230,7 @@ test('can see prospect converted to student badge on', function (string $pages) 
 
     $user->givePermissionTo('event_attendee.view-any');
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user);
 

--- a/app-modules/prospect/tests/Tenant/ProspectSource/CreateProspectSourceTest.php
+++ b/app-modules/prospect/tests/Tenant/ProspectSource/CreateProspectSourceTest.php
@@ -95,8 +95,8 @@ test('CreateProspectSource is gated with proper access control', function () {
     livewire(ProspectSourceResource\Pages\CreateProspectSource::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/prospect/tests/Tenant/ProspectSource/EditProspectSourceTest.php
+++ b/app-modules/prospect/tests/Tenant/ProspectSource/EditProspectSourceTest.php
@@ -114,8 +114,8 @@ test('EditProspectSource is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/prospect/tests/Tenant/ProspectSource/ListProspectSourcesTest.php
+++ b/app-modules/prospect/tests/Tenant/ProspectSource/ListProspectSourcesTest.php
@@ -90,7 +90,7 @@ test('ListProspectSources is gated with proper access control', function () {
             ProspectSourceResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/prospect/tests/Tenant/ProspectSource/ViewProspectSourceTest.php
+++ b/app-modules/prospect/tests/Tenant/ProspectSource/ViewProspectSourceTest.php
@@ -74,8 +74,8 @@ test('ViewProspectSource is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(

--- a/app-modules/prospect/tests/Tenant/ProspectStatus/CreateProspectStatusTest.php
+++ b/app-modules/prospect/tests/Tenant/ProspectStatus/CreateProspectStatusTest.php
@@ -98,8 +98,8 @@ test('CreateProspectStatus is gated with proper access control', function () {
     livewire(ProspectStatusResource\Pages\CreateProspectStatus::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/prospect/tests/Tenant/ProspectStatus/EditProspectStatusTest.php
+++ b/app-modules/prospect/tests/Tenant/ProspectStatus/EditProspectStatusTest.php
@@ -124,8 +124,8 @@ test('EditProspectStatus is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(

--- a/app-modules/prospect/tests/Tenant/ProspectStatus/ListProspectStatusesTest.php
+++ b/app-modules/prospect/tests/Tenant/ProspectStatus/ListProspectStatusesTest.php
@@ -100,7 +100,7 @@ test('ListProspectStatuses is gated with proper access control', function () {
             ProspectStatusResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(

--- a/app-modules/prospect/tests/Tenant/ProspectStatus/ViewProspectStatusTest.php
+++ b/app-modules/prospect/tests/Tenant/ProspectStatus/ViewProspectStatusTest.php
@@ -80,8 +80,8 @@ test('ViewProspectStatus is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(

--- a/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
@@ -41,6 +41,7 @@ use AdvisingApp\ResourceHub\Models\ResourceHubCategory;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -65,6 +66,13 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view resource hub categories.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view resource hub categories.'
@@ -73,6 +81,13 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this resource hub category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubCategory->getKey()}.view"],
             denyResponse: 'You do not have permission to view this resource hub category.'
@@ -81,6 +96,13 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create resource hub categories.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create resource hub categories.'
@@ -89,6 +111,13 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this resource hub category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubCategory->getKey()}.update"],
             denyResponse: 'You do not have permission to update this resource hub category.'
@@ -97,6 +126,13 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permissions to delete this resource hub category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubCategory->getKey()}.delete"],
             denyResponse: 'You do not have permissions to delete this resource hub category.'
@@ -105,6 +141,13 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this resource hub category.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubCategory->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this resource hub category.'
@@ -113,6 +156,13 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this resource hub category.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubCategory->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this resource hub category.'

--- a/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
@@ -162,7 +162,7 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
                 denyResponse: 'You do not have permission to permanently delete this resource hub category.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubCategory->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this resource hub category.'

--- a/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
@@ -41,7 +41,7 @@ use AdvisingApp\ResourceHub\Models\ResourceHubCategory;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -66,7 +66,7 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view resource hub categories.'
@@ -81,7 +81,7 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this resource hub category.'
@@ -96,7 +96,7 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create resource hub categories.'
@@ -111,7 +111,7 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this resource hub category.'
@@ -126,7 +126,7 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permissions to delete this resource hub category.'
@@ -141,7 +141,7 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this resource hub category.'
@@ -156,7 +156,7 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this resource hub category.'

--- a/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
@@ -162,7 +162,7 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
                 denyResponse: 'You do not have permission to permanently delete this resource hub quality.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubQuality->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this resource hub quality.'

--- a/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
@@ -41,6 +41,7 @@ use AdvisingApp\ResourceHub\Models\ResourceHubQuality;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -65,6 +66,13 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view resource hub qualities.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view resource hub qualities.'
@@ -73,6 +81,13 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this resource hub quality.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubQuality->getKey()}.view"],
             denyResponse: 'You do not have permission to view this resource hub quality.'
@@ -81,6 +96,13 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create resource hub qualities.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create resource hub qualities.'
@@ -89,6 +111,13 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this resource hub quality.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubQuality->getKey()}.update"],
             denyResponse: 'You do not have permission to update this resource hub quality.'
@@ -97,6 +126,13 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this resource hub quality.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubQuality->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this resource hub quality.'
@@ -105,6 +141,13 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this resource hub quality.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubQuality->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this resource hub quality.'
@@ -113,6 +156,13 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this resource hub quality.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubQuality->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this resource hub quality.'

--- a/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
@@ -41,7 +41,7 @@ use AdvisingApp\ResourceHub\Models\ResourceHubQuality;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -66,7 +66,7 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view resource hub qualities.'
@@ -81,7 +81,7 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this resource hub quality.'
@@ -96,7 +96,7 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create resource hub qualities.'
@@ -111,7 +111,7 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this resource hub quality.'
@@ -126,7 +126,7 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this resource hub quality.'
@@ -141,7 +141,7 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this resource hub quality.'
@@ -156,7 +156,7 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this resource hub quality.'

--- a/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
@@ -41,6 +41,7 @@ use AdvisingApp\ResourceHub\Models\ResourceHubStatus;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -65,6 +66,13 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view any resource hub statuses.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view any resource hub statuses.'
@@ -73,6 +81,13 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this resource hub status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubStatus->getKey()}.view"],
             denyResponse: 'You do not have permission to view this resource hub status.'
@@ -81,6 +96,13 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create resource hub statuses.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create resource hub statuses.'
@@ -89,6 +111,13 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this resource hub status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubStatus->getKey()}.update"],
             denyResponse: 'You do not have permission to update this resource hub status.'
@@ -97,6 +126,13 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this resource hub status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubStatus->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this resource hub status.'
@@ -105,6 +141,13 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this resource hub status.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubStatus->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this resource hub status.'
@@ -113,6 +156,13 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this resource hub status.'
+            );  
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubStatus->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this resource hub status.'

--- a/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
@@ -72,7 +72,7 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
                 denyResponse: 'You do not have permission to view any resource hub statuses.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view any resource hub statuses.'
@@ -160,9 +160,9 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this resource hub status.'
-            );  
+            );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubStatus->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this resource hub status.'

--- a/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
@@ -41,7 +41,7 @@ use AdvisingApp\ResourceHub\Models\ResourceHubStatus;
 use App\Concerns\PerformsFeatureChecks;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Policies\Contracts\PerformsChecksBeforeAuthorization;
 use Illuminate\Auth\Access\Response;
@@ -66,7 +66,7 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view any resource hub statuses.'
@@ -81,7 +81,7 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function view(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this resource hub status.'
@@ -96,7 +96,7 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create resource hub statuses.'
@@ -111,7 +111,7 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function update(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this resource hub status.'
@@ -126,7 +126,7 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function delete(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this resource hub status.'
@@ -141,7 +141,7 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function restore(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this resource hub status.'
@@ -156,7 +156,7 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
 
     public function forceDelete(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this resource hub status.'

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/CreateResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/CreateResourceHubCategoryTest.php
@@ -65,8 +65,8 @@ test('CreateResourceHubCategory is gated with proper access control', function (
     livewire(CreateResourceHubCategory::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -94,8 +94,8 @@ test('CreateResourceHubCategory is gated with proper feature access control', fu
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/EditResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/EditResourceHubCategoryTest.php
@@ -70,8 +70,8 @@ test('EditResourceHubCategory is gated with proper access control', function () 
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -101,8 +101,8 @@ test('EditResourceHubCategory is gated with proper feature access control', func
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $resourceHubCategory = ResourceHubCategory::factory()->create();
 

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/ListResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/ListResourceHubCategoryTest.php
@@ -56,7 +56,7 @@ test('ListResourceHubCategory is gated with proper access control', function () 
             ResourceHubCategoryResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -73,7 +73,7 @@ test('ListResourceHubCategory is gated with proper feature access control', func
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -102,7 +102,7 @@ test('ListResourceHubCategory is gated with proper license access control', func
 
     // And the authenticatable has the correct permissions
     // But they do not have the appropriate license
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     // They should not be able to access the resource
     actingAs($user)

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/ViewResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/ViewResourceHubCategoryTest.php
@@ -59,8 +59,8 @@ test('ViewResourceHubCategory is gated with proper access control', function () 
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(
@@ -79,8 +79,8 @@ test('ViewResourceHubCategory is gated with proper feature access control', func
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $resourceHubCategory = ResourceHubCategory::factory()->create();
 

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/CreateResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/CreateResourceHubQualityTest.php
@@ -65,8 +65,8 @@ test('CreateResourceHubQuality is gated with proper access control', function ()
     livewire(CreateResourceHubQuality::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -94,8 +94,8 @@ test('CreateResourceHubQuality is gated with proper feature ccess control', func
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/EditResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/EditResourceHubQualityTest.php
@@ -70,8 +70,8 @@ test('EditResourceHubQuality is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -101,8 +101,8 @@ test('EditResourceHubQuality is gated with proper feature access control', funct
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $resourceHubQuality = ResourceHubQuality::factory()->create();
 

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/ListResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/ListResourceHubQualityTest.php
@@ -56,7 +56,7 @@ test('ListResourceHubQuality is gated with proper access control', function () {
             ResourceHubQualityResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -73,7 +73,7 @@ test('ListResourceHubQuality is gated with proper feature access control', funct
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -102,7 +102,7 @@ test('ListResourceHubQuality is gated with proper license access control', funct
 
     // And the authenticatable has the correct permissions
     // But they do not have the appropriate license
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     // They should not be able to access the resource
     actingAs($user)

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/ViewResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/ViewResourceHubQualityTest.php
@@ -59,8 +59,8 @@ test('ViewResourceHubQuality is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(
@@ -79,8 +79,8 @@ test('ViewResourceHubQuality is gated with proper feature access control', funct
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $resourceHubQuality = ResourceHubQuality::factory()->create();
 

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/CreateResourceHubStatusTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/CreateResourceHubStatusTest.php
@@ -65,8 +65,8 @@ test('CreateResourceHubStatus is gated with proper access control', function () 
     livewire(CreateResourceHubStatus::class)
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(
@@ -94,8 +94,8 @@ test('CreateResourceHubStatus is gated with proper feature access control', func
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.create');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.create');
 
     actingAs($user)
         ->get(

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/EditResourceHubStatusTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/EditResourceHubStatusTest.php
@@ -70,8 +70,8 @@ test('EditResourceHubStatus is gated with proper access control', function () {
     ])
         ->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     actingAs($user)
         ->get(
@@ -101,8 +101,8 @@ test('EditResourceHubStatus is gated with proper feature access control', functi
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.update');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
 
     $resourceHubStatus = ResourceHubStatus::factory()->create();
 

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/ListResourceHubStatusesTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/ListResourceHubStatusesTest.php
@@ -56,7 +56,7 @@ test('ListResourceHubStatuses is gated with proper access control', function () 
             ResourceHubStatusResource::getUrl('index')
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -73,7 +73,7 @@ test('ListResourceHubStatuses is gated with proper feature access control', func
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     actingAs($user)
         ->get(
@@ -102,7 +102,7 @@ test('ListResourceHubStatus is gated with proper license access control', functi
 
     // And the authenticatable has the correct permissions
     // But they do not have the appropriate license
-    $user->givePermissionTo('product_admin.view-any');
+    $user->givePermissionTo('settings.view-any');
 
     // They should not be able to access the resource
     actingAs($user)

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/ViewResourceHubStatusTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/ViewResourceHubStatusTest.php
@@ -59,8 +59,8 @@ test('ViewResourceHubStatus is gated with proper access control', function () {
             ])
         )->assertForbidden();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     actingAs($user)
         ->get(
@@ -79,8 +79,8 @@ test('ViewResourceHubStatus is gated with proper feature access control', functi
 
     $user = User::factory()->licensed(LicenseType::cases())->create();
 
-    $user->givePermissionTo('product_admin.view-any');
-    $user->givePermissionTo('product_admin.*.view');
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.view');
 
     $resourceHubStatus = ResourceHubStatus::factory()->create();
 

--- a/app-modules/student-data-model/src/Filament/Pages/ManageStudentConfiguration.php
+++ b/app-modules/student-data-model/src/Filament/Pages/ManageStudentConfiguration.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\StudentDataModel\Filament\Pages;
 
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\StudentDataModel\Settings\ManageStudentConfigurationSettings;
+use App\Features\SettingsPermissions;
 use App\Filament\Clusters\ConstituentManagement;
 use App\Models\User;
 use Filament\Forms\Components\Toggle;
@@ -63,7 +64,7 @@ class ManageStudentConfiguration extends SettingsPage
             return false;
         }
 
-        return $user->can(['product_admin.view-any']);
+        return SettingsPermissions::active() ? $user->can(['settings.view-any']) : $user->can('product_admin.view-any');
     }
 
     public function form(Form $form): Form

--- a/app-modules/student-data-model/src/Filament/Pages/ManageStudentConfiguration.php
+++ b/app-modules/student-data-model/src/Filament/Pages/ManageStudentConfiguration.php
@@ -64,7 +64,7 @@ class ManageStudentConfiguration extends SettingsPage
             return false;
         }
 
-        return SettingsPermissions::active() ? $user->can(['settings.view-any']) : $user->can('product_admin.view-any');
+        return SettingsPermissions::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
     }
 
     public function form(Form $form): Form

--- a/app-modules/theme/src/Filament/Pages/ManageCollegeBrandingSettings.php
+++ b/app-modules/theme/src/Filament/Pages/ManageCollegeBrandingSettings.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Theme\Filament\Pages;
 
+use App\Features\SettingsPermissons;
 use App\Filament\Clusters\DisplaySettings;
 use App\Filament\Forms\Components\ColorSelect;
 use App\Models\User;
@@ -63,7 +64,7 @@ class ManageCollegeBrandingSettings extends SettingsPage
         /** @var User $user */
         $user = auth()->user();
 
-        return $user->can(['product_admin.view-any']);
+        return SettingsPermissons::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
     }
 
     public function form(Form $form): Form

--- a/app-modules/theme/src/Filament/Pages/ManageCollegeBrandingSettings.php
+++ b/app-modules/theme/src/Filament/Pages/ManageCollegeBrandingSettings.php
@@ -36,7 +36,7 @@
 
 namespace AdvisingApp\Theme\Filament\Pages;
 
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Filament\Clusters\DisplaySettings;
 use App\Filament\Forms\Components\ColorSelect;
 use App\Models\User;
@@ -64,7 +64,7 @@ class ManageCollegeBrandingSettings extends SettingsPage
         /** @var User $user */
         $user = auth()->user();
 
-        return SettingsPermissons::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
+        return SettingsPermissions::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
     }
 
     public function form(Form $form): Form

--- a/app/Features/SettingsPermissions.php
+++ b/app/Features/SettingsPermissions.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/app/Features/SettingsPermissions.php
+++ b/app/Features/SettingsPermissions.php
@@ -4,7 +4,7 @@ namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;
 
-class SettingsPermissons extends AbstractFeatureFlag
+class SettingsPermissions extends AbstractFeatureFlag
 {
     public function resolve(mixed $scope): mixed
     {

--- a/app/Features/SettingsPermissons.php
+++ b/app/Features/SettingsPermissons.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class SettingsPermissons extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Filament/Clusters/ArtificialIntelligence.php
+++ b/app/Filament/Clusters/ArtificialIntelligence.php
@@ -40,7 +40,7 @@ use Filament\Clusters\Cluster;
 
 class ArtificialIntelligence extends Cluster
 {
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 20;
 

--- a/app/Filament/Clusters/CaseManagementAdministration.php
+++ b/app/Filament/Clusters/CaseManagementAdministration.php
@@ -40,7 +40,7 @@ use Filament\Clusters\Cluster;
 
 class CaseManagementAdministration extends Cluster
 {
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 70;
 

--- a/app/Filament/Clusters/Communication.php
+++ b/app/Filament/Clusters/Communication.php
@@ -40,7 +40,7 @@ use Filament\Clusters\Cluster;
 
 class Communication extends Cluster
 {
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?string $navigationLabel = 'Communication Settings';
 

--- a/app/Filament/Clusters/ConstituentManagement.php
+++ b/app/Filament/Clusters/ConstituentManagement.php
@@ -40,7 +40,7 @@ use Filament\Clusters\Cluster;
 
 class ConstituentManagement extends Cluster
 {
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 50;
 }

--- a/app/Filament/Clusters/DisplaySettings.php
+++ b/app/Filament/Clusters/DisplaySettings.php
@@ -40,7 +40,7 @@ use Filament\Clusters\Cluster;
 
 class DisplaySettings extends Cluster
 {
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 110;
 }

--- a/app/Filament/Clusters/InteractionManagement.php
+++ b/app/Filament/Clusters/InteractionManagement.php
@@ -47,7 +47,7 @@ use Filament\Resources\Resource;
 
 class InteractionManagement extends Cluster
 {
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 90;
 

--- a/app/Filament/Clusters/OnlineAdmissions.php
+++ b/app/Filament/Clusters/OnlineAdmissions.php
@@ -40,7 +40,7 @@ use Filament\Clusters\Cluster;
 
 class OnlineAdmissions extends Cluster
 {
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 100;
 }

--- a/app/Filament/Clusters/ProfileManagement.php
+++ b/app/Filament/Clusters/ProfileManagement.php
@@ -40,7 +40,7 @@ use Filament\Clusters\Cluster;
 
 class ProfileManagement extends Cluster
 {
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 30;
 }

--- a/app/Filament/Clusters/ResourceHub.php
+++ b/app/Filament/Clusters/ResourceHub.php
@@ -40,7 +40,7 @@ use Filament\Clusters\Cluster;
 
 class ResourceHub extends Cluster
 {
-    protected static ?string $navigationGroup = 'Product Administration';
+    protected static ?string $navigationGroup = 'Settings';
 
     protected static ?int $navigationSort = 80;
 }

--- a/app/Filament/Pages/ManageDisplaySettings.php
+++ b/app/Filament/Pages/ManageDisplaySettings.php
@@ -36,7 +36,7 @@
 
 namespace App\Filament\Pages;
 
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Filament\Clusters\DisplaySettings as DisplaySettingsCluster;
 use App\Models\User;
 use App\Settings\DisplaySettings;
@@ -61,7 +61,7 @@ class ManageDisplaySettings extends SettingsPage
         /** @var User $user */
         $user = auth()->user();
 
-        return SettingsPermissons::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
+        return SettingsPermissions::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
     }
 
     public function form(Form $form): Form

--- a/app/Filament/Pages/ManageDisplaySettings.php
+++ b/app/Filament/Pages/ManageDisplaySettings.php
@@ -36,6 +36,7 @@
 
 namespace App\Filament\Pages;
 
+use App\Features\SettingsPermissons;
 use App\Filament\Clusters\DisplaySettings as DisplaySettingsCluster;
 use App\Models\User;
 use App\Settings\DisplaySettings;
@@ -60,7 +61,7 @@ class ManageDisplaySettings extends SettingsPage
         /** @var User $user */
         $user = auth()->user();
 
-        return $user->can(['product_admin.view-any']);
+        return SettingsPermissons::active() ? $user->can(['settings.view-any']) : $user->can(['product_admin.view-any']);
     }
 
     public function form(Form $form): Form

--- a/app/Policies/NotificationSettingPolicy.php
+++ b/app/Policies/NotificationSettingPolicy.php
@@ -36,6 +36,7 @@
 
 namespace App\Policies;
 
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Models\NotificationSetting;
 use Illuminate\Auth\Access\Response;
@@ -44,6 +45,13 @@ class NotificationSettingPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view notification settings.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view notification settings.'
@@ -52,6 +60,13 @@ class NotificationSettingPolicy
 
     public function view(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this notification setting.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.view"],
             denyResponse: 'You do not have permission to view this notification setting.'
@@ -60,6 +75,13 @@ class NotificationSettingPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create notification settings.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create notification settings.'
@@ -68,6 +90,13 @@ class NotificationSettingPolicy
 
     public function update(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update this notification setting.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.update"],
             denyResponse: 'You do not have permission to update this notification setting.'
@@ -76,6 +105,13 @@ class NotificationSettingPolicy
 
     public function delete(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this notification setting.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this notification setting.'
@@ -84,6 +120,13 @@ class NotificationSettingPolicy
 
     public function restore(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this notification setting.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this notification setting.'
@@ -92,6 +135,13 @@ class NotificationSettingPolicy
 
     public function forceDelete(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this notification setting.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this notification setting.'

--- a/app/Policies/NotificationSettingPolicy.php
+++ b/app/Policies/NotificationSettingPolicy.php
@@ -36,7 +36,7 @@
 
 namespace App\Policies;
 
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Models\NotificationSetting;
 use Illuminate\Auth\Access\Response;
@@ -45,7 +45,7 @@ class NotificationSettingPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view notification settings.'
@@ -60,7 +60,7 @@ class NotificationSettingPolicy
 
     public function view(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this notification setting.'
@@ -75,7 +75,7 @@ class NotificationSettingPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create notification settings.'
@@ -90,7 +90,7 @@ class NotificationSettingPolicy
 
     public function update(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update this notification setting.'
@@ -105,7 +105,7 @@ class NotificationSettingPolicy
 
     public function delete(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete this notification setting.'
@@ -120,7 +120,7 @@ class NotificationSettingPolicy
 
     public function restore(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore this notification setting.'
@@ -135,7 +135,7 @@ class NotificationSettingPolicy
 
     public function forceDelete(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete this notification setting.'

--- a/app/Policies/NotificationSettingPolicy.php
+++ b/app/Policies/NotificationSettingPolicy.php
@@ -51,7 +51,7 @@ class NotificationSettingPolicy
                 denyResponse: 'You do not have permission to view notification settings.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.view-any',
             denyResponse: 'You do not have permission to view notification settings.'
@@ -141,7 +141,7 @@ class NotificationSettingPolicy
                 denyResponse: 'You do not have permission to permanently delete this notification setting.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$notificationSetting->getKey()}.force-delete"],
             denyResponse: 'You do not have permission to permanently delete this notification setting.'

--- a/app/Policies/PronounsPolicy.php
+++ b/app/Policies/PronounsPolicy.php
@@ -36,6 +36,7 @@
 
 namespace App\Policies;
 
+use App\Features\SettingsPermissons;
 use App\Models\Authenticatable;
 use App\Models\Pronouns;
 use Illuminate\Auth\Access\Response;
@@ -44,6 +45,13 @@ class PronounsPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view pronouns.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ['product_admin.view-any'],
             denyResponse: 'You do not have permission to view pronouns.'
@@ -52,14 +60,28 @@ class PronounsPolicy
 
     public function view(Authenticatable $authenticatable, Pronouns $model): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this pronoun.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.view"],
-            denyResponse: 'You do not have permission to view these pronouns.'
+            denyResponse: 'You do not have permission to view these pronoun.'
         );
     }
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create pronouns.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create pronouns.'
@@ -68,33 +90,61 @@ class PronounsPolicy
 
     public function update(Authenticatable $authenticatable, Pronouns $model): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.update',
+                denyResponse: 'You do not have permission to update these pronoun.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.update"],
-            denyResponse: 'You do not have permission to update these pronouns.'
+            denyResponse: 'You do not have permission to update these pronoun.'
         );
     }
 
     public function delete(Authenticatable $authenticatable, Pronouns $model): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete these pronoun.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.delete"],
-            denyResponse: 'You do not have permission to delete these pronouns.'
+            denyResponse: 'You do not have permission to delete these pronoun.'
         );
     }
 
     public function restore(Authenticatable $authenticatable, Pronouns $model): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore these pronoun.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.restore"],
-            denyResponse: 'You do not have permission to restore these pronouns.'
+            denyResponse: 'You do not have permission to restore these pronoun.'
         );
     }
 
     public function forceDelete(Authenticatable $authenticatable, Pronouns $model): Response
     {
+        if (SettingsPermissons::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete these pronoun.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$model->getKey()}.force-delete"],
-            denyResponse: 'You do not have permission to permanently delete these pronouns.'
+            denyResponse: 'You do not have permission to permanently delete these pronoun.'
         );
     }
 }

--- a/app/Policies/PronounsPolicy.php
+++ b/app/Policies/PronounsPolicy.php
@@ -36,7 +36,7 @@
 
 namespace App\Policies;
 
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Models\Pronouns;
 use Illuminate\Auth\Access\Response;
@@ -45,7 +45,7 @@ class PronounsPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.view-any',
                 denyResponse: 'You do not have permission to view pronouns.'
@@ -60,7 +60,7 @@ class PronounsPolicy
 
     public function view(Authenticatable $authenticatable, Pronouns $model): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.view',
                 denyResponse: 'You do not have permission to view this pronoun.'
@@ -75,7 +75,7 @@ class PronounsPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.create',
                 denyResponse: 'You do not have permission to create pronouns.'
@@ -90,7 +90,7 @@ class PronounsPolicy
 
     public function update(Authenticatable $authenticatable, Pronouns $model): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.update',
                 denyResponse: 'You do not have permission to update these pronoun.'
@@ -105,7 +105,7 @@ class PronounsPolicy
 
     public function delete(Authenticatable $authenticatable, Pronouns $model): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.delete',
                 denyResponse: 'You do not have permission to delete these pronoun.'
@@ -120,7 +120,7 @@ class PronounsPolicy
 
     public function restore(Authenticatable $authenticatable, Pronouns $model): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.restore',
                 denyResponse: 'You do not have permission to restore these pronoun.'
@@ -135,7 +135,7 @@ class PronounsPolicy
 
     public function forceDelete(Authenticatable $authenticatable, Pronouns $model): Response
     {
-        if (SettingsPermissons::active()) {
+        if (SettingsPermissions::active()) {
             return $authenticatable->canOrElse(
                 abilities: 'settings.*.force-delete',
                 denyResponse: 'You do not have permission to permanently delete these pronoun.'

--- a/app/Policies/PronounsPolicy.php
+++ b/app/Policies/PronounsPolicy.php
@@ -51,7 +51,7 @@ class PronounsPolicy
                 denyResponse: 'You do not have permission to view pronouns.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.view-any'],
             denyResponse: 'You do not have permission to view pronouns.'

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -53,7 +53,7 @@ class TagPolicy
                 denyResponse: 'You do not have permission to view tags.'
             );
         }
-        
+
         return $authenticatable->canOrElse(
             abilities: ['product_admin.view-any'],
             denyResponse: 'You do not have permission to view tags.'

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -38,6 +38,7 @@ namespace App\Policies;
 
 use AdvisingApp\Campaign\Models\CampaignAction;
 use App\Enums\TagType;
+use App\Features\SettingsPermissions;
 use App\Models\Authenticatable;
 use App\Models\Tag;
 use Illuminate\Auth\Access\Response;
@@ -46,6 +47,13 @@ class TagPolicy
 {
     public function viewAny(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.view-any',
+                denyResponse: 'You do not have permission to view tags.'
+            );
+        }
+        
         return $authenticatable->canOrElse(
             abilities: ['product_admin.view-any'],
             denyResponse: 'You do not have permission to view tags.'
@@ -54,6 +62,13 @@ class TagPolicy
 
     public function view(Authenticatable $authenticatable, Tag $tag): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.view',
+                denyResponse: 'You do not have permission to view this tag.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$tag->getKey()}.view"],
             denyResponse: 'You do not have permission to view this tag.'
@@ -62,6 +77,13 @@ class TagPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.create',
+                denyResponse: 'You do not have permission to create tags.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'product_admin.create',
             denyResponse: 'You do not have permission to create tags.'
@@ -70,6 +92,13 @@ class TagPolicy
 
     public function update(Authenticatable $authenticatable, Tag $tag): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: ['settings.*.update'],
+                denyResponse: 'You do not have permission to update this tag.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$tag->getKey()}.update"],
             denyResponse: 'You do not have permission to update this tag.'
@@ -86,6 +115,13 @@ class TagPolicy
             return Response::deny('Delete access denided as tag is used in other records');
         }
 
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.delete',
+                denyResponse: 'You do not have permission to delete this tag.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$tag->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this tag.'
@@ -94,6 +130,13 @@ class TagPolicy
 
     public function restore(Authenticatable $authenticatable, Tag $tag): Response
     {
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.restore',
+                denyResponse: 'You do not have permission to restore this tag.'
+            );
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$tag->getKey()}.restore"],
             denyResponse: 'You do not have permission to restore this tag.'
@@ -108,6 +151,13 @@ class TagPolicy
 
         if (($tag->type === TagType::Student && $tag->students()->exists()) || ($tag->type === TagType::Prospect && $tag->prospects()->exists()) || $tagExist) {
             return Response::deny('Delete access denided as tag is used in other records');
+        }
+
+        if (SettingsPermissions::active()) {
+            return $authenticatable->canOrElse(
+                abilities: 'settings.*.force-delete',
+                denyResponse: 'You do not have permission to permanently delete this tag.'
+            );
         }
 
         return $authenticatable->canOrElse(

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -164,7 +164,7 @@ class AdminPanelProvider extends PanelProvider
                     ->icon('heroicon-o-users')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('Product Administration')
+                    ->label('Settings')
                     ->icon('heroicon-o-wrench-screwdriver')
                     ->collapsed(),
                 NavigationGroup::make()

--- a/database/migrations/2025_07_14_105203_data_rename_product_admin_to_settings_permissions.php
+++ b/database/migrations/2025_07_14_105203_data_rename_product_admin_to_settings_permissions.php
@@ -1,0 +1,56 @@
+<?php
+
+use CanyonGBS\Common\Database\Migrations\Concerns\CanModifyPermissions;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    use CanModifyPermissions;
+
+    /**
+     * @var array<string, string> $productAdminToSettingsPermissions
+     */
+    private array $productAdminToSettingsPermissions = [
+        'product_admin.*.delete' => 'settings.*.delete',
+        'product_admin.*.force-delete' => 'settings.*.force-delete',
+        'product_admin.*.restore' => 'settings.*.restore',
+        'product_admin.*.update' => 'settings.*.update',
+        'product_admin.*.view' => 'settings.*.view',
+        'product_admin.create' => 'settings.create',
+        'product_admin.view-any' => 'settings.view-any',
+    ];
+
+    /**
+     * @var array<string> $guards
+     */
+    private array $guards = [
+        'web',
+        'api',
+    ];
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            collect($this->guards)->each(function (string $guard) {
+                $this->renamePermissions($this->productAdminToSettingsPermissions, $guard);
+            });
+
+            $this->renamePermissionGroups([
+                'Product Admin' => 'Settings',
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            collect($this->guards)->each(function (string $guard) {
+                $this->renamePermissions(array_flip($this->productAdminToSettingsPermissions), $guard);
+            });
+
+            $this->renamePermissionGroups([
+                'Settings' => 'Product Admin',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2025_07_14_105203_data_rename_product_admin_to_settings_permissions.php
+++ b/database/migrations/2025_07_14_105203_data_rename_product_admin_to_settings_permissions.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use CanyonGBS\Common\Database\Migrations\Concerns\CanModifyPermissions;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;

--- a/database/migrations/2025_07_14_110004_data_activate_settings_permissions_feature_flag.php
+++ b/database/migrations/2025_07_14_110004_data_activate_settings_permissions_feature_flag.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\SettingsPermissions;
 use Illuminate\Database\Migrations\Migration;
 

--- a/database/migrations/2025_07_14_110004_data_activate_settings_permissions_feature_flag.php
+++ b/database/migrations/2025_07_14_110004_data_activate_settings_permissions_feature_flag.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Features\SettingsPermissons;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        SettingsPermissons::activate();
+    }
+
+    public function down(): void
+    {
+        SettingsPermissons::deactivate();
+    }
+};

--- a/database/migrations/2025_07_14_110004_data_activate_settings_permissions_feature_flag.php
+++ b/database/migrations/2025_07_14_110004_data_activate_settings_permissions_feature_flag.php
@@ -1,16 +1,16 @@
 <?php
 
-use App\Features\SettingsPermissons;
+use App\Features\SettingsPermissions;
 use Illuminate\Database\Migrations\Migration;
 
 return new class () extends Migration {
     public function up(): void
     {
-        SettingsPermissons::activate();
+        SettingsPermissions::activate();
     }
 
     public function down(): void
     {
-        SettingsPermissons::deactivate();
+        SettingsPermissions::deactivate();
     }
 };


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1667

### Technical Description

> Improve the navigation by renaming product administration to a more commonly understood name of settings.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> Yes.
> SettingsPermissions.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
