### PR TITLE
[ADVAPP-1803]: Enhance the SIS sync records capabilities to include the ability to upload athletics status and details and academic standing

### DIFF
--- a/app-modules/student-data-model/src/Filament/Imports/StudentImporter.php
+++ b/app-modules/student-data-model/src/Filament/Imports/StudentImporter.php
@@ -172,6 +172,14 @@ class StudentImporter extends Importer
                     'string',
                     'max:255',
                 ]),
+            ImportColumn::make('standing')
+                ->label('Academic Standing')
+                ->example('Suspended')
+                ->rules([
+                    'nullable',
+                    'string',
+                    'max:255',
+                ]),
             ImportColumn::make('firstgen')
                 ->example('true')
                 ->boolean()
@@ -203,6 +211,22 @@ class StudentImporter extends Importer
             ImportColumn::make('mr_e_term')
                 ->label('Most Recent Enrollment Term')
                 ->example('1234')
+                ->rules([
+                    'nullable',
+                    'string',
+                    'max:255',
+                ]),
+            ImportColumn::make('athletics_status')
+                ->label('Athletics Status')
+                ->example('Active')
+                ->rules([
+                    'nullable',
+                    'string',
+                    'max:255',
+                ]),
+            ImportColumn::make('athletic_details')
+                ->label('Athletic Details')
+                ->example('Football, 2024')
                 ->rules([
                     'nullable',
                     'string',


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1803

### Technical Description

> Enhance the SIS sync records capabilities to include the ability to upload athletics status and details and academic standing

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
