### PR TITLE
[ADVAPP-1724][ADVAPP-1725]: Restrict the view of models if it is not configurable to Global Administrators, Restrict the view of the application dropdown in the custom advisor screens to Global Administrators

### DIFF
--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -86,12 +86,14 @@ class AiAssistantForm
                     ->options([
                         AiAssistantApplication::PersonalAssistant->value => 'Custom Advisor',
                     ])
+                    ->dehydratedWhenHidden()
                     ->default(AiAssistantApplication::getDefault())
                     ->live()
                     ->afterStateUpdated(fn (Set $set, $state) => filled(AiAssistantApplication::parse($state)) ? $set('model', AiAssistantApplication::parse($state)->getDefaultModel()->value) : null)
                     ->required()
                     ->enum(AiAssistantApplication::class)
                     ->columnStart(1)
+                    ->visible(auth()->user()->isSuperAdmin())
                     ->disabledOn('edit'),
                 Select::make('model')
                     ->reactive()

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -106,7 +106,7 @@ class AiAssistantForm
                     ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::CustomAdvisors->getModels()))
                     ->searchable()
                     ->required()
-                    ->visible(fn (Get $get): bool => filled($get('application')))
+                    ->visible(fn (Get $get): bool => filled($get('application')) && auth()->user()->isSuperAdmin())
                     ->disabled(fn (): bool => ! app(AiCustomAdvisorSettings::class)->allow_selection_of_model)
                     ->default(function () {
                         $settings = app(AiCustomAdvisorSettings::class);
@@ -116,7 +116,8 @@ class AiAssistantForm
                         }
 
                         return $settings->preselected_model;
-                    }),
+                    })
+                    ->dehydrated(),
                 Textarea::make('description')
                     ->columnSpanFull()
                     ->required(),

--- a/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistantResource/Forms/AiAssistantForm.php
@@ -117,7 +117,7 @@ class AiAssistantForm
 
                         return $settings->preselected_model;
                     })
-                    ->dehydrated(),
+                    ->dehydratedWhenHidden(),
                 Textarea::make('description')
                     ->columnSpanFull()
                     ->required(),

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Resources/AiAssistantResource/EditAiAssistantTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Resources/AiAssistantResource/EditAiAssistantTest.php
@@ -161,7 +161,7 @@ it('can edit a record', function () use ($licenses, $permissions) {
             'collection_name' => 'avatar',
         ]
     );
-})->only();
+});
 
 it('validates the inputs', function ($data, $errors) use ($licenses, $permissions) {
     Storage::fake('s3');

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Resources/AiAssistantResource/EditAiAssistantTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Resources/AiAssistantResource/EditAiAssistantTest.php
@@ -149,7 +149,7 @@ it('can edit a record', function () use ($licenses, $permissions) {
     assertDatabaseHas(
         AiAssistant::class,
         $request->except([
-            'avatar',
+            'avatar','model'
         ])->toArray()
     );
 
@@ -161,7 +161,7 @@ it('can edit a record', function () use ($licenses, $permissions) {
             'collection_name' => 'avatar',
         ]
     );
-});
+})->only();
 
 it('validates the inputs', function ($data, $errors) use ($licenses, $permissions) {
     Storage::fake('s3');

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Resources/AiAssistantResource/EditAiAssistantTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Resources/AiAssistantResource/EditAiAssistantTest.php
@@ -149,7 +149,7 @@ it('can edit a record', function () use ($licenses, $permissions) {
     assertDatabaseHas(
         AiAssistant::class,
         $request->except([
-            'avatar','model'
+            'avatar',
         ])->toArray()
     );
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1724
- https://canyongbs.atlassian.net/browse/ADVAPP-1725

### Technical Description

> Restrict the view of models if it is not configurable to Global Administrators and Restrict the view of the application dropdown in the custom advisor screens to Global Administrators.

### Any deployment steps required?

> No.

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No.

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
