### PR TITLE
[ADVAPP-1671]: Improve the conversation quality of the prompt library by disabling the prompt library button after the initial prompt and add a tool tip to explain why it is not available

### DIFF
--- a/app-modules/ai/resources/views/components/assistant.blade.php
+++ b/app-modules/ai/resources/views/components/assistant.blade.php
@@ -733,7 +733,6 @@
                                         class="fi-topbar-close-sidebar-btn"
                                         color="gray"
                                         icon="heroicon-o-information-circle"
-                                        icon-alias="panels::topbar.close-sidebar-button"
                                         icon-size="lg"
                                         x-cloak
                                         x-show="messages.length > 0"

--- a/app-modules/ai/resources/views/components/assistant.blade.php
+++ b/app-modules/ai/resources/views/components/assistant.blade.php
@@ -704,7 +704,7 @@
                                     required
                                     maxlength="25000"
                                     @if (auth()->user()->is_submit_ai_chat_on_enter_enabled) x-on:keydown.enter.prevent="sendMessage()" @endif
-                                >                                
+                                >
                                 </textarea>
                             </div>
                             <div
@@ -728,6 +728,17 @@
                                     @endif
 
                                     {{ $this->insertFromPromptLibraryAction }}
+
+                                    <x-filament::icon-button
+                                        class="fi-topbar-close-sidebar-btn"
+                                        color="gray"
+                                        icon="heroicon-o-information-circle"
+                                        icon-alias="panels::topbar.close-sidebar-button"
+                                        icon-size="lg"
+                                        x-cloak
+                                        x-show="messages.length > 0"
+                                        tooltip="The prompt library can only be used as the initial prompt. To use the prompt library please begin a new conversation with your AI Advisor."
+                                    />
 
                                     <div
                                         class="flex w-full justify-center py-2 sm:w-auto"

--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManagePromptLibrary.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManagePromptLibrary.php
@@ -72,6 +72,7 @@ trait CanManagePromptLibrary
 
         return Action::make('insertFromPromptLibrary')
             ->label('Prompt library')
+            ->disabled(fn (): bool => $this->thread?->messages()->exists())
             ->color('gray')
             ->form([
                 ToggleButtons::make('isSmart')

--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManagePromptLibrary.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManagePromptLibrary.php
@@ -72,7 +72,7 @@ trait CanManagePromptLibrary
 
         return Action::make('insertFromPromptLibrary')
             ->label('Prompt library')
-            ->disabled(fn (): bool => $this->thread?->messages()->exists())
+            ->disabled(fn (): bool => $this->thread?->messages()->exists() ?? false)
             ->color('gray')
             ->form([
                 ToggleButtons::make('isSmart')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1671

### Technical Description

> Improve the conversation quality of the prompt library by disabling the prompt library button after the initial prompt and add a tool tip to explain why it is not available

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
