### PR TITLE
[Hotfix]: Enable database disconnection on octane request terminate

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -131,7 +131,7 @@ return [
         OperationTerminated::class => [
             FlushOnce::class,
             FlushTemporaryContainerInstances::class,
-            // DisconnectFromDatabases::class,
+            DisconnectFromDatabases::class,
             //CollectGarbage::class,
         ],
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Disconnect from the database at the end of an Octane request.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
