### PR TITLE
[ADVAPP-1837]: Update Tenant creation process to no longer require password or user information to be passed

### DIFF
--- a/app/Http/Controllers/Tenants/CreateTenantController.php
+++ b/app/Http/Controllers/Tenants/CreateTenantController.php
@@ -47,7 +47,6 @@ use App\Multitenancy\DataTransferObjects\TenantConfig;
 use App\Multitenancy\DataTransferObjects\TenantDatabaseConfig;
 use App\Multitenancy\DataTransferObjects\TenantMailConfig;
 use App\Multitenancy\DataTransferObjects\TenantS3FilesystemConfig;
-use App\Multitenancy\DataTransferObjects\TenantUser;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Str;
 use Sqids\Sqids;
@@ -96,11 +95,7 @@ class CreateTenantController
                     fromName: config('mail.from.name')
                 ),
             ),
-            new TenantUser(
-                name: $request->validated('user.name'),
-                email: $request->validated('user.email'),
-                password: $request->validated('user.password'),
-            ),
+            null,
             new LicenseData(
                 updatedAt: now(),
                 subscription: LicenseSubscriptionData::from($request->validated('subscription')),

--- a/app/Http/Requests/Tenants/CreateTenantRequest.php
+++ b/app/Http/Requests/Tenants/CreateTenantRequest.php
@@ -50,9 +50,6 @@ class CreateTenantRequest extends FormRequest
         return [
             'domain' => ['required', 'string', 'max:255', Rule::unique(Tenant::class)],
             'database' => ['required', 'string', 'max:255'],
-            'user.name' => ['required', 'string', 'max:255'],
-            'user.email' => ['required', 'email', 'max:255'],
-            'user.password' => ['required', 'string'],
             'limits' => ['required', 'array'],
             'limits.conversationalAiSeats' => ['required', 'integer', 'min:0'],
             'limits.conversationalAiAssistants' => ['required', 'integer', 'min:0'],


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1837

### Technical Description

Removes the user details and password requirement for Landlord tenant creation.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
