### PR TITLE
[ADVAPP-1710]: Set up new Partner Admin role

### DIFF
--- a/app-modules/authorization/database/migrations/2025_07_29_134904_seed_permissions_add_partner_admin_role.php
+++ b/app-modules/authorization/database/migrations/2025_07_29_134904_seed_permissions_add_partner_admin_role.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Authorization\Models\Role;
 use App\Models\Authenticatable;
 use Illuminate\Database\Migrations\Migration;

--- a/app-modules/authorization/database/migrations/2025_07_29_134904_seed_permissions_add_partner_admin_role.php
+++ b/app-modules/authorization/database/migrations/2025_07_29_134904_seed_permissions_add_partner_admin_role.php
@@ -1,0 +1,23 @@
+<?php
+
+use AdvisingApp\Authorization\Models\Role;
+use App\Models\Authenticatable;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Role::create([
+            'name' => Authenticatable::PARTNER_ADMIN_ROLE,
+            'guard_name' => 'web',
+        ]);
+    }
+
+    public function down(): void
+    {
+        Role::query()
+            ->where('name', Authenticatable::PARTNER_ADMIN_ROLE)
+            ->where('guard_name', 'web')
+            ->delete();
+    }
+};

--- a/app-modules/authorization/src/Enums/LicenseType.php
+++ b/app-modules/authorization/src/Enums/LicenseType.php
@@ -83,7 +83,10 @@ enum LicenseType: string implements HasLabel
     {
         return License::query()
             ->whereDoesntHave('user', function ($query) {
-                $query->role(Authenticatable::SUPER_ADMIN_ROLE);
+                $query->role([
+                    Authenticatable::SUPER_ADMIN_ROLE,
+                    Authenticatable::PARTNER_ADMIN_ROLE,
+                ]);
             })
             ->where('type', $this)
             ->count();

--- a/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
@@ -77,6 +77,10 @@ class ListRoles extends ListRecords
                 if (! $user?->isSuperAdmin()) {
                     $query->where('name', '!=', Authenticatable::SUPER_ADMIN_ROLE);
                 }
+
+                if (! $user?->isSuperAdmin() || ! $user?->isPartnerAdmin()) {
+                    $query->where('name', '!=', Authenticatable::PARTNER_ADMIN_ROLE);
+                }
             })
             ->columns([
                 IdColumn::make(),
@@ -106,7 +110,7 @@ class ListRoles extends ListRecords
                     ->modalDescription('This action will make a copy of the role and all associate permissions. This action will not, however, automatically attach any users to that role. To continue, please enter a name for the new role and then select the "Duplicate" option below.')
                     ->modalHeading('Duplicate Role')
                     ->modalSubmitActionLabel('Duplicate')
-                    ->visible(fn (Role $record): bool => $record->name !== Authenticatable::SUPER_ADMIN_ROLE)
+                    ->visible(fn (Role $record): bool => $record->name !== Authenticatable::SUPER_ADMIN_ROLE && $record->name !== Authenticatable::PARTNER_ADMIN_ROLE)
                     ->form([
                         TextInput::make('name')
                             ->label('New Role Name')

--- a/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
@@ -111,7 +111,7 @@ class ListRoles extends ListRecords
                     ->modalDescription('This action will make a copy of the role and all associate permissions. This action will not, however, automatically attach any users to that role. To continue, please enter a name for the new role and then select the "Duplicate" option below.')
                     ->modalHeading('Duplicate Role')
                     ->modalSubmitActionLabel('Duplicate')
-                    ->visible(fn (Role $record): bool => $record->name !== Authenticatable::SUPER_ADMIN_ROLE && $record->name !== Authenticatable::PARTNER_ADMIN_ROLE)
+                    ->visible(fn (Role $record): bool => ! in_array($record->name, [Authenticatable::SUPER_ADMIN_ROLE, Authenticatable::PARTNER_ADMIN_ROLE]))
                     ->form([
                         TextInput::make('name')
                             ->label('New Role Name')

--- a/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
+++ b/app-modules/authorization/src/Filament/Resources/RoleResource/Pages/ListRoles.php
@@ -71,14 +71,15 @@ class ListRoles extends ListRecords
     {
         return $table
             ->modifyQueryUsing(function (Builder $query) {
-                /** @var User $user */
                 $user = auth()->user();
 
-                if (! $user?->isSuperAdmin()) {
+                assert($user instanceof Authenticatable);
+
+                if (! $user->isSuperAdmin()) {
                     $query->where('name', '!=', Authenticatable::SUPER_ADMIN_ROLE);
                 }
 
-                if (! $user?->isSuperAdmin() || ! $user?->isPartnerAdmin()) {
+                if (! $user->isSuperAdmin() && ! $user->isPartnerAdmin()) {
                     $query->where('name', '!=', Authenticatable::PARTNER_ADMIN_ROLE);
                 }
             })

--- a/app/Filament/Resources/UserResource/RelationManagers/RolesRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/RolesRelationManager.php
@@ -91,10 +91,15 @@ class RolesRelationManager extends RelationManager
                             ->rule(new ExcludeSuperAdmin())
                             ->preload()
                             ->getSearchResultsUsing(
-                                fn (string $search): array => Role::query()->when(
-                                    ! auth()->user()->isSuperAdmin(),
-                                    fn (Builder $query) => $query->where('name', '!=', Authenticatable::SUPER_ADMIN_ROLE)
-                                )
+                                fn (string $search): array => Role::query()
+                                    ->when(
+                                        ! auth()->user()->isSuperAdmin(),
+                                        fn (Builder $query) => $query->where('name', '!=', Authenticatable::SUPER_ADMIN_ROLE)
+                                    )
+                                    ->when(
+                                        ! auth()->user()->isSuperAdmin() && ! auth()->user()->isPartnerAdmin(),
+                                        fn (Builder $query) => $query->where('name', '!=', Authenticatable::PARTNER_ADMIN_ROLE)
+                                    )
                                     ->where(new Expression('lower(name)'), 'like', '%' . strtolower($search) . '%')
                                     ->limit(50)->pluck('name', 'id')
                                     ->toArray()
@@ -107,6 +112,10 @@ class RolesRelationManager extends RelationManager
                                     ->when(
                                         ! auth()->user()->isSuperAdmin(),
                                         fn (Builder $query) => $query->where('name', '!=', Authenticatable::SUPER_ADMIN_ROLE)
+                                    )
+                                    ->when(
+                                        ! auth()->user()->isSuperAdmin() && ! auth()->user()->isPartnerAdmin(),
+                                        fn (Builder $query) => $query->where('name', '!=', Authenticatable::PARTNER_ADMIN_ROLE)
                                     )
                                     ->when(
                                         $user->has('roles'),

--- a/app/Models/Authenticatable.php
+++ b/app/Models/Authenticatable.php
@@ -54,6 +54,8 @@ abstract class Authenticatable extends BaseAuthenticatable
 
     protected bool $isSuperAdmin;
 
+    protected bool $isPartnerAdmin;
+
     /**
      * @param LicenseType | string | array<LicenseType | string> | null $type
      */
@@ -67,5 +69,10 @@ abstract class Authenticatable extends BaseAuthenticatable
     public function isSuperAdmin(): bool
     {
         return $this->isSuperAdmin ??= $this->hasRole(static::SUPER_ADMIN_ROLE);
+    }
+
+    public function isPartnerAdmin(): bool
+    {
+        return $this->isPartnerAdmin ??= $this->hasRole(static::PARTNER_ADMIN_ROLE);
     }
 }

--- a/app/Models/Authenticatable.php
+++ b/app/Models/Authenticatable.php
@@ -50,6 +50,8 @@ abstract class Authenticatable extends BaseAuthenticatable
 
     public const SUPER_ADMIN_ROLE = 'SaaS Global Admin';
 
+    public const PARTNER_ADMIN_ROLE = 'Partner Admin';
+
     protected bool $isSuperAdmin;
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -63,7 +63,7 @@ class AuthServiceProvider extends ServiceProvider
             function (Authenticatable $authenticatable, string $ability, bool|null|Response $result, mixed $arguments) {
                 return (
                     (! $result instanceof FeatureAccessResponse)
-                    && $authenticatable->isSuperAdmin()
+                    && ($authenticatable->isSuperAdmin() || $authenticatable->isPartnerAdmin())
                 )
                     ? true
                     : $result;

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -59,11 +59,16 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        Gate::after(function (Authenticatable $authenticatable, string $ability, bool|null|Response $result, mixed $arguments) {
-            return ((! $result instanceof FeatureAccessResponse) && $authenticatable->isSuperAdmin())
+        Gate::after(
+            function (Authenticatable $authenticatable, string $ability, bool|null|Response $result, mixed $arguments) {
+                return (
+                    (! $result instanceof FeatureAccessResponse)
+                    && $authenticatable->isSuperAdmin()
+                )
                     ? true
                     : $result;
-        });
+            }
+        );
 
         collect(Feature::cases())
             ->each(fn (Feature $feature) => $feature->generateGate());


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1710

### Technical Description

Adds a new Partner Admin role and gives it the ability to pass all permission gates but still make sure it is not allowed to do any global admin things.

Also make it so only super admins and other partners admins can see the partner admin role.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
