### PR TITLE
[ADVAPP-1775]: Ensure that Subscriptions take into account soft deleted Users and/or the Educatables to prevent unnecessary exceptions

### DIFF
--- a/app-modules/campaign/src/Jobs/SubscriptionCampaignActionJob.php
+++ b/app-modules/campaign/src/Jobs/SubscriptionCampaignActionJob.php
@@ -58,9 +58,7 @@ class SubscriptionCampaignActionJob extends ExecuteCampaignActionOnEducatableJob
             assert($educatable instanceof Subscribable);
             assert($educatable instanceof Student || $educatable instanceof Prospect);
 
-            if (! is_null($educatable->deleted_at)) {
-                throw new Exception('This educatable has been deleted.');
-            }
+            throw_if(!is_null($educatable->deleted_at), new Exception('This educatable has been deleted.'));
 
             $action = $this->actionEducatable->campaignAction;
 
@@ -74,9 +72,7 @@ class SubscriptionCampaignActionJob extends ExecuteCampaignActionOnEducatableJob
             foreach ($action->data['user_ids'] as $userId) {
                 $user = User::find($userId);
 
-                if (! is_null($user->deleted_at)) {
-                    throw new Exception('This user has been deleted.');
-                }
+                throw_if(!is_null($user->deleted_at), new Exception('This user has been deleted.'));
 
                 $subscriptions[] = resolve(SubscriptionCreate::class)
                     ->handle($user, $educatable);

--- a/app-modules/campaign/src/Jobs/SubscriptionCampaignActionJob.php
+++ b/app-modules/campaign/src/Jobs/SubscriptionCampaignActionJob.php
@@ -68,8 +68,14 @@ class SubscriptionCampaignActionJob extends ExecuteCampaignActionOnEducatableJob
             $subscriptions = [];
 
             foreach ($action->data['user_ids'] as $userId) {
+                $user = User::find($userId);
+
+                if(is_null($user) || ! is_null($user->deleted_at)) {
+                  continue;
+                }
+
                 $subscriptions[] = resolve(SubscriptionCreate::class)
-                    ->handle(User::find($userId), $educatable);
+                    ->handle($user, $educatable);
             }
 
             foreach ($subscriptions as $subscription) {

--- a/app-modules/campaign/src/Jobs/SubscriptionCampaignActionJob.php
+++ b/app-modules/campaign/src/Jobs/SubscriptionCampaignActionJob.php
@@ -58,8 +58,8 @@ class SubscriptionCampaignActionJob extends ExecuteCampaignActionOnEducatableJob
             assert($educatable instanceof Subscribable);
             assert($educatable instanceof Student || $educatable instanceof Prospect);
 
-            if(!is_null($educatable->deleted_at)) {
-              throw new Exception('This educatable has been deleted.');
+            if (! is_null($educatable->deleted_at)) {
+                throw new Exception('This educatable has been deleted.');
             }
 
             $action = $this->actionEducatable->campaignAction;
@@ -74,8 +74,8 @@ class SubscriptionCampaignActionJob extends ExecuteCampaignActionOnEducatableJob
             foreach ($action->data['user_ids'] as $userId) {
                 $user = User::find($userId);
 
-                if(!is_null($user->deleted_at)) {
-                  throw new Exception('This user has been deleted.');
+                if (! is_null($user->deleted_at)) {
+                    throw new Exception('This user has been deleted.');
                 }
 
                 $subscriptions[] = resolve(SubscriptionCreate::class)

--- a/app-modules/campaign/src/Jobs/SubscriptionCampaignActionJob.php
+++ b/app-modules/campaign/src/Jobs/SubscriptionCampaignActionJob.php
@@ -58,7 +58,7 @@ class SubscriptionCampaignActionJob extends ExecuteCampaignActionOnEducatableJob
             assert($educatable instanceof Subscribable);
             assert($educatable instanceof Student || $educatable instanceof Prospect);
 
-            throw_if(!is_null($educatable->deleted_at), new Exception('This educatable has been deleted.'));
+            throw_if(! is_null($educatable->deleted_at), new Exception('This educatable has been deleted.'));
 
             $action = $this->actionEducatable->campaignAction;
 
@@ -72,7 +72,7 @@ class SubscriptionCampaignActionJob extends ExecuteCampaignActionOnEducatableJob
             foreach ($action->data['user_ids'] as $userId) {
                 $user = User::find($userId);
 
-                throw_if(!is_null($user->deleted_at), new Exception('This user has been deleted.'));
+                throw_if(! is_null($user->deleted_at), new Exception('This user has been deleted.'));
 
                 $subscriptions[] = resolve(SubscriptionCreate::class)
                     ->handle($user, $educatable);

--- a/app-modules/campaign/src/Jobs/SubscriptionCampaignActionJob.php
+++ b/app-modules/campaign/src/Jobs/SubscriptionCampaignActionJob.php
@@ -70,8 +70,8 @@ class SubscriptionCampaignActionJob extends ExecuteCampaignActionOnEducatableJob
             foreach ($action->data['user_ids'] as $userId) {
                 $user = User::find($userId);
 
-                if(is_null($user) || ! is_null($user->deleted_at)) {
-                  continue;
+                if (is_null($user) || ! is_null($user->deleted_at)) {
+                    continue;
                 }
 
                 $subscriptions[] = resolve(SubscriptionCreate::class)

--- a/app-modules/notification/src/Actions/SubscriptionCreate.php
+++ b/app-modules/notification/src/Actions/SubscriptionCreate.php
@@ -38,12 +38,20 @@ namespace AdvisingApp\Notification\Actions;
 
 use AdvisingApp\Notification\Models\Contracts\Subscribable;
 use AdvisingApp\Notification\Models\Subscription;
+use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\User;
+use Exception;
 
 class SubscriptionCreate
 {
     public function handle(User $user, Subscribable $subscribable): Subscription
     {
+        assert($subscribable instanceof Student || $subscribable instanceof Prospect);
+
+        throw_if(! is_null($subscribable->deleted_at), new Exception('This sub$subscribable has been deleted.'));
+        throw_if(! is_null($user->deleted_at), new Exception('This user has been deleted.'));
+
         return $user->subscriptions()
             ->firstOrCreate([
                 'subscribable_id' => $subscribable->getKey(),

--- a/app-modules/notification/src/Actions/SubscriptionCreate.php
+++ b/app-modules/notification/src/Actions/SubscriptionCreate.php
@@ -38,20 +38,12 @@ namespace AdvisingApp\Notification\Actions;
 
 use AdvisingApp\Notification\Models\Contracts\Subscribable;
 use AdvisingApp\Notification\Models\Subscription;
-use AdvisingApp\Prospect\Models\Prospect;
-use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\User;
-use Exception;
 
 class SubscriptionCreate
 {
     public function handle(User $user, Subscribable $subscribable): Subscription
     {
-        assert($subscribable instanceof Student || $subscribable instanceof Prospect);
-
-        throw_if(! is_null($subscribable->deleted_at), new Exception('This subscribable has been deleted.'));
-        throw_if(! is_null($user->deleted_at), new Exception('This user has been deleted.'));
-
         return $user->subscriptions()
             ->firstOrCreate([
                 'subscribable_id' => $subscribable->getKey(),

--- a/app-modules/notification/src/Actions/SubscriptionCreate.php
+++ b/app-modules/notification/src/Actions/SubscriptionCreate.php
@@ -49,7 +49,7 @@ class SubscriptionCreate
     {
         assert($subscribable instanceof Student || $subscribable instanceof Prospect);
 
-        throw_if(! is_null($subscribable->deleted_at), new Exception('This sub$subscribable has been deleted.'));
+        throw_if(! is_null($subscribable->deleted_at), new Exception('This subscribable has been deleted.'));
         throw_if(! is_null($user->deleted_at), new Exception('This user has been deleted.'));
 
         return $user->subscriptions()

--- a/app-modules/notification/src/Filament/Actions/SubscribeBulkAction.php
+++ b/app-modules/notification/src/Filament/Actions/SubscribeBulkAction.php
@@ -76,6 +76,8 @@ class SubscribeBulkAction
                 $records->each(function ($record) use ($data, $context) {
                     throw_unless($record instanceof Student || $record instanceof Prospect, new Exception("Record must be of type {$context}."));
 
+                    throw_if(! is_null($record->deleted_at), new Exception('This record has been deleted.'));
+
                     $removePrior = $data['remove_prior'];
                     $userIds = $data['user_ids'] ?? [];
 
@@ -84,6 +86,8 @@ class SubscribeBulkAction
                     }
 
                     foreach ($userIds as $userId) {
+                      throw_if(! is_null(User::find($userId)->deleted_at), new Exception('This user has been deleted.'));
+
                         $record->subscriptions()
                             ->firstOrCreate([
                                 'subscribable_id' => $record->getKey(),

--- a/app-modules/notification/src/Filament/Actions/SubscribeBulkAction.php
+++ b/app-modules/notification/src/Filament/Actions/SubscribeBulkAction.php
@@ -76,7 +76,7 @@ class SubscribeBulkAction
                 $records->each(function ($record) use ($data, $context) {
                     throw_unless($record instanceof Student || $record instanceof Prospect, new Exception("Record must be of type {$context}."));
 
-                    if(! is_null($record->deleted_at)) {
+                    if (! is_null($record->deleted_at)) {
                         return;
                     }
 
@@ -88,7 +88,7 @@ class SubscribeBulkAction
                     }
 
                     foreach ($userIds as $userId) {
-                        if(! is_null(User::find($userId)->deleted_at)) {
+                        if (! is_null(User::find($userId)->deleted_at)) {
                             continue;
                         }
 

--- a/app-modules/notification/src/Filament/Actions/SubscribeBulkAction.php
+++ b/app-modules/notification/src/Filament/Actions/SubscribeBulkAction.php
@@ -76,7 +76,9 @@ class SubscribeBulkAction
                 $records->each(function ($record) use ($data, $context) {
                     throw_unless($record instanceof Student || $record instanceof Prospect, new Exception("Record must be of type {$context}."));
 
-                    throw_if(! is_null($record->deleted_at), new Exception('This record has been deleted.'));
+                    if(! is_null($record->deleted_at)) {
+                        return;
+                    }
 
                     $removePrior = $data['remove_prior'];
                     $userIds = $data['user_ids'] ?? [];
@@ -86,7 +88,9 @@ class SubscribeBulkAction
                     }
 
                     foreach ($userIds as $userId) {
-                        throw_if(! is_null(User::find($userId)->deleted_at), new Exception('This user has been deleted.'));
+                        if(! is_null(User::find($userId)->deleted_at)) {
+                            continue;
+                        }
 
                         $record->subscriptions()
                             ->firstOrCreate([

--- a/app-modules/notification/src/Filament/Actions/SubscribeBulkAction.php
+++ b/app-modules/notification/src/Filament/Actions/SubscribeBulkAction.php
@@ -86,7 +86,7 @@ class SubscribeBulkAction
                     }
 
                     foreach ($userIds as $userId) {
-                      throw_if(! is_null(User::find($userId)->deleted_at), new Exception('This user has been deleted.'));
+                        throw_if(! is_null(User::find($userId)->deleted_at), new Exception('This user has been deleted.'));
 
                         $record->subscriptions()
                             ->firstOrCreate([

--- a/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
+++ b/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
@@ -60,9 +60,7 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             assert($educatable instanceof Subscribable);
             assert($educatable instanceof Student || $educatable instanceof Prospect);
 
-            if (! is_null($educatable->deleted_at)) {
-                throw new Exception('This educatable has been deleted.');
-            }
+            throw_if(!is_null($educatable->deleted_at), new Exception('This educatable has been deleted.'));
 
             $details = $this->workflowRunStep->details;
 
@@ -78,9 +76,7 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             foreach ($details->user_ids as $userId) {
                 $user = User::find($userId);
 
-                if (! is_null($user->deleted_at)) {
-                    throw new Exception('This user has been deleted.');
-                }
+                throw_if(!is_null($user->deleted_at), new Exception('This user has been deleted.'));
 
                 $subscriptions[] = resolve(SubscriptionCreate::class)
                     ->handle($user, $educatable);

--- a/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
+++ b/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
@@ -39,12 +39,9 @@ namespace AdvisingApp\Workflow\Jobs;
 use AdvisingApp\Notification\Actions\SubscriptionCreate;
 use AdvisingApp\Notification\Models\Contracts\Subscribable;
 use AdvisingApp\Notification\Models\Subscription;
-use AdvisingApp\Prospect\Models\Prospect;
-use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Workflow\Models\WorkflowRunStepRelated;
 use AdvisingApp\Workflow\Models\WorkflowSubscriptionDetails;
 use App\Models\User;
-use Exception;
 use Illuminate\Support\Facades\DB;
 use Throwable;
 
@@ -58,10 +55,7 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             $educatable = $this->workflowRunStep->workflowRun->related;
 
             assert($educatable instanceof Subscribable);
-            assert($educatable instanceof Student || $educatable instanceof Prospect);
-
-            throw_if(! is_null($educatable->deleted_at), new Exception('This educatable has been deleted.'));
-
+            
             $details = $this->workflowRunStep->details;
 
             assert($details instanceof WorkflowSubscriptionDetails);
@@ -74,12 +68,8 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             $subscriptions = [];
 
             foreach ($details->user_ids as $userId) {
-                $user = User::find($userId);
-
-                throw_if(! is_null($user->deleted_at), new Exception('This user has been deleted.'));
-
                 $subscriptions[] = resolve(SubscriptionCreate::class)
-                    ->handle($user, $educatable);
+                    ->handle(User::find($userId), $educatable);
             }
 
             foreach ($subscriptions as $subscription) {

--- a/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
+++ b/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
@@ -70,8 +70,8 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             foreach ($details->user_ids as $userId) {
                 $user = User::find($userId);
 
-                if(is_null($user) || ! is_null($user->deleted_at)) {
-                  continue;
+                if (is_null($user) || ! is_null($user->deleted_at)) {
+                    continue;
                 }
 
                 $subscriptions[] = resolve(SubscriptionCreate::class)

--- a/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
+++ b/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
@@ -40,7 +40,6 @@ use AdvisingApp\Notification\Actions\SubscriptionCreate;
 use AdvisingApp\Notification\Models\Contracts\Subscribable;
 use AdvisingApp\Notification\Models\Subscription;
 use AdvisingApp\Prospect\Models\Prospect;
-use AdvisingApp\StudentDataModel\Models\Contracts\Educatable;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Workflow\Models\WorkflowRunStepRelated;
 use AdvisingApp\Workflow\Models\WorkflowSubscriptionDetails;
@@ -61,8 +60,8 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             assert($educatable instanceof Subscribable);
             assert($educatable instanceof Student || $educatable instanceof Prospect);
 
-            if(!is_null($educatable->deleted_at)) {
-              throw new Exception('This educatable has been deleted.');
+            if (! is_null($educatable->deleted_at)) {
+                throw new Exception('This educatable has been deleted.');
             }
 
             $details = $this->workflowRunStep->details;
@@ -79,8 +78,8 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             foreach ($details->user_ids as $userId) {
                 $user = User::find($userId);
 
-                if(!is_null($user->deleted_at)) {
-                  throw new Exception('This user has been deleted.');
+                if (! is_null($user->deleted_at)) {
+                    throw new Exception('This user has been deleted.');
                 }
 
                 $subscriptions[] = resolve(SubscriptionCreate::class)

--- a/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
+++ b/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
@@ -55,7 +55,7 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             $educatable = $this->workflowRunStep->workflowRun->related;
 
             assert($educatable instanceof Subscribable);
-            
+
             $details = $this->workflowRunStep->details;
 
             assert($details instanceof WorkflowSubscriptionDetails);

--- a/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
+++ b/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
@@ -68,8 +68,14 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             $subscriptions = [];
 
             foreach ($details->user_ids as $userId) {
+                $user = User::find($userId);
+
+                if(is_null($user) || ! is_null($user->deleted_at)) {
+                  continue;
+                }
+
                 $subscriptions[] = resolve(SubscriptionCreate::class)
-                    ->handle(User::find($userId), $educatable);
+                    ->handle($user, $educatable);
             }
 
             foreach ($subscriptions as $subscription) {

--- a/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
+++ b/app-modules/workflow/src/Jobs/SubscriptionWorkflowActionJob.php
@@ -60,7 +60,7 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             assert($educatable instanceof Subscribable);
             assert($educatable instanceof Student || $educatable instanceof Prospect);
 
-            throw_if(!is_null($educatable->deleted_at), new Exception('This educatable has been deleted.'));
+            throw_if(! is_null($educatable->deleted_at), new Exception('This educatable has been deleted.'));
 
             $details = $this->workflowRunStep->details;
 
@@ -76,7 +76,7 @@ class SubscriptionWorkflowActionJob extends ExecuteWorkflowActionJob
             foreach ($details->user_ids as $userId) {
                 $user = User::find($userId);
 
-                throw_if(!is_null($user->deleted_at), new Exception('This user has been deleted.'));
+                throw_if(! is_null($user->deleted_at), new Exception('This user has been deleted.'));
 
                 $subscriptions[] = resolve(SubscriptionCreate::class)
                     ->handle($user, $educatable);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1775

### Technical Description

Ensure that users and educatables are not deleted before creating a subscription between them.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
