### PR TITLE
[ADVAPP-1745]: When a new Tenant is created make the first User a new role of "Partner Administrator"

### DIFF
--- a/app/Jobs/CreateTenantUser.php
+++ b/app/Jobs/CreateTenantUser.php
@@ -81,7 +81,7 @@ class CreateTenantUser implements ShouldQueue, NotTenantAware
                 }
             }
 
-            $user->roles()->sync(Role::where('name', Authenticatable::SUPER_ADMIN_ROLE)->firstOrFail());
+            $user->roles()->sync(Role::where('name', Authenticatable::PARTNER_ADMIN_ROLE)->firstOrFail());
         });
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1745

### Technical Description

This pull request updates the role assignment logic in the `CreateTenantUser` job to ensure the correct role is assigned to new users. We now assign users created by Olympus to be the new Partner Admin role, instead of the Super Admin role which will be accessible in a different way going forward.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
