### PR TITLE
[ADVAPP-1796]: Introduce dynamic user representation for "From Name" in outbound email and text messages

### DIFF
--- a/app-modules/engagement/database/migrations/2025_08_08_110510_add_engagement_settings.php
+++ b/app-modules/engagement/database/migrations/2025_08_08_110510_add_engagement_settings.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        $this->migrator->add(
+            'engagement.are_dynamic_engagements_enabled',
+            false,
+        );
+    }
+};

--- a/app-modules/engagement/src/Settings/EngagementSettings.php
+++ b/app-modules/engagement/src/Settings/EngagementSettings.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Engagement\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+class EngagementSettings extends Settings
+{
+    public bool $are_dynamic_engagements_enabled = false;
+
+    public static function group(): string
+    {
+        return 'engagement';
+    }
+}

--- a/app-modules/integration-aws-ses-event-handling/src/Filament/Pages/ManageAmazonSesSettings.php
+++ b/app-modules/integration-aws-ses-event-handling/src/Filament/Pages/ManageAmazonSesSettings.php
@@ -36,7 +36,9 @@
 
 namespace AdvisingApp\IntegrationAwsSesEventHandling\Filament\Pages;
 
+use AdvisingApp\Engagement\Settings\EngagementSettings;
 use AdvisingApp\IntegrationAwsSesEventHandling\Settings\SesSettings;
+use App\Features\EngagementSettingsFeature;
 use App\Filament\Clusters\ProductIntegrations;
 use App\Models\Tenant;
 use App\Models\User;
@@ -80,6 +82,10 @@ class ManageAmazonSesSettings extends SettingsPage
     {
         return $form
             ->schema([
+                Toggle::make('are_dynamic_engagements_enabled')
+                    ->label('Dynamic Engagements')
+                    ->live()
+                    ->visible(EngagementSettingsFeature::active()),
                 Toggle::make('isDemoModeEnabled')
                     ->label('Demo Mode')
                     ->live(),
@@ -140,6 +146,14 @@ class ManageAmazonSesSettings extends SettingsPage
                 $data['fromName'],
             );
 
+            if (EngagementSettingsFeature::active()) {
+                $engagementSettings = app(EngagementSettings::class);
+                $engagementSettings->are_dynamic_engagements_enabled = $data['are_dynamic_engagements_enabled'];
+                $engagementSettings->save();
+
+                unset($data['are_dynamic_engagements_enabled']);
+            }
+
             $settings = app(static::getSettings());
 
             $settings->fill($data);
@@ -190,6 +204,7 @@ class ManageAmazonSesSettings extends SettingsPage
         $data = $this->mutateFormDataBeforeFill(
             [
                 ...$settings->toArray(),
+                'are_dynamic_engagements_enabled' => EngagementSettingsFeature::active() ? app(EngagementSettings::class)->are_dynamic_engagements_enabled : false,
                 'isDemoModeEnabled' => $config->mail->isDemoModeEnabled ?? false,
                 'isExcludingSystemNotificationsFromDemoMode' => $config->mail->isExcludingSystemNotificationsFromDemoMode ?? true,
                 'fromName' => $config->mail->fromName,

--- a/app-modules/notification/src/Notifications/Messages/MailMessage.php
+++ b/app-modules/notification/src/Notifications/Messages/MailMessage.php
@@ -70,13 +70,15 @@ class MailMessage extends BaseMailMessage
         return $this;
     }
 
+    public function from($address = null, $name = null): static
+    {
+        return parent::from($address ?? config('mail.from.address'), $name);
+    }
+
     public function settings(?NotificationSetting $setting): static
     {
         if (! empty($setting->from_name)) {
-            $this->from(
-                address: config('mail.from.address'),
-                name: $setting->from_name,
-            );
+            $this->from(name: $setting->from_name);
         }
 
         $this->viewData = [

--- a/app/Features/EngagementSettingsFeature.php
+++ b/app/Features/EngagementSettingsFeature.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class EngagementSettingsFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/database/migrations/2025_08_08_110955_data_activate_engagement_settings_feature.php
+++ b/database/migrations/2025_08_08_110955_data_activate_engagement_settings_feature.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Features\EngagementSettingsFeature;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        EngagementSettingsFeature::activate();
+    }
+
+    public function down(): void
+    {
+        EngagementSettingsFeature::deactivate();
+    }
+};


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1796

### Technical Description

Introduces new engagement settings (SES settings are not the right place to store this, in my opinion). Reads that setting in the notification and sets the from name. To avoid setting the from address too, I have overridden the `from()` method on the base message object to pass the correct address by default.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

EngagementSettingsFeature

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
