### PR TITLE
[ADVAPP-1695]: Some users have reported an issue where the QnA Advisor is not positioned correctly relative to the Prompt Library

### DIFF
--- a/app-modules/ai/src/Filament/Resources/PromptResource.php
+++ b/app-modules/ai/src/Filament/Resources/PromptResource.php
@@ -51,7 +51,7 @@ class PromptResource extends Resource
 
     protected static ?string $navigationLabel = 'Prompt Library';
 
-    protected static ?int $navigationSort = 40;
+    protected static ?int $navigationSort = 50;
 
     public static function getPages(): array
     {

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisorResource.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisorResource.php
@@ -56,7 +56,7 @@ class QnaAdvisorResource extends Resource
 
     protected static ?string $modelLabel = 'QnA Advisor';
 
-    protected static ?int $navigationSort = 50;
+    protected static ?int $navigationSort = 40;
 
     public static function getPages(): array
     {


### PR DESCRIPTION
…r is not positioned correctly relative to the Prompt Library

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1695

### Technical Description

> Some users have reported an issue where the QnA Advisor is not positioned correctly relative to the Prompt Library.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
