### PR TITLE
[ADVAPP-1823]: Some users have reported that the Resource Hub is still located under the CRM navigation group and displays the wrong interface under Knowledge Management

### DIFF
--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticleResource.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticleResource.php
@@ -56,9 +56,9 @@ class ResourceHubArticleResource extends Resource
 
     protected static ?string $breadcrumb = 'Resource Hub';
 
-    protected static ?string $navigationGroup = 'CRM';
+    protected static ?string $navigationGroup = 'Knowledge Management';
 
-    protected static ?int $navigationSort = 40;
+    protected static ?int $navigationSort = 10;
 
     protected static ?string $recordTitleAttribute = 'title';
 

--- a/app/Filament/Clusters/DisplaySettings.php
+++ b/app/Filament/Clusters/DisplaySettings.php
@@ -42,5 +42,5 @@ class DisplaySettings extends Cluster
 {
     protected static ?string $navigationGroup = 'Settings';
 
-    protected static ?int $navigationSort = 100;
+    protected static ?int $navigationSort = 110;
 }

--- a/app/Filament/Clusters/InteractionManagement.php
+++ b/app/Filament/Clusters/InteractionManagement.php
@@ -49,7 +49,7 @@ class InteractionManagement extends Cluster
 {
     protected static ?string $navigationGroup = 'Settings';
 
-    protected static ?int $navigationSort = 80;
+    protected static ?int $navigationSort = 90;
 
     /**
      * @var array<class-string<Resource>>

--- a/app/Filament/Clusters/OnlineAdmissions.php
+++ b/app/Filament/Clusters/OnlineAdmissions.php
@@ -42,5 +42,5 @@ class OnlineAdmissions extends Cluster
 {
     protected static ?string $navigationGroup = 'Settings';
 
-    protected static ?int $navigationSort = 90;
+    protected static ?int $navigationSort = 100;
 }

--- a/app/Filament/Clusters/ResourceHub.php
+++ b/app/Filament/Clusters/ResourceHub.php
@@ -40,7 +40,7 @@ use Filament\Clusters\Cluster;
 
 class ResourceHub extends Cluster
 {
-    protected static ?string $navigationGroup = 'Knowledge Management';
+    protected static ?string $navigationGroup = 'Settings';
 
-    protected static ?int $navigationSort = 10;
+    protected static ?int $navigationSort = 80;
 }

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -152,6 +152,10 @@ class AdminPanelProvider extends PanelProvider
                     ->icon('heroicon-o-rocket-launch')
                     ->collapsed(),
                 NavigationGroup::make()
+                    ->label('Knowledge Management')
+                    ->icon('heroicon-o-book-open')
+                    ->collapsed(),
+                NavigationGroup::make()
                     ->label('Project Management')
                     ->icon('heroicon-o-clipboard-document-check')
                     ->collapsed(),

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -152,10 +152,6 @@ class AdminPanelProvider extends PanelProvider
                     ->icon('heroicon-o-rocket-launch')
                     ->collapsed(),
                 NavigationGroup::make()
-                    ->label('Knowledge Management')
-                    ->icon('heroicon-o-book-open')
-                    ->collapsed(),
-                NavigationGroup::make()
                     ->label('Project Management')
                     ->icon('heroicon-o-clipboard-document-check')
                     ->collapsed(),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1823

### Technical Description

Revert the changes moving the resource hub settings and correctly moves the resource hub resource.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
