### PR TITLE
[ADVAPP-1621]: Enhance QnA Advisor capabilities by introducing the ability systematically generate background instructions as the advisor is updated.

### DIFF
--- a/app-modules/ai/database/migrations/2025_07_15_215736_add_restrictions_setting_to_ai_qna_advisor_settings.php
+++ b/app-modules/ai/database/migrations/2025_07_15_215736_add_restrictions_setting_to_ai_qna_advisor_settings.php
@@ -34,25 +34,26 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Ai\Settings;
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsBlueprint;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
-use AdvisingApp\Ai\Enums\AiModel;
-use Spatie\LaravelSettings\Settings;
-
-class AiQnaAdvisorSettings extends Settings
-{
-    public bool $allow_selection_of_model = true;
-
-    public ?AiModel $preselected_model = null;
-
-    public ?string $instructions = null;
-
-    public ?string $background_information = null;
-
-    public ?string $restrictions = null;
-
-    public static function group(): string
+return new class () extends SettingsMigration {
+    public function up(): void
     {
-        return 'ai-qna-advisor';
+        $this->migrator->inGroup('ai-qna-advisor', function (SettingsBlueprint $blueprint) {
+            try {
+                $blueprint->add('restrictions', null);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+        });
     }
-}
+
+    public function down(): void
+    {
+        $this->migrator->inGroup('ai-qna-advisor', function (SettingsBlueprint $blueprint) {
+            $blueprint->delete('restrictions');
+        });
+    }
+};

--- a/app-modules/ai/src/Actions/GetQnaAdvisorInstructions.php
+++ b/app-modules/ai/src/Actions/GetQnaAdvisorInstructions.php
@@ -6,33 +6,36 @@ use AdvisingApp\Ai\Models\QnaAdvisor;
 use AdvisingApp\Ai\Models\QnaAdvisorCategory;
 use AdvisingApp\Ai\Models\QnaAdvisorQuestion;
 use AdvisingApp\Ai\Settings\AiQnaAdvisorSettings;
+use Illuminate\Support\Facades\Cache;
 
 class GetQnaAdvisorInstructions
 {
     public function execute(QnaAdvisor $qnaAdvisor): string
     {
-        $settings = app(AiQnaAdvisorSettings::class);
+        return Cache::tags(['qna_advisor_instructions'])->remember($qnaAdvisor->getInstructionsCacheKey(), now()->addHour(), function () use ($qnaAdvisor) {
+            $settings = app(AiQnaAdvisorSettings::class);
 
-        $instructions = $settings->instructions ?? '';
-        $backgroundInformation = $settings->background_information ?? '';
+            $instructions = $settings->instructions ?? '';
+            $backgroundInformation = $settings->background_information ?? '';
 
-        $qnaSection = $this->generateQnaSection($qnaAdvisor);
+            $qnaSection = $this->generateQnaSection($qnaAdvisor);
 
-        $restrictions = $settings->restrictions ?? '';
+            $restrictions = $settings->restrictions ?? '';
 
-        return <<<END
+            return <<<END
 
-        # Instructions
-        {$instructions}
+            # Instructions
+            {$instructions}
 
-        ## Institutional Background Information
-        {$backgroundInformation}
+            ## Institutional Background Information
+            {$backgroundInformation}
 
-        {$qnaSection}
-        ## Restrictions
-        {$restrictions}
+            {$qnaSection}
+            ## Restrictions
+            {$restrictions}
 
-        END;
+            END;
+        });
     }
 
     protected function generateQnaSection(QnaAdvisor $qnaAdvisor): string

--- a/app-modules/ai/src/Actions/GetQnaAdvisorInstructions.php
+++ b/app-modules/ai/src/Actions/GetQnaAdvisorInstructions.php
@@ -12,30 +12,35 @@ class GetQnaAdvisorInstructions
 {
     public function execute(QnaAdvisor $qnaAdvisor): string
     {
-        return Cache::tags(['qna_advisor_instructions'])->remember($qnaAdvisor->getInstructionsCacheKey(), now()->addHour(), function () use ($qnaAdvisor) {
-            $settings = app(AiQnaAdvisorSettings::class);
+        return Cache::tags(['{qna_advisor_instructions}'])
+            ->remember(
+                $qnaAdvisor->getInstructionsCacheKey(),
+                now()->addHour(),
+                function () use ($qnaAdvisor) {
+                    $settings = app(AiQnaAdvisorSettings::class);
 
-            $instructions = $settings->instructions ?? '';
-            $backgroundInformation = $settings->background_information ?? '';
+                    $instructions = $settings->instructions ?? '';
+                    $backgroundInformation = $settings->background_information ?? '';
 
-            $qnaSection = $this->generateQnaSection($qnaAdvisor);
+                    $qnaSection = $this->generateQnaSection($qnaAdvisor);
 
-            $restrictions = $settings->restrictions ?? '';
+                    $restrictions = $settings->restrictions ?? '';
 
-            return <<<END
+                    return <<<END
 
-            # Instructions
-            {$instructions}
+                    # Instructions
+                    {$instructions}
 
-            ## Institutional Background Information
-            {$backgroundInformation}
+                    ## Institutional Background Information
+                    {$backgroundInformation}
 
-            {$qnaSection}
-            ## Restrictions
-            {$restrictions}
+                    {$qnaSection}
+                    ## Restrictions
+                    {$restrictions}
 
-            END;
-        });
+                    END;
+                }
+            );
     }
 
     protected function generateQnaSection(QnaAdvisor $qnaAdvisor): string

--- a/app-modules/ai/src/Actions/GetQnaAdvisorInstructions.php
+++ b/app-modules/ai/src/Actions/GetQnaAdvisorInstructions.php
@@ -5,10 +5,37 @@ namespace AdvisingApp\Ai\Actions;
 use AdvisingApp\Ai\Models\QnaAdvisor;
 use AdvisingApp\Ai\Models\QnaAdvisorCategory;
 use AdvisingApp\Ai\Models\QnaAdvisorQuestion;
+use AdvisingApp\Ai\Settings\AiQnaAdvisorSettings;
 
 class GetQnaAdvisorInstructions
 {
     public function execute(QnaAdvisor $qnaAdvisor): string
+    {
+        $settings = app(AiQnaAdvisorSettings::class);
+
+        $instructions = $settings->instructions ?? '';
+        $backgroundInformation = $settings->background_information ?? '';
+
+        $qnaSection = $this->generateQnaSection($qnaAdvisor);
+
+        $restrictions = $settings->restrictions ?? '';
+
+        return <<<END
+
+        # Instructions
+        {$instructions}
+
+        ## Institutional Background Information
+        {$backgroundInformation}
+
+        {$qnaSection}
+        ## Restrictions
+        {$restrictions}
+
+        END;
+    }
+
+    protected function generateQnaSection(QnaAdvisor $qnaAdvisor): string
     {
         $qnaAdvisor->loadMissing('categories.questions');
 

--- a/app-modules/ai/src/Actions/GetQnaAdvisorInstructions.php
+++ b/app-modules/ai/src/Actions/GetQnaAdvisorInstructions.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace AdvisingApp\Ai\Actions;
+
+use AdvisingApp\Ai\Models\QnaAdvisor;
+use AdvisingApp\Ai\Models\QnaAdvisorCategory;
+use AdvisingApp\Ai\Models\QnaAdvisorQuestion;
+
+class GetQnaAdvisorInstructions
+{
+    public function execute(QnaAdvisor $qnaAdvisor): string
+    {
+        $qnaAdvisor->loadMissing('categories.questions');
+
+        /**
+         * Note: Please be careful in adjusting tabing / spacing within the HEREDOCs as even a minor change can cause the markdown to render incorrectly.
+         */
+        $qnaSection = <<<END
+        ## Questions and Answers
+        This section contains the specialized knowledge you will use to answer questions from students via a conversational bot experience.
+
+
+        END;
+
+        $qnaAdvisor
+            ->categories
+            ->where(fn (QnaAdvisorCategory $category) => $category->questions->isNotEmpty())
+            ->each(function (QnaAdvisorCategory $category) use (&$qnaSection) {
+                $questions = $category->questions->reduce(
+                    function (string $carry, QnaAdvisorQuestion $question) {
+                        return $carry . <<<END
+                        #### {$question->question}
+                        {$question->answer}
+                    
+                    
+                    END;
+                    },
+                    ''
+                );
+
+                $qnaSection .= <<<END
+                ### Category
+                {$category->name}
+                {$category->description}
+                The following questions are part of this category of knowledge for you to use when answering student questions.
+
+            {$questions}
+            END;
+            });
+
+        return $qnaSection;
+    }
+}

--- a/app-modules/ai/src/Filament/Pages/ManageAiQnaAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiQnaAdvisorSettings.php
@@ -87,12 +87,21 @@ class ManageAiQnaAdvisorSettings extends ManageAiICustomAdvisorSettings
                 Textarea::make('instructions')
                     ->label('Instructions')
                     ->columnSpanFull()
+                    ->rows(10)
                     ->maxLength(65535)
                     ->required(),
                 Textarea::make('background_information')
                     ->label('Background Information')
                     ->columnSpanFull()
+                    ->rows(10)
                     ->maxLength(65535)
+                    ->required(),
+                Textarea::make('restrictions')
+                    ->label('Restrictions')
+                    ->columnSpanFull()
+                    ->rows(10)
+                    ->maxLength(65535)
+                    ->helperText('These restrictions will be applied to the QnA advisor. Use this field to specify any limitations or guidelines for the AI model.')
                     ->required(),
             ]);
     }

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/ViewQnaAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/ViewQnaAdvisor.php
@@ -91,7 +91,6 @@ class ViewQnaAdvisor extends ViewRecord
                                     ->hiddenLabel()
                                     ->columnSpanFull()
                                     ->markdown()
-                                    // ->extraAttributes(['class' => 'overflow-auto'])
                                     ->getStateUsing(fn (QnaAdvisor $record): string => app(GetQnaAdvisorInstructions::class)->execute($record)),
                             ]),
                     ])->visible(fn () => auth()->guard('web')->user()?->isSuperAdmin()),

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/ViewQnaAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/ViewQnaAdvisor.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Ai\Filament\Resources\QnaAdvisorResource\Pages;
 
+use AdvisingApp\Ai\Actions\GetQnaAdvisorInstructions;
 use AdvisingApp\Ai\Filament\Resources\QnaAdvisorResource;
 use AdvisingApp\Ai\Models\QnaAdvisor;
 use Filament\Actions\Action;
@@ -45,6 +46,7 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
 class ViewQnaAdvisor extends ViewRecord
@@ -65,6 +67,13 @@ class ViewQnaAdvisor extends ViewRecord
                     ->circular(),
                 TextEntry::make('name'),
                 TextEntry::make('description'),
+                TextEntry::make('markdown')
+                    ->columnSpanFull()
+                    ->html()
+                    ->extraAttributes(['class' => 'overflow-auto'])
+                    ->getStateUsing(fn (QnaAdvisor $record): string => new HtmlString(
+                        '<pre>' . app(GetQnaAdvisorInstructions::class)->execute($record) . '</pre>'
+                    )),
             ]),
         ]);
     }

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/ViewQnaAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/ViewQnaAdvisor.php
@@ -42,6 +42,8 @@ use AdvisingApp\Ai\Models\QnaAdvisor;
 use Filament\Actions\Action;
 use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\SpatieMediaLibraryImageEntry;
+use Filament\Infolists\Components\Tabs;
+use Filament\Infolists\Components\Tabs\Tab;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Infolist;
 use Filament\Notifications\Notification;
@@ -67,13 +69,32 @@ class ViewQnaAdvisor extends ViewRecord
                     ->circular(),
                 TextEntry::make('name'),
                 TextEntry::make('description'),
-                TextEntry::make('markdown')
-                    ->columnSpanFull()
-                    ->html()
-                    ->extraAttributes(['class' => 'overflow-auto'])
-                    ->getStateUsing(fn (QnaAdvisor $record): string => new HtmlString(
-                        '<pre>' . app(GetQnaAdvisorInstructions::class)->execute($record) . '</pre>'
-                    )),
+                Tabs::make('Generated Instructions')
+                    ->tabs([
+                        Tab::make('Generated Instructions Markdown')
+                            ->icon('heroicon-o-document-text')
+                            ->schema([
+                                TextEntry::make('generated_instructions')
+                                    ->hiddenLabel()
+                                    ->columnSpanFull()
+                                    ->html()
+                                    ->extraAttributes(['class' => 'overflow-auto'])
+                                    ->getStateUsing(fn (QnaAdvisor $record): string => new HtmlString(
+                                        '<pre>' . app(GetQnaAdvisorInstructions::class)->execute($record) . '</pre>'
+                                    )),
+                            ]),
+                        Tab::make('Rendered')
+                            ->hiddenLabel()
+                            ->icon('heroicon-o-eye')
+                            ->schema([
+                                TextEntry::make('generated_instructions_preview')
+                                    ->hiddenLabel()
+                                    ->columnSpanFull()
+                                    ->markdown()
+                                    // ->extraAttributes(['class' => 'overflow-auto'])
+                                    ->getStateUsing(fn (QnaAdvisor $record): string => app(GetQnaAdvisorInstructions::class)->execute($record)),
+                            ]),
+                    ])->visible(fn () => auth()->guard('web')->user()?->isSuperAdmin()),
             ]),
         ]);
     }

--- a/app-modules/ai/src/Listeners/ClearQnaAdvisorInstructionsCacheOnGlobalSettingsUpdate.php
+++ b/app-modules/ai/src/Listeners/ClearQnaAdvisorInstructionsCacheOnGlobalSettingsUpdate.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AdvisingApp\Ai\Listeners;
+
+use AdvisingApp\Ai\Settings\AiQnaAdvisorSettings;
+use Illuminate\Support\Facades\Cache;
+use Spatie\LaravelSettings\Events\SettingsSaved;
+
+class ClearQnaAdvisorInstructionsCacheOnGlobalSettingsUpdate
+{
+    public function handle(SettingsSaved $event): void
+    {
+        if ($event->settings instanceof AiQnaAdvisorSettings) {
+            Cache::tags(['qna_advisor_instructions'])->flush();
+        }
+    }
+}

--- a/app-modules/ai/src/Models/QnaAdvisor.php
+++ b/app-modules/ai/src/Models/QnaAdvisor.php
@@ -127,4 +127,9 @@ class QnaAdvisor extends BaseModel implements HasMedia, Auditable
     {
         return $this->hasMany(QnaAdvisorFile::class, 'advisor_id');
     }
+
+    public function getInstructionsCacheKey(): string
+    {
+        return 'qna-advisor-' . $this->getKey() . '-instructions';
+    }
 }

--- a/app-modules/ai/src/Models/QnaAdvisorCategory.php
+++ b/app-modules/ai/src/Models/QnaAdvisorCategory.php
@@ -36,7 +36,9 @@
 
 namespace AdvisingApp\Ai\Models;
 
+use AdvisingApp\Ai\Observers\QnaAdvisorCategoryObserver;
 use App\Models\BaseModel;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -46,6 +48,7 @@ use OwenIt\Auditing\Contracts\Auditable;
 /**
  * @mixin IdeHelperQnaAdvisorCategory
  */
+#[ObservedBy(QnaAdvisorCategoryObserver::class)]
 class QnaAdvisorCategory extends BaseModel implements Auditable
 {
     use SoftDeletes;

--- a/app-modules/ai/src/Models/QnaAdvisorQuestion.php
+++ b/app-modules/ai/src/Models/QnaAdvisorQuestion.php
@@ -36,7 +36,9 @@
 
 namespace AdvisingApp\Ai\Models;
 
+use AdvisingApp\Ai\Observers\QnaAdvisorQuestionObserver;
 use App\Models\BaseModel;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use OwenIt\Auditing\Auditable as AuditableTrait;
@@ -45,6 +47,7 @@ use OwenIt\Auditing\Contracts\Auditable;
 /**
  * @mixin IdeHelperQnaAdvisorQuestion
  */
+#[ObservedBy(QnaAdvisorQuestionObserver::class)]
 class QnaAdvisorQuestion extends BaseModel implements Auditable
 {
     use SoftDeletes;

--- a/app-modules/ai/src/Observers/QnaAdvisorCategoryObserver.php
+++ b/app-modules/ai/src/Observers/QnaAdvisorCategoryObserver.php
@@ -9,11 +9,11 @@ class QnaAdvisorCategoryObserver
 {
     public function saved(QnaAdvisorCategory $category): void
     {
-        Cache::forget($category->qnaAdvisor->getInstructionsCacheKey());
+        Cache::tags(['{qna_advisor_instructions}'])->forget($category->qnaAdvisor->getInstructionsCacheKey());
     }
 
     public function deleted(QnaAdvisorCategory $category): void
     {
-        Cache::forget($category->qnaAdvisor->getInstructionsCacheKey());
+        Cache::tags(['{qna_advisor_instructions}'])->forget($category->qnaAdvisor->getInstructionsCacheKey());
     }
 }

--- a/app-modules/ai/src/Observers/QnaAdvisorCategoryObserver.php
+++ b/app-modules/ai/src/Observers/QnaAdvisorCategoryObserver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AdvisingApp\Ai\Observers;
+
+use AdvisingApp\Ai\Models\QnaAdvisorCategory;
+use Illuminate\Support\Facades\Cache;
+
+class QnaAdvisorCategoryObserver
+{
+    public function saved(QnaAdvisorCategory $category): void
+    {
+        Cache::forget($category->qnaAdvisor->getInstructionsCacheKey());
+    }
+
+    public function deleted(QnaAdvisorCategory $category): void
+    {
+        Cache::forget($category->qnaAdvisor->getInstructionsCacheKey());
+    }
+}

--- a/app-modules/ai/src/Observers/QnaAdvisorQuestionObserver.php
+++ b/app-modules/ai/src/Observers/QnaAdvisorQuestionObserver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AdvisingApp\Ai\Observers;
+
+use AdvisingApp\Ai\Models\QnaAdvisorQuestion;
+use Illuminate\Support\Facades\Cache;
+
+class QnaAdvisorQuestionObserver
+{
+    public function saved(QnaAdvisorQuestion $question): void
+    {
+        Cache::forget($question->category->qnaAdvisor->getInstructionsCacheKey());
+    }
+
+    public function deleted(QnaAdvisorQuestion $question): void
+    {
+        Cache::forget($question->category->qnaAdvisor->getInstructionsCacheKey());
+    }
+}

--- a/app-modules/ai/src/Observers/QnaAdvisorQuestionObserver.php
+++ b/app-modules/ai/src/Observers/QnaAdvisorQuestionObserver.php
@@ -9,11 +9,11 @@ class QnaAdvisorQuestionObserver
 {
     public function saved(QnaAdvisorQuestion $question): void
     {
-        Cache::forget($question->category->qnaAdvisor->getInstructionsCacheKey());
+        Cache::tags(['{qna_advisor_instructions}'])->forget($question->category->qnaAdvisor->getInstructionsCacheKey());
     }
 
     public function deleted(QnaAdvisorQuestion $question): void
     {
-        Cache::forget($question->category->qnaAdvisor->getInstructionsCacheKey());
+        Cache::tags(['{qna_advisor_instructions}'])->forget($question->category->qnaAdvisor->getInstructionsCacheKey());
     }
 }

--- a/app-modules/ai/src/Providers/AiServiceProvider.php
+++ b/app-modules/ai/src/Providers/AiServiceProvider.php
@@ -43,6 +43,7 @@ use AdvisingApp\Ai\Events\AiMessageTrashed;
 use AdvisingApp\Ai\Events\AiThreadForceDeleting;
 use AdvisingApp\Ai\Events\AiThreadTrashed;
 use AdvisingApp\Ai\Events\AssistantFilesFinishedUploading;
+use AdvisingApp\Ai\Listeners\ClearQnaAdvisorInstructionsCacheOnGlobalSettingsUpdate;
 use AdvisingApp\Ai\Listeners\HandleAssistantFilesFinishedUploading;
 use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiAssistantFile;
@@ -60,6 +61,7 @@ use Filament\Panel;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Spatie\LaravelSettings\Events\SettingsSaved;
 
 class AiServiceProvider extends ServiceProvider
 {
@@ -72,6 +74,7 @@ class AiServiceProvider extends ServiceProvider
         AiMessageCreated::class => AiMessageCreated::LISTENERS,
         AiMessageTrashed::class => AiMessageTrashed::LISTENERS,
         AiMessageFileForceDeleting::class => AiMessageFileForceDeleting::LISTENERS,
+        SettingsSaved::class => [ClearQnaAdvisorInstructionsCacheOnGlobalSettingsUpdate::class],
     ];
 
     public function register(): void


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1621

### Technical Description

Add an Action class for generating the instructions for a QnaAdvisor and displays it in a section only visible to super admins.

Also cache this result and clear it when related data is changed.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
