### PR TITLE
[ADVAPP-1668]: Fix different filetype parsing

### DIFF
--- a/app-modules/ai/src/Actions/FetchFileParsingResults.php
+++ b/app-modules/ai/src/Actions/FetchFileParsingResults.php
@@ -47,12 +47,7 @@ class FetchFileParsingResults
 
     public function execute(string $fileId, string $mimetype): ?string
     {
-        // $response = Http::withToken(app(AiIntegrationsSettings::class)->llamaparse_api_key)
-        //     ->get("https://api.cloud.llamaindex.ai/api/v1/parsing/job/{$this->file->file_id}/details");
-
-        // logger()->debug('FetchQnaAdvisorFileParsingResults response', [
-        //     'response' => $response->json(),
-        // ]);
+        // TODO: Check the status of the file parsing job, if it is not completed, return null. If it is in an ERROR state then throw an exeception that upstream needs to handle.
 
         $outputFormat = match (true) {
             str($mimetype)->startsWith(['audio/', 'video/']) => 'text',

--- a/app-modules/ai/src/Actions/FetchFileParsingResults.php
+++ b/app-modules/ai/src/Actions/FetchFileParsingResults.php
@@ -47,6 +47,13 @@ class FetchFileParsingResults
 
     public function execute(string $fileId, string $mimetype): ?string
     {
+        // $response = Http::withToken(app(AiIntegrationsSettings::class)->llamaparse_api_key)
+        //     ->get("https://api.cloud.llamaindex.ai/api/v1/parsing/job/{$this->file->file_id}/details");
+
+        // logger()->debug('FetchQnaAdvisorFileParsingResults response', [
+        //     'response' => $response->json(),
+        // ]);
+
         $outputFormat = match (true) {
             str($mimetype)->startsWith(['audio/', 'video/']) => 'text',
             default => 'markdown',

--- a/app-modules/ai/src/Actions/UploadFileForParsing.php
+++ b/app-modules/ai/src/Actions/UploadFileForParsing.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Ai\Actions;
+
+use AdvisingApp\Ai\Settings\AiIntegrationsSettings;
+use Illuminate\Filesystem\AwsS3V3Adapter;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+class UploadFileForParsing
+{
+    public function __construct(
+        protected AiIntegrationsSettings $aiIntegrationsSettings,
+    ) {}
+
+    public function execute(string $path, string $name, string $mimeType): ?string
+    {
+        /** @var AwsS3V3Adapter $s3Adapter */
+        $s3Adapter = Storage::disk('s3')->getAdapter();
+
+        invade($s3Adapter)->client->registerStreamWrapper(); /** @phpstan-ignore-line */
+        $fileS3Path = (string) str('s3://' . config('filesystems.disks.s3.bucket') . '/' . $path)->replace('\\', '/');
+
+        $resource = fopen($fileS3Path, mode: 'r', context: stream_context_create([
+            's3' => [
+                'seekable' => true,
+            ],
+        ]));
+
+        $response = Http::attach(
+            'file',
+            $resource,
+            $name,
+            ['Content-Type' => $mimeType]
+        )
+            ->withToken($this->aiIntegrationsSettings->llamaparse_api_key)
+            ->acceptJson()
+            ->post('https://api.cloud.llamaindex.ai/api/v1/parsing/upload');
+
+        if ((! $response->successful()) || blank($response->json('id'))) {
+            return null;
+        }
+
+        return $response->json('id');
+    }
+}

--- a/app-modules/ai/src/Actions/UploadFileForParsing.php
+++ b/app-modules/ai/src/Actions/UploadFileForParsing.php
@@ -65,6 +65,7 @@ class UploadFileForParsing
         ]));
 
         $data = [
+            // TODO: Remove invalidate_cache
             'invalidate_cache' => true,
             'parse_mode' => 'parse_page_with_lvm',
             'user_prompt' => 'If the upload has images retrieve text from it and also describe the image in detail. If the upload seems to be just an image with no text in it, just return the image description.',

--- a/app-modules/ai/src/Actions/UploadFileForParsing.php
+++ b/app-modules/ai/src/Actions/UploadFileForParsing.php
@@ -70,6 +70,11 @@ class UploadFileForParsing
             'user_prompt' => 'If the upload has images retrieve text from it and also describe the image in detail. If the upload seems to be just an image with no text in it, just return the image description.',
         ];
 
+        /**
+         * For right now, we have been asked to use the default Institutional Advisor
+         * as the LVM Model for parsing.
+         * In the future we may want this to be configurable.
+         */
         $service = AiAssistant::query()
             ->where('is_default', true)
             ->first()

--- a/app-modules/ai/src/Actions/UploadFileForParsing.php
+++ b/app-modules/ai/src/Actions/UploadFileForParsing.php
@@ -69,7 +69,10 @@ class UploadFileForParsing
         )
             ->withToken($this->aiIntegrationsSettings->llamaparse_api_key)
             ->acceptJson()
