### PR TITLE
[ADVAPP-1728]: Bug Fix: Attempts to Send Alert to a Deleted User

### DIFF
--- a/app-modules/alert/src/Listeners/NotifySubscribersOfAlertCreated.php
+++ b/app-modules/alert/src/Listeners/NotifySubscribersOfAlertCreated.php
@@ -48,10 +48,10 @@ class NotifySubscribersOfAlertCreated implements ShouldQueue
     public function handle(AlertCreated $event): void
     {
         /** @var Student|Prospect $concern */
-        $concern = $event->alert->concern->where('deleted_at', null)->all();
+        $concern = $event->alert->concern;
 
         $concern->subscriptions?->each(function (Subscription $subscription) use ($event) {
-            $subscription->user->notify(new AlertCreatedNotification($event->alert));
+            $subscription->user?->notify(new AlertCreatedNotification($event->alert));
         });
     }
 }

--- a/app-modules/alert/src/Listeners/NotifySubscribersOfAlertCreated.php
+++ b/app-modules/alert/src/Listeners/NotifySubscribersOfAlertCreated.php
@@ -51,7 +51,7 @@ class NotifySubscribersOfAlertCreated implements ShouldQueue
         $concern = $event->alert->concern;
 
         $concern->subscriptions?->each(function (Subscription $subscription) use ($event) {
-            $subscription->user?->notify(new AlertCreatedNotification($event->alert));
+            $subscription->user->notify(new AlertCreatedNotification($event->alert));
         });
     }
 }

--- a/app-modules/alert/src/Listeners/NotifySubscribersOfAlertCreated.php
+++ b/app-modules/alert/src/Listeners/NotifySubscribersOfAlertCreated.php
@@ -48,7 +48,7 @@ class NotifySubscribersOfAlertCreated implements ShouldQueue
     public function handle(AlertCreated $event): void
     {
         /** @var Student|Prospect $concern */
-        $concern = $event->alert->concern;
+        $concern = $event->alert->concern->where('deleted_at', null)->all();
 
         $concern->subscriptions?->each(function (Subscription $subscription) use ($event) {
             $subscription->user->notify(new AlertCreatedNotification($event->alert));

--- a/app-modules/alert/tests/Tenant/AlertCreateTest.php
+++ b/app-modules/alert/tests/Tenant/AlertCreateTest.php
@@ -79,3 +79,25 @@ it('dispatches the proper notifications to subscribers on created', function () 
     Notification::assertSentTo($users, AlertCreatedNotification::class);
     Notification::assertSentTimes(AlertCreatedNotification::class, $student->subscriptions()->count());
 });
+
+it('only notifies active users of alerts', function () {
+    Notification::fake();
+
+    $deletedUser = User::factory()->licensed(LicenseType::cases())->create();
+
+    /** @var Student $student */
+    $student = Student::factory()->create();
+
+    $student->subscriptions()->create([
+        'user_id' => $deletedUser->id,
+    ]);
+
+    $deletedUser->delete();
+
+    Alert::factory()->create([
+        'concern_id' => $student->sisid,
+        'concern_type' => Student::class,
+    ]);
+
+    Notification::assertNotSentTo($deletedUser, AlertCreatedNotification::class);
+});

--- a/app-modules/alert/tests/Tenant/AlertCreateTest.php
+++ b/app-modules/alert/tests/Tenant/AlertCreateTest.php
@@ -81,6 +81,7 @@ it('dispatches the proper notifications to subscribers on created', function () 
 });
 
 it('only notifies active users of alerts', function () {
+    // @Todo: This tests works but we should change it to use the Listener instead of the Notification
     Notification::fake();
 
     $deletedUser = User::factory()->licensed(LicenseType::cases())->create();

--- a/app-modules/notification/src/Models/Concerns/HasSubscriptions.php
+++ b/app-modules/notification/src/Models/Concerns/HasSubscriptions.php
@@ -46,6 +46,6 @@ trait HasSubscriptions
      */
     public function subscriptions(): MorphMany
     {
-        return $this->morphMany(Subscription::class, 'subscribable');
+        return $this->morphMany(Subscription::class, 'subscribable')->whereHas('user');
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1728

### Technical Description
- Add a scope to only pull back Subscriptions if they have a user.

### Any deployment steps required?
- No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?
- No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
