### PR TITLE
[ADVAPP-1675]: Hide cases resource from the main navigation

### DIFF
--- a/app-modules/case-management/src/Filament/Resources/CaseResource.php
+++ b/app-modules/case-management/src/Filament/Resources/CaseResource.php
@@ -57,6 +57,9 @@ class CaseResource extends Resource
 
     protected static ?string $modelLabel = 'Case';
 
+    // TODO: Look into whether or not we should just delete this resource
+    protected static bool $shouldRegisterNavigation = false;
+
     public static function shouldShowFormSubmission(Page $page): bool
     {
         if (! is_null($page->record) && ! is_null($page->record->caseFormSubmission)) {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1675

### Technical Description

Ensure that the cases resource does not register in the main navigation. This was forgotten about to be cleaned up in [ADVAPP-1675].

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).


[ADVAPP-1675]: https://canyongbs.atlassian.net/browse/ADVAPP-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