-            ->post('https://api.cloud.llamaindex.ai/api/v1/parsing/upload');
+            ->post('https://api.cloud.llamaindex.ai/api/v1/parsing/upload', [
+                'parse_mode' => 'parse_page_with_lvm',
+                'user_prompt' => 'If the upload has images retrieve text from it and also describe the image in detail. If the upload seems to be just an image with no text in it, just return the image description.',
+            ]);
 
         if ((! $response->successful()) || blank($response->json('id'))) {
             return null;

--- a/app-modules/ai/src/Actions/UploadFileForParsing.php
+++ b/app-modules/ai/src/Actions/UploadFileForParsing.php
@@ -65,8 +65,6 @@ class UploadFileForParsing
         ]));
 
         $data = [
-            // TODO: Remove invalidate_cache
-            'invalidate_cache' => true,
             'parse_mode' => 'parse_page_with_lvm',
             'user_prompt' => 'If the upload has images retrieve text from it and also describe the image in detail. If the upload seems to be just an image with no text in it, just return the image description.',
         ];

--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanUploadFiles.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanUploadFiles.php
@@ -36,15 +36,14 @@
 
 namespace AdvisingApp\Ai\Filament\Pages\Assistant\Concerns;
 
+use AdvisingApp\Ai\Actions\UploadFileForParsing;
 use AdvisingApp\Ai\Models\AiMessageFile;
 use AdvisingApp\Ai\Settings\AiIntegrationsSettings;
 use Filament\Actions\Action;
 use Filament\Forms\Components\FileUpload;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Filesystem\AwsS3V3Adapter;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Storage;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
@@ -172,29 +171,13 @@ trait CanUploadFiles
                 $file->mime_type = $attachment->getMimeType();
                 $file->temporary_url = $attachment->temporaryUrl();
 
-                /** @var AwsS3V3Adapter $s3Adapter */
-                $s3Adapter = Storage::disk('s3')->getAdapter();
+                $fileId = app(UploadFileForParsing::class)->execute(
+                    path: $attachment->getRealPath(),
+                    name: $file->name,
+                    mimeType: $file->mime_type,
+                );
 
-                invade($s3Adapter)->client->registerStreamWrapper(); /** @phpstan-ignore-line */
-                $fileS3Path = (string) str('s3://' . config('filesystems.disks.s3.bucket') . '/' . $attachment->getRealPath())->replace('\\', '/');
-
-                $resource = fopen($fileS3Path, mode: 'r', context: stream_context_create([
-                    's3' => [
-                        'seekable' => true,
-                    ],
-                ]));
-
-                $response = Http::attach(
-                    'file',
-                    $resource,
-                    $file->name,
-                    ['Content-Type' => $file->mime_type]
-                )
-                    ->withToken(app(AiIntegrationsSettings::class)->llamaparse_api_key)
-                    ->acceptJson()
-                    ->post('https://api.cloud.llamaindex.ai/api/v1/parsing/upload');
-
-                if ((! $response->successful()) || blank($response->json('id'))) {
+                if (blank($fileId)) {
                     Notification::make()
                         ->title('File Upload Failed')
                         ->body('There was an error uploading the file. Please try again later.')
@@ -206,7 +189,7 @@ trait CanUploadFiles
                     return;
                 }
 
-                $file->file_id = $response->json('id');
+                $file->file_id = $fileId;
                 $file->save();
 
                 $file->addMediaFromUrl($file->temporary_url)->toMediaCollection('files');

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/ManageQnaAdditionalKnowledge.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/ManageQnaAdditionalKnowledge.php
@@ -208,7 +208,11 @@ class ManageQnaAdditionalKnowledge extends EditRecord
                 )
                     ->withToken(app(AiIntegrationsSettings::class)->llamaparse_api_key)
                     ->acceptJson()
-                    ->post('https://api.cloud.llamaindex.ai/api/v1/parsing/upload');
+                    ->post('https://api.cloud.llamaindex.ai/api/v1/parsing/upload', [
+                        'invalidate_cache' => true,
+                        'parse_mode' => 'parse_page_with_lvm',
+                        'user_prompt' => 'If the upload has images retrieve text from it and also describe the image in detail. If the upload seems to be just an image with no text in it, just return the image description.',
+                    ]);
 
                 if ((! $response->successful()) || blank($response->json('id'))) {
                     Notification::make()

--- a/app-modules/ai/src/Jobs/FetchAiAssistantFileParsingResults.php
+++ b/app-modules/ai/src/Jobs/FetchAiAssistantFileParsingResults.php
@@ -36,8 +36,8 @@
 
 namespace AdvisingApp\Ai\Jobs;
 
+use AdvisingApp\Ai\Actions\FetchFileParsingResults;
 use AdvisingApp\Ai\Models\AiAssistantFile;
-use AdvisingApp\Ai\Settings\AiIntegrationsSettings;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -45,7 +45,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Http;
 use Spatie\Multitenancy\Jobs\TenantAware;
 
 class FetchAiAssistantFileParsingResults implements ShouldQueue, TenantAware, ShouldBeUnique
@@ -66,14 +65,13 @@ class FetchAiAssistantFileParsingResults implements ShouldQueue, TenantAware, Sh
             return;
         }
 
-        $response = Http::withToken(app(AiIntegrationsSettings::class)->llamaparse_api_key)
-            ->get("https://api.cloud.llamaindex.ai/api/v1/parsing/job/{$this->file->file_id}/result/text");
+        $result = app(FetchFileParsingResults::class)->execute($this->file->file_id, $this->file->mime_type);
 
-        if ((! $response->successful()) || blank($response->json('text'))) {
+        if (blank($result)) {
             return;
         }
 
-        $this->file->parsing_results = $response->json('text');
+        $this->file->parsing_results = $result;
         $this->file->save();
     }
 

--- a/app-modules/ai/src/Jobs/FetchQnaAdvisorFileParsingResults.php
+++ b/app-modules/ai/src/Jobs/FetchQnaAdvisorFileParsingResults.php
@@ -67,6 +67,13 @@ class FetchQnaAdvisorFileParsingResults implements ShouldQueue, TenantAware, Sho
         }
 
         $response = Http::withToken(app(AiIntegrationsSettings::class)->llamaparse_api_key)
+            ->get("https://api.cloud.llamaindex.ai/api/v1/parsing/job/{$this->file->file_id}/details");
+
+        logger()->debug('FetchQnaAdvisorFileParsingResults response', [
+            'response' => $response->json(),
+        ]);
+
+        $response = Http::withToken(app(AiIntegrationsSettings::class)->llamaparse_api_key)
             ->get("https://api.cloud.llamaindex.ai/api/v1/parsing/job/{$this->file->file_id}/result/markdown");
 
         if ((! $response->successful()) || blank($response->json('markdown'))) {

--- a/app-modules/ai/src/Jobs/FetchQnaAdvisorFileParsingResults.php
+++ b/app-modules/ai/src/Jobs/FetchQnaAdvisorFileParsingResults.php
@@ -67,13 +67,13 @@ class FetchQnaAdvisorFileParsingResults implements ShouldQueue, TenantAware, Sho
         }
 
         $response = Http::withToken(app(AiIntegrationsSettings::class)->llamaparse_api_key)
-            ->get("https://api.cloud.llamaindex.ai/api/v1/parsing/job/{$this->file->file_id}/result/text");
+            ->get("https://api.cloud.llamaindex.ai/api/v1/parsing/job/{$this->file->file_id}/result/markdown");
 
-        if ((! $response->successful()) || blank($response->json('text'))) {
+        if ((! $response->successful()) || blank($response->json('markdown'))) {
             return;
         }
 
-        $this->file->parsing_results = $response->json('text');
+        $this->file->parsing_results = $response->json('markdown');
         $this->file->save();
     }
 

--- a/app-modules/ai/src/Jobs/FetchQnaAdvisorFileParsingResults.php
+++ b/app-modules/ai/src/Jobs/FetchQnaAdvisorFileParsingResults.php
@@ -38,7 +38,6 @@ namespace AdvisingApp\Ai\Jobs;
 
 use AdvisingApp\Ai\Actions\FetchFileParsingResults;
 use AdvisingApp\Ai\Models\QnaAdvisorFile;
-use AdvisingApp\Ai\Settings\AiIntegrationsSettings;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
@@ -46,7 +45,6 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Http;
 use Spatie\Multitenancy\Jobs\TenantAware;
 
 class FetchQnaAdvisorFileParsingResults implements ShouldQueue, TenantAware, ShouldBeUnique
@@ -66,13 +64,6 @@ class FetchQnaAdvisorFileParsingResults implements ShouldQueue, TenantAware, Sho
         if (filled($this->file->parsing_results)) {
             return;
         }
-
-        // $response = Http::withToken(app(AiIntegrationsSettings::class)->llamaparse_api_key)
-        //     ->get("https://api.cloud.llamaindex.ai/api/v1/parsing/job/{$this->file->file_id}/details");
-
-        // logger()->debug('FetchQnaAdvisorFileParsingResults response', [
-        //     'response' => $response->json(),
-        // ]);
 
         $result = app(FetchFileParsingResults::class)->execute($this->file->file_id, $this->file->mime_type);
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1668

### Technical Description

Ensures that Llamaparse content is retrieved as `markdown` when we can. And also modies the way we tell it to parse so it can handle non-document files.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
