### PR TITLE
[ADVAPP-1686]: Remove legacy purchase order fields in the data model and interface under subscription information for global administrators

### DIFF
--- a/app/Console/Commands/CreateTenant.php
+++ b/app/Console/Commands/CreateTenant.php
@@ -122,8 +122,6 @@ class CreateTenant extends Command
                 subscription: new LicenseSubscriptionData(
                     clientName: 'Jane Smith',
                     partnerName: 'Fake Edu Tech',
-                    clientPo: 'abc123',
-                    partnerPo: 'def456',
                     startDate: now(),
                     endDate: now()->addYear(),
                 ),

--- a/app/DataTransferObjects/LicenseManagement/LicenseSubscriptionData.php
+++ b/app/DataTransferObjects/LicenseManagement/LicenseSubscriptionData.php
@@ -47,8 +47,6 @@ class LicenseSubscriptionData extends Data
     public function __construct(
         public ?string $clientName,
         public ?string $partnerName,
-        public ?string $clientPo,
-        public ?string $partnerPo,
         public ?Carbon $startDate,
         public ?Carbon $endDate,
     ) {}

--- a/app/Filament/Pages/ManageLicenseSettings.php
+++ b/app/Filament/Pages/ManageLicenseSettings.php
@@ -82,12 +82,6 @@ class ManageLicenseSettings extends SettingsPage
                             TextInput::make('data.subscription.partnerName')
                                 ->label('Partner Name')
                                 ->required(),
-                            TextInput::make('data.subscription.clientPo')
-                                ->label('Client PO')
-                                ->required(),
-                            TextInput::make('data.subscription.partnerPo')
-                                ->label('Partner PO')
-                                ->required(),
                             DatePicker::make('data.subscription.startDate')
                                 ->label('Start Date')
                                 ->required()

--- a/app/Http/Requests/Tenants/CreateTenantRequest.php
+++ b/app/Http/Requests/Tenants/CreateTenantRequest.php
@@ -79,8 +79,6 @@ class CreateTenantRequest extends FormRequest
             'subscription' => ['required', 'array'],
             'subscription.clientName' => ['required', 'string'],
             'subscription.partnerName' => ['required', 'string'],
-            'subscription.clientPo' => ['required', 'string'],
-            'subscription.partnerPo' => ['required', 'string'],
             'subscription.startDate' => ['required', 'string'],
             'subscription.endDate' => ['required', 'string'],
             'theme.color_overrides' => ['nullable', 'array'],

--- a/app/Http/Requests/Tenants/SyncTenantRequest.php
+++ b/app/Http/Requests/Tenants/SyncTenantRequest.php
@@ -78,8 +78,6 @@ class SyncTenantRequest extends FormRequest
             'subscription' => ['required', 'array'],
             'subscription.clientName' => ['required', 'string'],
             'subscription.partnerName' => ['required', 'string'],
-            'subscription.clientPo' => ['required', 'string'],
-            'subscription.partnerPo' => ['required', 'string'],
             'subscription.startDate' => ['required', 'string'],
             'subscription.endDate' => ['required', 'string'],
         ];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -114,8 +114,6 @@ abstract class TestCase extends BaseTestCase
                     subscription: new LicenseSubscriptionData(
                         clientName: 'Jane Smith',
                         partnerName: 'Fake Edu Tech',
-                        clientPo: 'abc123',
-                        partnerPo: 'def456',
                         startDate: now(),
                         endDate: now()->addYear(),
                     ),
@@ -215,8 +213,6 @@ abstract class TestCase extends BaseTestCase
                 subscription: new LicenseSubscriptionData(
                     clientName: 'Jane Smith',
                     partnerName: 'Fake Edu Tech',
-                    clientPo: 'abc123',
-                    partnerPo: 'def456',
                     startDate: now(),
                     endDate: now()->addYear(),
                 ),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1686

### Technical Description

Remove the purchase order fields from Subscriptions. No need for any sort of migration as the data is loading into a setting via DTO. So it will just not be used and removed the next time the Subscription is updated.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
