### PR TITLE
[ADVAPP-1819]: Some users have reported that deleted Resource Hub Category, Quality, and Status are replaced with UUID in article properties instead of being removed

### DIFF
--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategoryResource/Pages/EditResourceHubCategory.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategoryResource/Pages/EditResourceHubCategory.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\ResourceHub\Filament\Resources\ResourceHubCategoryResource\Pages;
 
 use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubCategoryResource;
+use AdvisingApp\ResourceHub\Models\ResourceHubCategory;
 use App\Filament\Forms\Components\IconSelect;
 use App\Filament\Resources\Pages\EditRecord\Concerns\EditPageRedirection;
 use Filament\Actions\DeleteAction;
@@ -73,7 +74,8 @@ class EditResourceHubCategory extends EditRecord
     {
         return [
             ViewAction::make(),
-            DeleteAction::make(),
+            DeleteAction::make()
+              ->hidden(fn (ResourceHubCategory $record) => count($record->resourceHubArticles) !== 0),
         ];
     }
 }

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualityResource/Pages/EditResourceHubQuality.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualityResource/Pages/EditResourceHubQuality.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\ResourceHub\Filament\Resources\ResourceHubQualityResource\Pages;
 
 use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubQualityResource;
+use AdvisingApp\ResourceHub\Models\ResourceHubQuality;
 use App\Filament\Resources\Pages\EditRecord\Concerns\EditPageRedirection;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ViewAction;
@@ -65,7 +66,8 @@ class EditResourceHubQuality extends EditRecord
     {
         return [
             ViewAction::make(),
-            DeleteAction::make(),
+            DeleteAction::make()
+              ->hidden(fn (ResourceHubQuality $record) => count($record->resourceHubArticles) !== 0),
         ];
     }
 }

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatusResource/Pages/EditResourceHubStatus.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatusResource/Pages/EditResourceHubStatus.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\ResourceHub\Filament\Resources\ResourceHubStatusResource\Pages;
 
 use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubStatusResource;
+use AdvisingApp\ResourceHub\Models\ResourceHubStatus;
 use App\Filament\Resources\Pages\EditRecord\Concerns\EditPageRedirection;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\ViewAction;
@@ -65,7 +66,8 @@ class EditResourceHubStatus extends EditRecord
     {
         return [
             ViewAction::make(),
-            DeleteAction::make(),
+            DeleteAction::make()
+              ->hidden(fn (ResourceHubStatus $record) => count($record->resourceHubArticles) !== 0),
         ];
     }
 }

--- a/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
@@ -133,6 +133,10 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
             );
         }
 
+        if(count($resourceHubCategory->resourceHubArticles) !==0 ){
+            return Response::deny('You do not have permissions to delete this resource hub category.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubCategory->getKey()}.delete"],
             denyResponse: 'You do not have permissions to delete this resource hub category.'

--- a/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
@@ -133,6 +133,10 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
             );
         }
 
+        if(count($resourceHubQuality->resourceHubArticles) !==0 ){
+            return Response::deny('You do not have permissions to delete this resource hub quality.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubQuality->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this resource hub quality.'

--- a/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
@@ -133,6 +133,10 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
             );
         }
 
+        if(count($resourceHubStatus->resourceHubArticles) !==0 ){
+            return Response::deny('You do not have permissions to delete this resource hub status.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: ["product_admin.{$resourceHubStatus->getKey()}.delete"],
             denyResponse: 'You do not have permission to delete this resource hub status.'


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1819

### Technical Description

Prevent deleting resource hub categories, qualities, or statuses associated with articles.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
