### PR TITLE
[ADVAPP-1721]: When models are previously selected and they have been removed from the Model Applicability list, select inputs that load them throw an error

### DIFF
--- a/app-modules/ai/src/Filament/Pages/ManageAiICustomAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiICustomAdvisorSettings.php
@@ -89,12 +89,10 @@ class ManageAiICustomAdvisorSettings extends SettingsPage
                     ->live(),
                 Select::make('preselected_model')
                     ->label('Select Model')
-                    ->options(function (?AiModel $state) {
-                        return array_unique([
-                            ...AiModelApplicabilityFeature::CustomAdvisors->getModelsAsSelectOptions(),
-                            ...$state ? [$state->value => $state->getLabel()] : [],
-                        ]);
-                    })
+                    ->options(fn (?AiModel $state) => array_unique([
+                        ...AiModelApplicabilityFeature::CustomAdvisors->getModelsAsSelectOptions(),
+                        ...$state ? [$state->value => $state->getLabel()] : [],
+                    ]))
                     ->searchable()
                     ->helperText('This model will be the model used for custom advisors.')
                     ->required()

--- a/app-modules/ai/src/Filament/Pages/ManageAiICustomAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiICustomAdvisorSettings.php
@@ -89,9 +89,13 @@ class ManageAiICustomAdvisorSettings extends SettingsPage
                     ->live(),
                 Select::make('preselected_model')
                     ->label('Select Model')
-                    ->options(fn (?AiModel $state) => array_unique([
+                    ->options(fn (AiModel|string|null $state) => array_unique([
                         ...AiModelApplicabilityFeature::CustomAdvisors->getModelsAsSelectOptions(),
-                        ...$state ? [$state->value => $state->getLabel()] : [],
+                        ...match (true) {
+                            $state instanceof AiModel => [$state->value => $state->getLabel()],
+                            is_string($state) => [$state => AiModel::parse($state)->getLabel()],
+                            default => [],
+                        },
                     ]))
                     ->searchable()
                     ->helperText('This model will be the model used for custom advisors.')

--- a/app-modules/ai/src/Filament/Pages/ManageAiICustomAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiICustomAdvisorSettings.php
@@ -89,7 +89,12 @@ class ManageAiICustomAdvisorSettings extends SettingsPage
                     ->live(),
                 Select::make('preselected_model')
                     ->label('Select Model')
-                    ->options(AiModelApplicabilityFeature::CustomAdvisors->getModelsAsSelectOptions())
+                    ->options(function (?AiModel $state) {
+                        return array_unique([
+                            ...AiModelApplicabilityFeature::CustomAdvisors->getModelsAsSelectOptions(),
+                            ...$state ? [$state->value => $state->getLabel()] : [],
+                        ]);
+                    })
                     ->searchable()
                     ->helperText('This model will be the model used for custom advisors.')
                     ->required()

--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegratedAssistantSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegratedAssistantSettings.php
@@ -46,6 +46,7 @@ use App\Models\User;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
 use Filament\Pages\SettingsPage;
+use Illuminate\Validation\Rule;
 
 /**
  * @property-read ?AiAssistant $defaultAssistant
@@ -77,7 +78,11 @@ class ManageAiIntegratedAssistantSettings extends SettingsPage
         return $form
             ->schema([
                 Select::make('default_model')
-                    ->options(AiModelApplicabilityFeature::IntegratedAdvisor->getModelsAsSelectOptions())
+                    ->options(fn (?AiModel $state) => array_unique([
+                        ...AiModelApplicabilityFeature::IntegratedAdvisor->getModelsAsSelectOptions(),
+                        ...$state ? [$state->value => $state->getLabel()] : [],
+                    ]))
+                    ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::IntegratedAdvisor->getModels()))
                     ->searchable()
                     ->helperText('Used for general purposes like generating content when an assistant is not being used.')
                     ->required(),

--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegratedAssistantSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegratedAssistantSettings.php
@@ -78,9 +78,13 @@ class ManageAiIntegratedAssistantSettings extends SettingsPage
         return $form
             ->schema([
                 Select::make('default_model')
-                    ->options(fn (?AiModel $state) => array_unique([
+                    ->options(fn (AiModel|string|null $state) => array_unique([
                         ...AiModelApplicabilityFeature::IntegratedAdvisor->getModelsAsSelectOptions(),
-                        ...$state ? [$state->value => $state->getLabel()] : [],
+                        ...match (true) {
+                            $state instanceof AiModel => [$state->value => $state->getLabel()],
+                            is_string($state) => [$state => AiModel::parse($state)->getLabel()],
+                            default => [],
+                        },
                     ]))
                     ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::IntegratedAdvisor->getModels()))
                     ->searchable()

--- a/app-modules/ai/src/Filament/Pages/ManageAiQnaAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiQnaAdvisorSettings.php
@@ -77,7 +77,10 @@ class ManageAiQnaAdvisorSettings extends ManageAiICustomAdvisorSettings
                     ->live(),
                 Select::make('preselected_model')
                     ->label('Select Model')
-                    ->options(AiModelApplicabilityFeature::QuestionAndAnswerAdvisor->getModelsAsSelectOptions())
+                    ->options(fn (?AiModel $state) => array_unique([
+                        ...AiModelApplicabilityFeature::QuestionAndAnswerAdvisor->getModelsAsSelectOptions(),
+                        ...$state ? [$state->value => $state->getLabel()] : [],
+                    ]))
                     ->searchable()
                     ->helperText('This model will be the model used for QnA advisors.')
                     ->columnSpanFull()

--- a/app-modules/ai/src/Filament/Pages/ManageAiQnaAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiQnaAdvisorSettings.php
@@ -77,9 +77,13 @@ class ManageAiQnaAdvisorSettings extends ManageAiICustomAdvisorSettings
                     ->live(),
                 Select::make('preselected_model')
                     ->label('Select Model')
-                    ->options(fn (?AiModel $state) => array_unique([
+                    ->options(fn (AiModel|string|null $state) => array_unique([
                         ...AiModelApplicabilityFeature::QuestionAndAnswerAdvisor->getModelsAsSelectOptions(),
-                        ...$state ? [$state->value => $state->getLabel()] : [],
+                        ...match (true) {
+                            $state instanceof AiModel => [$state->value => $state->getLabel()],
+                            is_string($state) => [$state => AiModel::parse($state)->getLabel()],
+                            default => [],
+                        },
                     ]))
                     ->searchable()
                     ->helperText('This model will be the model used for QnA advisors.')

--- a/app-modules/ai/src/Filament/Pages/ManageAiResearchAssistantSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiResearchAssistantSettings.php
@@ -46,6 +46,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Form;
 use Filament\Pages\SettingsPage;
+use Illuminate\Validation\Rule;
 
 class ManageAiResearchAssistantSettings extends SettingsPage
 {
@@ -72,12 +73,20 @@ class ManageAiResearchAssistantSettings extends SettingsPage
         return $form
             ->schema([
                 Select::make('discovery_model')
-                    ->options(AiModelApplicabilityFeature::IntegratedAdvisor->getModelsAsSelectOptions())
+                    ->options(fn (?AiModel $state) => array_unique([
+                        ...AiModelApplicabilityFeature::IntegratedAdvisor->getModelsAsSelectOptions(),
+                        ...$state ? [$state->value => $state->getLabel()] : [],
+                    ]))
+                    ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::IntegratedAdvisor->getModels()))
                     ->searchable()
                     ->helperText('Used for the generation of the pre-research questions.')
                     ->required(),
                 Select::make('research_model')
-                    ->options(AiModelApplicabilityFeature::ResearchAdvisor->getModelsAsSelectOptions())
+                    ->options(fn (?AiModel $state) => array_unique([
+                        ...AiModelApplicabilityFeature::ResearchAdvisor->getModelsAsSelectOptions(),
+                        ...$state ? [$state->value => $state->getLabel()] : [],
+                    ]))
+                    ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::ResearchAdvisor->getModels()))
                     ->searchable()
                     ->helperText('Used for the generation of the research report.')
                     ->required(),

--- a/app-modules/ai/src/Filament/Pages/ManageAiResearchAssistantSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiResearchAssistantSettings.php
@@ -73,18 +73,26 @@ class ManageAiResearchAssistantSettings extends SettingsPage
         return $form
             ->schema([
                 Select::make('discovery_model')
-                    ->options(fn (?AiModel $state) => array_unique([
+                    ->options(fn (AiModel|string|null $state) => array_unique([
                         ...AiModelApplicabilityFeature::IntegratedAdvisor->getModelsAsSelectOptions(),
-                        ...$state ? [$state->value => $state->getLabel()] : [],
+                        ...match (true) {
+                            $state instanceof AiModel => [$state->value => $state->getLabel()],
+                            is_string($state) => [$state => AiModel::parse($state)->getLabel()],
+                            default => [],
+                        },
                     ]))
                     ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::IntegratedAdvisor->getModels()))
                     ->searchable()
                     ->helperText('Used for the generation of the pre-research questions.')
                     ->required(),
                 Select::make('research_model')
-                    ->options(fn (?AiModel $state) => array_unique([
+                    ->options(fn (AiModel|string|null $state) => array_unique([
                         ...AiModelApplicabilityFeature::ResearchAdvisor->getModelsAsSelectOptions(),
-                        ...$state ? [$state->value => $state->getLabel()] : [],
+                        ...match (true) {
+                            $state instanceof AiModel => [$state->value => $state->getLabel()],
+                            is_string($state) => [$state => AiModel::parse($state)->getLabel()],
+                            default => [],
+                        },
                     ]))
                     ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::ResearchAdvisor->getModels()))
                     ->searchable()

--- a/app-modules/ai/src/Filament/Pages/ManageAiSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiSettings.php
@@ -58,6 +58,7 @@ use Filament\Forms\Get;
 use Filament\Notifications\Notification;
 use Filament\Pages\SettingsPage;
 use Filament\Support\Enums\MaxWidth;
+use Illuminate\Validation\Rule;
 use Livewire\Attributes\Computed;
 use Throwable;
 
@@ -107,7 +108,11 @@ class ManageAiSettings extends SettingsPage
                     ->model($this->defaultAssistant)
                     ->schema([
                         Select::make('model')
-                            ->options(AiModelApplicabilityFeature::InstitutionalAdvisor->getModelsAsSelectOptions())
+                            ->options(fn (?AiModel $state) => array_unique([
+                                ...AiModelApplicabilityFeature::InstitutionalAdvisor->getModelsAsSelectOptions(),
+                                ...$state ? [$state->value => $state->getLabel()] : [],
+                            ]))
+                            ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::InstitutionalAdvisor->getModels()))
                             ->searchable()
                             ->required()
                             ->columnSpanFull()
@@ -142,7 +147,11 @@ class ManageAiSettings extends SettingsPage
                     ->minValue(0)
                     ->maxValue(1),
                 Select::make('default_model')
-                    ->options(AiModelApplicabilityFeature::InstitutionalAdvisor->getModelsAsSelectOptions())
+                    ->options(fn (?AiModel $state) => array_unique([
+                        ...AiModelApplicabilityFeature::InstitutionalAdvisor->getModelsAsSelectOptions(),
+                        ...$state ? [$state->value => $state->getLabel()] : [],
+                    ]))
+                    ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::InstitutionalAdvisor->getModels()))
                     ->searchable()
                     ->required(),
             ])

--- a/app-modules/ai/src/Filament/Pages/ManageAiSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiSettings.php
@@ -108,9 +108,13 @@ class ManageAiSettings extends SettingsPage
                     ->model($this->defaultAssistant)
                     ->schema([
                         Select::make('model')
-                            ->options(fn (?AiModel $state) => array_unique([
+                            ->options(fn (AiModel|string|null $state) => array_unique([
                                 ...AiModelApplicabilityFeature::InstitutionalAdvisor->getModelsAsSelectOptions(),
-                                ...$state ? [$state->value => $state->getLabel()] : [],
+                                ...match (true) {
+                                    $state instanceof AiModel => [$state->value => $state->getLabel()],
+                                    is_string($state) => [$state => AiModel::parse($state)->getLabel()],
+                                    default => [],
+                                },
                             ]))
                             ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::InstitutionalAdvisor->getModels()))
                             ->searchable()
@@ -147,9 +151,13 @@ class ManageAiSettings extends SettingsPage
                     ->minValue(0)
                     ->maxValue(1),
                 Select::make('default_model')
-                    ->options(fn (?AiModel $state) => array_unique([
+                    ->options(fn (AiModel|string|null $state) => array_unique([
                         ...AiModelApplicabilityFeature::InstitutionalAdvisor->getModelsAsSelectOptions(),
-                        ...$state ? [$state->value => $state->getLabel()] : [],
+                        ...match (true) {
+                            $state instanceof AiModel => [$state->value => $state->getLabel()],
+                            is_string($state) => [$state => AiModel::parse($state)->getLabel()],
+                            default => [],
+                        },
                     ]))
                     ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::InstitutionalAdvisor->getModels()))
                     ->searchable()

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -95,9 +95,13 @@ class AiAssistantForm
                     ->disabledOn('edit'),
                 Select::make('model')
                     ->reactive()
-                    ->options(fn (?AiModel $state) => array_unique([
+                    ->options(fn (AiModel|string|null $state) => array_unique([
                         ...AiModelApplicabilityFeature::CustomAdvisors->getModelsAsSelectOptions(),
-                        ...$state ? [$state->value => $state->getLabel()] : [],
+                        ...match (true) {
+                            $state instanceof AiModel => [$state->value => $state->getLabel()],
+                            is_string($state) => [$state => AiModel::parse($state)->getLabel()],
+                            default => [],
+                        },
                     ]))
                     ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::CustomAdvisors->getModels()))
                     ->searchable()

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -95,10 +95,13 @@ class AiAssistantForm
                     ->disabledOn('edit'),
                 Select::make('model')
                     ->reactive()
-                    ->options(AiModelApplicabilityFeature::CustomAdvisors->getModelsAsSelectOptions())
+                    ->options(fn (?AiModel $state) => array_unique([
+                        ...AiModelApplicabilityFeature::CustomAdvisors->getModelsAsSelectOptions(),
+                        ...$state ? [$state->value => $state->getLabel()] : [],
+                    ]))
+                    ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::CustomAdvisors->getModels()))
                     ->searchable()
                     ->required()
-                    ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::CustomAdvisors->getModels()))
                     ->visible(fn (Get $get): bool => filled($get('application')))
                     ->disabled(fn (): bool => ! app(AiCustomAdvisorSettings::class)->allow_selection_of_model)
                     ->default(function () {

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/CreateQnaAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/CreateQnaAdvisor.php
@@ -74,7 +74,10 @@ class CreateQnaAdvisor extends CreateRecord
                     ->maxLength(255),
                 Select::make('model')
                     ->live()
-                    ->options(AiModelApplicabilityFeature::QuestionAndAnswerAdvisor->getModelsAsSelectOptions())
+                    ->options(fn (?AiModel $state) => array_unique([
+                        ...AiModelApplicabilityFeature::QuestionAndAnswerAdvisor->getModelsAsSelectOptions(),
+                        ...$state ? [$state->value => $state->getLabel()] : [],
+                    ]))
                     ->searchable()
                     ->required()
                     ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::QuestionAndAnswerAdvisor->getModels()))

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/CreateQnaAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/CreateQnaAdvisor.php
@@ -74,9 +74,13 @@ class CreateQnaAdvisor extends CreateRecord
                     ->maxLength(255),
                 Select::make('model')
                     ->live()
-                    ->options(fn (?AiModel $state) => array_unique([
+                    ->options(fn (AiModel|string|null $state) => array_unique([
                         ...AiModelApplicabilityFeature::QuestionAndAnswerAdvisor->getModelsAsSelectOptions(),
-                        ...$state ? [$state->value => $state->getLabel()] : [],
+                        ...match (true) {
+                            $state instanceof AiModel => [$state->value => $state->getLabel()],
+                            is_string($state) => [$state => AiModel::parse($state)->getLabel()],
+                            default => [],
+                        },
                     ]))
                     ->searchable()
                     ->required()

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/EditQnaAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/EditQnaAdvisor.php
@@ -112,7 +112,10 @@ class EditQnaAdvisor extends EditRecord
                             ->maxLength(255),
                         Select::make('model')
                             ->live()
-                            ->options(AiModelApplicabilityFeature::QuestionAndAnswerAdvisor->getModelsAsSelectOptions())
+                            ->options(fn (?AiModel $state) => array_unique([
+                                ...AiModelApplicabilityFeature::QuestionAndAnswerAdvisor->getModelsAsSelectOptions(),
+                                ...$state ? [$state->value => $state->getLabel()] : [],
+                            ]))
                             ->searchable()
                             ->required()
                             ->visible(auth()->user()->isSuperAdmin())

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/EditQnaAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisorResource/Pages/EditQnaAdvisor.php
@@ -112,9 +112,13 @@ class EditQnaAdvisor extends EditRecord
                             ->maxLength(255),
                         Select::make('model')
                             ->live()
-                            ->options(fn (?AiModel $state) => array_unique([
+                            ->options(fn (AiModel|string|null $state) => array_unique([
                                 ...AiModelApplicabilityFeature::QuestionAndAnswerAdvisor->getModelsAsSelectOptions(),
-                                ...$state ? [$state->value => $state->getLabel()] : [],
+                                ...match (true) {
+                                    $state instanceof AiModel => [$state->value => $state->getLabel()],
+                                    is_string($state) => [$state => AiModel::parse($state)->getLabel()],
+                                    default => [],
+                                },
                             ]))
                             ->searchable()
                             ->required()


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1721

### Technical Description

Fix issue with the loading of previously selected models after they have been removed from the applicability list.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
