### PR TITLE
[ADVAPP-1712]: Update Olympus API tenant creation to work without a name passed

### DIFF
--- a/app/Http/Controllers/Tenants/CreateTenantController.php
+++ b/app/Http/Controllers/Tenants/CreateTenantController.php
@@ -56,11 +56,10 @@ class CreateTenantController
 {
     public function __invoke(CreateTenantRequest $request): JsonResponse
     {
-        $name = $request->validated('name');
-        $rootName = Str::snake($name) . '_' . (new Sqids())->encode([time()]);
+        $rootName = Str::snake($request->validated('domain')) . '_' . (new Sqids())->encode([time()]);
 
         $tenant = app(CreateTenant::class)(
-            $name,
+            $request->validated('domain'),
             $request->validated('domain'),
             new TenantConfig(
                 database: new TenantDatabaseConfig(

--- a/app/Http/Requests/Tenants/CreateTenantRequest.php
+++ b/app/Http/Requests/Tenants/CreateTenantRequest.php
@@ -48,7 +48,6 @@ class CreateTenantRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
             'domain' => ['required', 'string', 'max:255', Rule::unique(Tenant::class)],
             'database' => ['required', 'string', 'max:255'],
             'user.name' => ['required', 'string', 'max:255'],


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1712

### Technical Description

Update the Olympus API Tenant creation process to no longer require the name of the Tenant be passed and now instead use the domain provided as the name of the Tenant and the key for the folder names in storage.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
