### PR TITLE
[ADVAPP-1741]: Improve the usability of the Care Team role assignment by showing all role values in the dropdown menu

### DIFF
--- a/app-modules/campaign/src/Filament/Blocks/CareTeamBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/CareTeamBlock.php
@@ -105,8 +105,10 @@ class CareTeamBlock extends CampaignActionBlock
                                 CareTeamRoleType::Student->getLabel() => CareTeamRoleType::Student,
                                 CareTeamRoleType::Prospect->getLabel() => CareTeamRoleType::Prospect,
                                 default => throw new Exception('The segment population was not of a type that can have a care team role associated with it.'),
-                            });
+                            })->orderByDesc('created_at');
                         })
+                        ->preload()
+                        ->optionsLimit(20)
                         ->searchable()
                         ->default(function (Get $get, $livewire, string $operation) {
                             if ($livewire instanceof CreateCampaign) {

--- a/app-modules/care-team/src/Filament/Actions/AddCareTeamMemberAction.php
+++ b/app-modules/care-team/src/Filament/Actions/AddCareTeamMemberAction.php
@@ -79,7 +79,9 @@ class AddCareTeamMemberAction
                     ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', match ($context) {
                         CareTeamRoleType::Student => CareTeamRoleType::Student,
                         CareTeamRoleType::Prospect => CareTeamRoleType::Prospect,
-                    }))
+                    })->orderByDesc('created_at'))
+                    ->preload()
+                    ->optionsLimit(20)
                     ->searchable()
                     ->model(CareTeam::class)
                     ->visible(CareTeamRole::where('type', match ($context) {

--- a/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectResource/Pages/ManageProspectCareTeam.php
@@ -122,7 +122,9 @@ class ManageProspectCareTeam extends ManageRelatedRecords
                             ),
                         Select::make('care_team_role_id')
                             ->label('Role')
-                            ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Prospect))
+                            ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Prospect)->orderByDesc('created_at'))
+                            ->preload()
+                            ->optionsLimit(20)
                             ->searchable()
                             ->model(CareTeam::class)
                             ->visible(CareTeamRole::where('type', CareTeamRoleType::Prospect)->count() > 0),

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -112,7 +112,9 @@ trait CanManageEducatableCareTeam
                             ),
                         Select::make('care_team_role_id')
                             ->label('Role')
-                            ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Student))
+                            ->relationship('careTeamRole', 'name', fn (Builder $query) => $query->where('type', CareTeamRoleType::Student)->orderByDesc('created_at'))
+                            ->preload()
+                            ->optionsLimit(20)
                             ->searchable()
                             ->model(CareTeam::class)
                             ->visible(CareTeamRole::where('type', CareTeamRoleType::Student)->count() > 0),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1741

### Technical Description

Load up to 20 of the most recently created care team roles in areas where such assignment is possible: the manage educatable care team pages, bulk assignment, and campaign actions.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
