### PR TITLE
[ADVAPP-1754]: Implement confidential tasks and to share those with projects, other users or teams of users

### DIFF
--- a/app-modules/campaign/src/Filament/Blocks/TaskBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/TaskBlock.php
@@ -65,34 +65,34 @@ class TaskBlock extends CampaignActionBlock
         return [
             Fieldset::make('Details')
                 ->schema([
-                  Fieldset::make($fieldPrefix . 'Confidentiality')
-                    ->visible(ConfidentialTaskFeature::active())
-                    ->schema([
-                        Checkbox::make('is_confidential')
-                            ->label('Confidential')
-                            ->live(),
-                        Select::make('confidential_task_projects')
-                            ->relationship('confidentialAccessProjects', 'name')
-                            ->preload()
-                            ->label('Projects')
-                            ->multiple()
-                            ->exists('projects', 'id')
-                            ->visible(fn (Get $get) => $get('is_confidential')),
-                        Select::make('confidential_task_users')
-                            ->relationship('confidentialAccessUsers', 'name')
-                            ->preload()
-                            ->label('Users')
-                            ->multiple()
-                            ->exists('users', 'id')
-                            ->visible(fn (Get $get) => $get('is_confidential')),
-                        Select::make('confidential_task_teams')
-                            ->relationship('confidentialAccessTeams', 'name')
-                            ->preload()
-                            ->label('Teams')
-                            ->multiple()
-                            ->exists('teams', 'id')
-                            ->visible(fn (Get $get) => $get('is_confidential')),
-                    ]),
+                    Fieldset::make($fieldPrefix . 'Confidentiality')
+                        ->visible(ConfidentialTaskFeature::active())
+                        ->schema([
+                            Checkbox::make('is_confidential')
+                                ->label('Confidential')
+                                ->live(),
+                            Select::make('confidential_task_projects')
+                                ->relationship('confidentialAccessProjects', 'name')
+                                ->preload()
+                                ->label('Projects')
+                                ->multiple()
+                                ->exists('projects', 'id')
+                                ->visible(fn (Get $get) => $get('is_confidential')),
+                            Select::make('confidential_task_users')
+                                ->relationship('confidentialAccessUsers', 'name')
+                                ->preload()
+                                ->label('Users')
+                                ->multiple()
+                                ->exists('users', 'id')
+                                ->visible(fn (Get $get) => $get('is_confidential')),
+                            Select::make('confidential_task_teams')
+                                ->relationship('confidentialAccessTeams', 'name')
+                                ->preload()
+                                ->label('Teams')
+                                ->multiple()
+                                ->exists('teams', 'id')
+                                ->visible(fn (Get $get) => $get('is_confidential')),
+                        ]),
                     TextInput::make($fieldPrefix . 'title')
                         ->required()
                         ->maxLength(100)

--- a/app-modules/campaign/src/Filament/Blocks/TaskBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/TaskBlock.php
@@ -38,12 +38,15 @@ namespace AdvisingApp\Campaign\Filament\Blocks;
 
 use AdvisingApp\Campaign\Settings\CampaignSettings;
 use AdvisingApp\Task\Models\Task;
+use App\Features\ConfidentialTaskFeature;
 use Carbon\CarbonImmutable;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Get;
 use Illuminate\Support\Facades\Auth;
 
 class TaskBlock extends CampaignActionBlock
@@ -62,6 +65,34 @@ class TaskBlock extends CampaignActionBlock
         return [
             Fieldset::make('Details')
                 ->schema([
+                  Fieldset::make($fieldPrefix . 'Confidentiality')
+                    ->visible(ConfidentialTaskFeature::active())
+                    ->schema([
+                        Checkbox::make('is_confidential')
+                            ->label('Confidential')
+                            ->live(),
+                        Select::make('confidential_task_projects')
+                            ->relationship('confidentialAccessProjects', 'name')
+                            ->preload()
+                            ->label('Projects')
+                            ->multiple()
+                            ->exists('projects', 'id')
+                            ->visible(fn (Get $get) => $get('is_confidential')),
+                        Select::make('confidential_task_users')
+                            ->relationship('confidentialAccessUsers', 'name')
+                            ->preload()
+                            ->label('Users')
+                            ->multiple()
+                            ->exists('users', 'id')
+                            ->visible(fn (Get $get) => $get('is_confidential')),
+                        Select::make('confidential_task_teams')
+                            ->relationship('confidentialAccessTeams', 'name')
+                            ->preload()
+                            ->label('Teams')
+                            ->multiple()
+                            ->exists('teams', 'id')
+                            ->visible(fn (Get $get) => $get('is_confidential')),
+                    ]),
                     TextInput::make($fieldPrefix . 'title')
                         ->required()
                         ->maxLength(100)

--- a/app-modules/project/src/Filament/Resources/ProjectResource/Pages/ManageTasks.php
+++ b/app-modules/project/src/Filament/Resources/ProjectResource/Pages/ManageTasks.php
@@ -37,6 +37,8 @@
 namespace AdvisingApp\Project\Filament\Resources\ProjectResource\Pages;
 
 use AdvisingApp\Project\Filament\Resources\ProjectResource;
+use AdvisingApp\Task\Models\Task;
+use App\Features\ConfidentialTaskFeature;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Tables\Actions\AssociateAction;
 use Filament\Tables\Actions\BulkActionGroup;
@@ -64,7 +66,9 @@ class ManageTasks extends ManageRelatedRecords
             ->columns([
                 TextColumn::make('title')
                     ->sortable()
-                    ->searchable(),
+                    ->searchable()
+                    ->icon(fn (Task $record) => ConfidentialTaskFeature::active() && $record->is_confidential ? 'heroicon-m-lock-closed' : null)
+                    ->tooltip(fn (Task $record) => ConfidentialTaskFeature::active() && $record->is_confidential ? 'Confidential' : null),
             ])
             ->headerActions([
                 AssociateAction::make()

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManageTasksTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManageTasksTest.php
@@ -137,8 +137,8 @@ it('can list tasks', function () {
 it('does not list tasks already associated with a project in task search', function () {
     asSuperAdmin();
 
-    $projectOne = Project::factory()->create(['is_confidential' => false]);
-    $projectTwo = Project::factory()->create(['is_confidential' => false]);
+    $projectOne = Project::factory()->create();
+    $projectTwo = Project::factory()->create();
 
     $task = Task::factory()->for($projectOne)->concerningStudent(Student::factory()->create())->create();
 

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManageTasksTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectResource/Pages/ManageTasksTest.php
@@ -126,7 +126,7 @@ it('can list tasks', function () {
 
     $project = Project::factory()->create();
 
-    Task::factory()->count(5)->for($project)->concerningStudent(Student::factory()->create())->create();
+    Task::factory()->count(5)->for($project)->concerningStudent(Student::factory()->create())->create(['is_confidential' => false]);
 
     livewire(ManageTasks::class, [
         'record' => $project->getRouteKey(),
@@ -137,8 +137,8 @@ it('can list tasks', function () {
 it('does not list tasks already associated with a project in task search', function () {
     asSuperAdmin();
 
-    $projectOne = Project::factory()->create();
-    $projectTwo = Project::factory()->create();
+    $projectOne = Project::factory()->create(['is_confidential' => false]);
+    $projectTwo = Project::factory()->create(['is_confidential' => false]);
 
     $task = Task::factory()->for($projectOne)->concerningStudent(Student::factory()->create())->create();
 

--- a/app-modules/prospect/tests/Tenant/Unit/RecruitmentCrmDashboardTest.php
+++ b/app-modules/prospect/tests/Tenant/Unit/RecruitmentCrmDashboardTest.php
@@ -50,7 +50,7 @@ use function Pest\Livewire\livewire;
 
 it('renders all prospects correctly in the recruitment dashboard for the All tab', function () {
     $allProspects = Prospect::factory()->has(
-        Task::factory()->state(['status' => TaskStatus::Pending]),
+        Task::factory()->state(['status' => TaskStatus::Pending, 'is_confidential' => false]),
         'tasks'
     )->count(2)->create();
 
@@ -111,7 +111,7 @@ it('renders subscribed prospects correctly in the recruitment dashboard for the 
             'subscriptions'
         )
         ->has(
-            Task::factory()->state(['status' => TaskStatus::Pending]),
+            Task::factory()->state(['status' => TaskStatus::Pending, 'is_confidential' => false]),
             'tasks'
         )->count(2)->create();
 
@@ -147,7 +147,7 @@ it('renders care team prospects correctly in the recruitment dashboard for the C
             'careTeam'
         )
         ->has(
-            Task::factory()->state(['status' => TaskStatus::Pending]),
+            Task::factory()->state(['status' => TaskStatus::Pending, 'is_confidential' => false]),
             'tasks'
         )
         ->count(2)

--- a/app-modules/report/tests/Tenant/Filament/Widgets/MostRecentTasksTableTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/MostRecentTasksTableTest.php
@@ -45,14 +45,17 @@ it('displays only tasks added within the selected date range', function () {
 
     $taskWithinRange1 = Task::factory()->state([
         'created_at' => $startDate,
+        'is_confidential' => false,
     ])->create();
 
     $taskWithinRange2 = Task::factory()->state([
         'created_at' => $endDate,
+        'is_confidential' => false,
     ])->create();
 
     $taskOutsideRange = Task::factory()->state([
         'created_at' => now()->subDays(20),
+        'is_confidential' => false,
     ])->create();
 
     $filters = [

--- a/app-modules/report/tests/Tenant/Filament/Widgets/ProspectReportStatsTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/ProspectReportStatsTest.php
@@ -74,6 +74,7 @@ it('returns correct total prospect stats of prospects, alerts, segments and task
         'concern_id' => Prospect::factory(),
         'concern_type' => (new Prospect())->getMorphClass(),
         'created_at' => $startDate,
+        'is_confidential' => false,
     ])->create();
 
     $widget = new ProspectReportStats();

--- a/app-modules/report/tests/Tenant/Filament/Widgets/StudentsStatsTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/StudentsStatsTest.php
@@ -81,6 +81,7 @@ it('returns correct total student stats of students, alerts, segments and tasks 
             ]),
         'concern_type' => (new Student())->getMorphClass(),
         'created_at' => $startDate,
+        'is_confidential' => false,
     ])->create();
 
     $widget = new StudentsStats();
@@ -166,7 +167,7 @@ it('returns correct total student stats of students, alerts, cases and tasks bas
             Student::factory()->create(['last' => 'John']),
             'concern'
         )
-        ->create();
+        ->create(['is_confidential' => false]);
 
     Task::factory()
         ->count($count)
@@ -174,7 +175,7 @@ it('returns correct total student stats of students, alerts, cases and tasks bas
             Student::factory()->create(['last' => 'Doe']),
             'concern'
         )
-        ->create();
+        ->create(['is_confidential' => false]);
 
     $widget = new StudentsStats();
     $widget->cacheTag = 'report-student';

--- a/app-modules/report/tests/Tenant/Filament/Widgets/TaskCumulativeCountLineChartTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/TaskCumulativeCountLineChartTest.php
@@ -52,6 +52,7 @@ it('returns correct cumulative task counts grouped by month within the given dat
         'concern_type' => (new Student())->getMorphClass(),
         'status' => TaskStatus::Pending,
         'created_at' => $endDate,
+        'is_confidential' => false,
     ])->create();
 
     Task::factory()->count(2)->state([
@@ -59,6 +60,7 @@ it('returns correct cumulative task counts grouped by month within the given dat
         'concern_type' => (new Prospect())->getMorphClass(),
         'status' => TaskStatus::Pending,
         'created_at' => $endDate,
+        'is_confidential' => false,
     ])->create();
 
     Task::factory()->count(2)->state([
@@ -66,6 +68,7 @@ it('returns correct cumulative task counts grouped by month within the given dat
         'concern_type' => null,
         'status' => TaskStatus::Pending,
         'created_at' => $endDate,
+        'is_confidential' => false,
     ])->create();
 
     $widgetInstance = new TaskCumulativeCountLineChart();

--- a/app-modules/report/tests/Tenant/Filament/Widgets/TaskStatsTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/TaskStatsTest.php
@@ -51,11 +51,13 @@ it('returns correct task statistics for total tasks, staff, students, and prospe
     Task::factory()->count($taskCount)->state([
         'status' => TaskStatus::Completed,
         'created_at' => $startDate,
+        'is_confidential' => false,
     ])->create();
 
     Task::factory()->count($taskCount)->state([
         'status' => TaskStatus::Canceled,
         'created_at' => $endDate,
+        'is_confidential' => false,
     ])->create();
 
     $staffTasks = Task::factory()->assigned()->count($taskCount)->state([
@@ -63,6 +65,7 @@ it('returns correct task statistics for total tasks, staff, students, and prospe
         'concern_type' => (new Student())->getMorphClass(),
         'status' => TaskStatus::InProgress,
         'created_at' => $startDate,
+        'is_confidential' => false,
     ])->create();
 
     Task::factory()->count($taskCount)->state([
@@ -70,6 +73,7 @@ it('returns correct task statistics for total tasks, staff, students, and prospe
         'concern_type' => (new Student())->getMorphClass(),
         'status' => TaskStatus::Pending,
         'created_at' => $endDate,
+        'is_confidential' => false,
     ])->create();
 
     Task::factory()->count($taskCount)->state([
@@ -77,6 +81,7 @@ it('returns correct task statistics for total tasks, staff, students, and prospe
         'concern_type' => (new Prospect())->getMorphClass(),
         'status' => TaskStatus::Pending,
         'created_at' => $endDate,
+        'is_confidential' => false,
     ])->create();
 
     $widget = new TaskStats();

--- a/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableTasks.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EducatableResource/Pages/Concerns/CanManageEducatableTasks.php
@@ -43,13 +43,17 @@ use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Task\Enums\TaskStatus;
 use AdvisingApp\Task\Filament\Resources\TaskResource\Components\TaskViewAction;
 use AdvisingApp\Task\Models\Task;
+use App\Features\ConfidentialTaskFeature;
 use App\Filament\Resources\UserResource;
 use App\Filament\Tables\Columns\IdColumn;
 use App\Models\Scopes\HasLicense;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
+use Filament\Forms\Get;
 use Filament\Tables\Actions\BulkActionGroup;
 use Filament\Tables\Actions\CreateAction;
 use Filament\Tables\Actions\DissociateAction;
@@ -78,6 +82,34 @@ trait CanManageEducatableTasks
     {
         return $form
             ->schema([
+                Fieldset::make('Confidentiality')
+                    ->visible(ConfidentialTaskFeature::active())
+                    ->schema([
+                        Checkbox::make('is_confidential')
+                            ->label('Confidential')
+                            ->live(),
+                        Select::make('confidential_task_projects')
+                            ->relationship('confidentialAccessProjects', 'name')
+                            ->preload()
+                            ->label('Projects')
+                            ->multiple()
+                            ->exists('projects', 'id')
+                            ->visible(fn (Get $get) => $get('is_confidential')),
+                        Select::make('confidential_task_users')
+                            ->relationship('confidentialAccessUsers', 'name')
+                            ->preload()
+                            ->label('Users')
+                            ->multiple()
+                            ->exists('users', 'id')
+                            ->visible(fn (Get $get) => $get('is_confidential')),
+                        Select::make('confidential_task_teams')
+                            ->relationship('confidentialAccessTeams', 'name')
+                            ->preload()
+                            ->label('Teams')
+                            ->multiple()
+                            ->exists('teams', 'id')
+                            ->visible(fn (Get $get) => $get('is_confidential')),
+                    ]),
                 TextInput::make('title')
                     ->required()
                     ->maxLength(100)
@@ -111,7 +143,9 @@ trait CanManageEducatableTasks
                 IdColumn::make(),
                 TextColumn::make('description')
                     ->wrap()
-                    ->limit(50),
+                    ->limit(50)
+                    ->icon(fn (Task $record) => ConfidentialTaskFeature::active() && $record->is_confidential ? 'heroicon-m-lock-closed' : null)
+                    ->tooltip(fn (Task $record) => ConfidentialTaskFeature::active() && $record->is_confidential ? 'Confidential' : null),
                 TextColumn::make('status')
                     ->formatStateUsing(fn (TaskStatus $state): string => str($state->value)->title()->headline())
                     ->badge()

--- a/app-modules/student-data-model/tests/Tenant/Unit/RetentionCrmDashboardTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Unit/RetentionCrmDashboardTest.php
@@ -48,7 +48,7 @@ use function Pest\Livewire\livewire;
 
 it('renders all students correctly in the retention dashboard', function () {
     $allStudents = Student::factory()->has(
-        Task::factory()->state(['status' => TaskStatus::Pending]),
+        Task::factory()->state(['status' => TaskStatus::Pending, 'is_confidential' => false]),
         'tasks'
     )->count(2)->create();
 

--- a/app-modules/task/database/factories/ConfidentialTasksProjectsFactory.php
+++ b/app-modules/task/database/factories/ConfidentialTasksProjectsFactory.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Task\Database\Factories;
 
 use AdvisingApp\Project\Models\Project;

--- a/app-modules/task/database/factories/ConfidentialTasksProjectsFactory.php
+++ b/app-modules/task/database/factories/ConfidentialTasksProjectsFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AdvisingApp\Task\Database\Factories;
+
+use AdvisingApp\Project\Models\Project;
+use AdvisingApp\Task\Models\Task;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\AdvisingApp\Task\Models\ConfidentialTasksProjects>
+ */
+class ConfidentialTasksProjectsFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'task_id' => Task::factory(),
+            'project_id' => Project::factory(),
+        ];
+    }
+}

--- a/app-modules/task/database/factories/ConfidentialTasksTeamsFactory.php
+++ b/app-modules/task/database/factories/ConfidentialTasksTeamsFactory.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Task\Database\Factories;
 
 use AdvisingApp\Task\Models\Task;

--- a/app-modules/task/database/factories/ConfidentialTasksTeamsFactory.php
+++ b/app-modules/task/database/factories/ConfidentialTasksTeamsFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AdvisingApp\Task\Database\Factories;
+
+use AdvisingApp\Task\Models\Task;
+use AdvisingApp\Team\Models\Team;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\AdvisingApp\Task\Models\ConfidentialTasksTeams>
+ */
+class ConfidentialTasksTeamsFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'task_id' => Task::factory(),
+            'team_id' => Team::factory(),
+        ];
+    }
+}

--- a/app-modules/task/database/factories/ConfidentialTasksUsersFactory.php
+++ b/app-modules/task/database/factories/ConfidentialTasksUsersFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AdvisingApp\Task\Database\Factories;
+
+use AdvisingApp\Task\Models\Task;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\AdvisingApp\Task\Models\ConfidentialTasksUsers>
+ */
+class ConfidentialTasksUsersFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'task_id' => Task::factory(),
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/app-modules/task/database/factories/ConfidentialTasksUsersFactory.php
+++ b/app-modules/task/database/factories/ConfidentialTasksUsersFactory.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Task\Database\Factories;
 
 use AdvisingApp\Task\Models\Task;

--- a/app-modules/task/database/factories/TaskFactory.php
+++ b/app-modules/task/database/factories/TaskFactory.php
@@ -59,6 +59,7 @@ class TaskFactory extends Factory
             'created_by' => User::factory(),
             'concern_id' => null,
             'concern_type' => null,
+            'is_confidential' => $this->faker->boolean(),
         ];
     }
 

--- a/app-modules/task/database/migrations/2025_08_27_213346_add_is_confidential_to_tasks_table.php
+++ b/app-modules/task/database/migrations/2025_08_27_213346_add_is_confidential_to_tasks_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->boolean('is_confidential')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn('is_confidential');
+        });
+    }
+};

--- a/app-modules/task/database/migrations/2025_08_27_213346_add_is_confidential_to_tasks_table.php
+++ b/app-modules/task/database/migrations/2025_08_27_213346_add_is_confidential_to_tasks_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;

--- a/app-modules/task/database/migrations/2025_08_27_213543_make_confidential_tasks_users_table.php
+++ b/app-modules/task/database/migrations/2025_08_27_213543_make_confidential_tasks_users_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;

--- a/app-modules/task/database/migrations/2025_08_27_213543_make_confidential_tasks_users_table.php
+++ b/app-modules/task/database/migrations/2025_08_27_213543_make_confidential_tasks_users_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('confidential_task_users', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->foreignUuid('task_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('confidential_task_users');
+    }
+};

--- a/app-modules/task/database/migrations/2025_08_27_213719_make_confidential_tasks_teams_table.php
+++ b/app-modules/task/database/migrations/2025_08_27_213719_make_confidential_tasks_teams_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;

--- a/app-modules/task/database/migrations/2025_08_27_213719_make_confidential_tasks_teams_table.php
+++ b/app-modules/task/database/migrations/2025_08_27_213719_make_confidential_tasks_teams_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('confidential_task_teams', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->foreignUuid('task_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('confidential_task_teams');
+    }
+};

--- a/app-modules/task/database/migrations/2025_08_27_221812_make_confidential_tasks_projects_table.php
+++ b/app-modules/task/database/migrations/2025_08_27_221812_make_confidential_tasks_projects_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;

--- a/app-modules/task/database/migrations/2025_08_27_221812_make_confidential_tasks_projects_table.php
+++ b/app-modules/task/database/migrations/2025_08_27_221812_make_confidential_tasks_projects_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('confidential_task_projects', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            $table->foreignUuid('task_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('confidential_task_projects');
+    }
+};

--- a/app-modules/task/database/migrations/2025_08_27_221812_make_confidential_tasks_projects_table.php
+++ b/app-modules/task/database/migrations/2025_08_27_221812_make_confidential_tasks_projects_table.php
@@ -45,7 +45,7 @@ return new class () extends Migration {
             $table->uuid('id')->primary();
 
             $table->foreignUuid('task_id')->constrained()->cascadeOnDelete();
-            $table->foreignUuid('team_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('project_id')->constrained()->cascadeOnDelete();
 
             $table->timestamps();
         });

--- a/app-modules/task/database/migrations/2025_08_29_215640_data_activate_confidential_task_feature.php
+++ b/app-modules/task/database/migrations/2025_08_29_215640_data_activate_confidential_task_feature.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Features\ConfidentialTaskFeature;
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        ConfidentialTaskFeature::activate();
+    }
+
+    public function down(): void
+    {
+        ConfidentialTaskFeature::deactivate();
+    }
+};

--- a/app-modules/task/database/migrations/2025_08_29_215640_data_activate_confidential_task_feature.php
+++ b/app-modules/task/database/migrations/2025_08_29_215640_data_activate_confidential_task_feature.php
@@ -1,12 +1,43 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\ConfidentialTaskFeature;
 use Illuminate\Database\Migrations\Migration;
-use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
-use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         ConfidentialTaskFeature::activate();

--- a/app-modules/task/database/seeders/TaskSeeder.php
+++ b/app-modules/task/database/seeders/TaskSeeder.php
@@ -50,7 +50,7 @@ class TaskSeeder extends Seeder
             ->assigned(User::first())
             ->concerningStudent()
             ->pastDue()
-            ->create();
+            ->create(['is_confidential' => false]);
 
         // Past due, Prospect Concerned
         Task::factory()
@@ -58,7 +58,7 @@ class TaskSeeder extends Seeder
             ->assigned(User::first())
             ->concerningProspect()
             ->pastDue()
-            ->create();
+            ->create(['is_confidential' => false]);
 
         // Due Later, Student Concerned
         Task::factory()
@@ -66,7 +66,7 @@ class TaskSeeder extends Seeder
             ->assigned(User::first())
             ->concerningStudent()
             ->dueLater()
-            ->create();
+            ->create(['is_confidential' => false]);
 
         // Due Later, Prospect Concerned
         Task::factory()
@@ -74,26 +74,26 @@ class TaskSeeder extends Seeder
             ->assigned(User::first())
             ->concerningProspect()
             ->dueLater()
-            ->create();
+            ->create(['is_confidential' => false]);
 
         // Unassigned
         Task::factory()
             ->count(3)
             ->concerningStudent()
-            ->create();
+            ->create(['is_confidential' => false]);
 
         // Unassigned, Past Due
         Task::factory()
             ->count(3)
             ->concerningStudent()
             ->pastDue()
-            ->create();
+            ->create(['is_confidential' => false]);
 
         // Randomly assigned
         Task::factory()
             ->count(10)
             ->assigned()
             ->concerningStudent()
-            ->create();
+            ->create(['is_confidential' => false]);
     }
 }

--- a/app-modules/task/src/Filament/Concerns/TaskViewActionInfoList.php
+++ b/app-modules/task/src/Filament/Concerns/TaskViewActionInfoList.php
@@ -42,6 +42,7 @@ use AdvisingApp\StudentDataModel\Filament\Resources\StudentResource;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Task\Enums\TaskStatus;
 use AdvisingApp\Task\Models\Task;
+use App\Features\ConfidentialTaskFeature;
 use App\Filament\Resources\UserResource;
 use Filament\Infolists\Components\Fieldset;
 use Filament\Infolists\Components\Grid;
@@ -56,6 +57,12 @@ trait TaskViewActionInfoList
             Split::make([
                 Grid::make()
                     ->schema([
+                        TextEntry::make('is_confidential')
+                            ->columnSpanFull()
+                            ->label('')
+                            ->badge()
+                            ->formatStateUsing(fn ($state): string => $state ? 'Confidential' : '')
+                            ->visible(fn ($record): bool => ConfidentialTaskFeature::active() && $record->is_confidential),
                         TextEntry::make('title')
                             ->columnSpanFull(),
                         TextEntry::make('description')

--- a/app-modules/task/src/Filament/RelationManagers/BaseTaskRelationManager.php
+++ b/app-modules/task/src/Filament/RelationManagers/BaseTaskRelationManager.php
@@ -43,13 +43,17 @@ use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Task\Enums\TaskStatus;
 use AdvisingApp\Task\Filament\Resources\TaskResource\Components\TaskViewAction;
 use AdvisingApp\Task\Models\Task;
+use App\Features\ConfidentialTaskFeature;
 use App\Filament\Resources\UserResource;
 use App\Filament\Tables\Columns\IdColumn;
 use App\Models\Scopes\HasLicense;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
+use Filament\Forms\Get;
 use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Tables\Actions\BulkActionGroup;
 use Filament\Tables\Actions\CreateAction;
@@ -70,6 +74,34 @@ abstract class BaseTaskRelationManager extends ManageRelatedRecords
     {
         return $form
             ->schema([
+                Fieldset::make('Confidentiality')
+                    ->visible(ConfidentialTaskFeature::active())
+                    ->schema([
+                        Checkbox::make('is_confidential')
+                            ->label('Confidential')
+                            ->live(),
+                        Select::make('confidential_task_projects')
+                            ->relationship('confidentialAccessProjects', 'name')
+                            ->preload()
+                            ->label('Projects')
+                            ->multiple()
+                            ->exists('projects', 'id')
+                            ->visible(fn (Get $get) => $get('is_confidential')),
+                        Select::make('confidential_task_users')
+                            ->relationship('confidentialAccessUsers', 'name')
+                            ->preload()
+                            ->label('Users')
+                            ->multiple()
+                            ->exists('users', 'id')
+                            ->visible(fn (Get $get) => $get('is_confidential')),
+                        Select::make('confidential_task_teams')
+                            ->relationship('confidentialAccessTeams', 'name')
+                            ->preload()
+                            ->label('Teams')
+                            ->multiple()
+                            ->exists('teams', 'id')
+                            ->visible(fn (Get $get) => $get('is_confidential')),
+                    ]),
                 TextInput::make('title')
                     ->required()
                     ->maxLength(100)
@@ -104,7 +136,9 @@ abstract class BaseTaskRelationManager extends ManageRelatedRecords
                 TextColumn::make('description')
                     ->searchable()
                     ->wrap()
-                    ->limit(50),
+                    ->limit(50)
+                    ->icon(fn (Task $record) => ConfidentialTaskFeature::active() && $record->is_confidential ? 'heroicon-m-lock-closed' : null)
+                    ->tooltip(fn (Task $record) => ConfidentialTaskFeature::active() && $record->is_confidential ? 'Confidential' : null),
                 TextColumn::make('status')
                     ->formatStateUsing(fn (TaskStatus $state): string => str($state->value)->title()->headline())
                     ->badge()

--- a/app-modules/task/src/Models/ConfidentialTasksProjects.php
+++ b/app-modules/task/src/Models/ConfidentialTasksProjects.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Task\Models;
 
 use AdvisingApp\Project\Models\Project;

--- a/app-modules/task/src/Models/ConfidentialTasksProjects.php
+++ b/app-modules/task/src/Models/ConfidentialTasksProjects.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AdvisingApp\Task\Models;
+
+use AdvisingApp\Project\Models\Project;
+use AdvisingApp\Task\Database\Factories\ConfidentialTasksProjectsFactory;
+use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @mixin IdeHelperConfidentialTasksProjects
+ */
+class ConfidentialTasksProjects extends Pivot
+{
+    /** @use HasFactory<ConfidentialTasksProjectsFactory> */
+    use HasFactory;
+
+    use HasUuids;
+
+    /**
+     * @return BelongsTo<Task, $this>
+     */
+    public function task(): BelongsTo
+    {
+        return $this->belongsTo(Task::class);
+    }
+
+    /**
+     * @return BelongsTo<Project, $this>
+     */
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+}

--- a/app-modules/task/src/Models/ConfidentialTasksTeams.php
+++ b/app-modules/task/src/Models/ConfidentialTasksTeams.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Task\Models;
 
 use AdvisingApp\Task\Database\Factories\ConfidentialTasksTeamsFactory;

--- a/app-modules/task/src/Models/ConfidentialTasksTeams.php
+++ b/app-modules/task/src/Models/ConfidentialTasksTeams.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AdvisingApp\Task\Models;
+
+use AdvisingApp\Task\Database\Factories\ConfidentialTasksTeamsFactory;
+use AdvisingApp\Team\Models\Team;
+use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @mixin IdeHelperConfidentialTasksTeams
+ */
+class ConfidentialTasksTeams extends Pivot
+{
+    /** @use HasFactory<ConfidentialTasksTeamsFactory> */
+    use HasFactory;
+
+    use HasUuids;
+
+    /**
+     * @return BelongsTo<Task, $this>
+     */
+    public function task(): BelongsTo
+    {
+        return $this->belongsTo(Task::class);
+    }
+
+    /**
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+}

--- a/app-modules/task/src/Models/ConfidentialTasksUsers.php
+++ b/app-modules/task/src/Models/ConfidentialTasksUsers.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AdvisingApp\Task\Models;
+
+use AdvisingApp\Task\Database\Factories\ConfidentialTasksUsersFactory;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Concerns\HasVersion4Uuids as HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @mixin IdeHelperConfidentialTasksUsers
+ */
+class ConfidentialTasksUsers extends Pivot
+{
+    /** @use HasFactory<ConfidentialTasksUsersFactory> */
+    use HasFactory;
+
+    use HasUuids;
+
+    /**
+     * @return BelongsTo<Task, $this>
+     */
+    public function task(): BelongsTo
+    {
+        return $this->belongsTo(Task::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app-modules/task/src/Models/ConfidentialTasksUsers.php
+++ b/app-modules/task/src/Models/ConfidentialTasksUsers.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Task\Models;
 
 use AdvisingApp\Task\Database\Factories\ConfidentialTasksUsersFactory;

--- a/app-modules/task/src/Models/Scopes/ConfidentialTaskScope.php
+++ b/app-modules/task/src/Models/Scopes/ConfidentialTaskScope.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Task\Models\Scopes;
 
 use Illuminate\Database\Eloquent\Builder;

--- a/app-modules/task/src/Models/Scopes/ConfidentialTaskScope.php
+++ b/app-modules/task/src/Models/Scopes/ConfidentialTaskScope.php
@@ -45,7 +45,7 @@ class ConfidentialTaskScope implements Scope
 {
     public function apply(Builder $builder, Model $model)
     {
-        if (!ConfidentialTaskFeature::active() || auth()->user()?->isSuperAdmin()) {
+        if (! ConfidentialTaskFeature::active() || auth()->user()?->isSuperAdmin()) {
             return;
         }
 

--- a/app-modules/task/src/Models/Scopes/ConfidentialTaskScope.php
+++ b/app-modules/task/src/Models/Scopes/ConfidentialTaskScope.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Task\Models\Scopes;
 
+use App\Features\ConfidentialTaskFeature;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Scope;
@@ -44,13 +45,10 @@ class ConfidentialTaskScope implements Scope
 {
     public function apply(Builder $builder, Model $model)
     {
-        //feature flag check
-
-        if (auth()->user()?->isSuperAdmin()) {
+        if (!ConfidentialTaskFeature::active() || auth()->user()?->isSuperAdmin()) {
             return;
         }
 
-        //need to account for projects too!
         $builder->where('is_confidential', false)->orWhere(function (Builder $query) {
             $query->where('is_confidential', true)
                 ->where('created_by', auth()->id())

--- a/app-modules/task/src/Models/Scopes/ConfidentialTaskScope.php
+++ b/app-modules/task/src/Models/Scopes/ConfidentialTaskScope.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AdvisingApp\Task\Models\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class ConfidentialTaskScope implements Scope
+{
+    public function apply(Builder $builder, Model $model)
+    {
+        //feature flag check
+
+        if (auth()->user()?->isSuperAdmin()) {
+            return;
+        }
+
+        //need to account for projects too!
+        $builder->where('is_confidential', false)->orWhere(function (Builder $query) {
+            $query->where('is_confidential', true)
+                ->where('created_by', auth()->id())
+                ->orWhereHas('confidentialAccessTeams', function (Builder $query) {
+                    $query->whereHas('users', function (Builder $query) {
+                        $query->where('users.id', auth()->id());
+                    });
+                })
+                ->orWhereHas('confidentialAccessUsers', function (Builder $query) {
+                    $query->where('user_id', auth()->id());
+                });
+        });
+    }
+}

--- a/app-modules/task/src/Models/Scopes/ConfidentialTaskScope.php
+++ b/app-modules/task/src/Models/Scopes/ConfidentialTaskScope.php
@@ -59,6 +59,11 @@ class ConfidentialTaskScope implements Scope
                 })
                 ->orWhereHas('confidentialAccessUsers', function (Builder $query) {
                     $query->where('user_id', auth()->id());
+                })
+                ->orWhereHas('confidentialAccessProjects', function (Builder $query) {
+                    $query->whereHas('createdBy', function (Builder $query) {
+                        $query->where('created_by_id', auth()->id());
+                    });
                 });
         });
     }

--- a/app-modules/task/tests/Tenant/Models/Scopes/ConfidentialTaskScopeTest.php
+++ b/app-modules/task/tests/Tenant/Models/Scopes/ConfidentialTaskScopeTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Task\Models\Scopes\ConfidentialTaskScope;
@@ -16,70 +50,70 @@ it('is applied as a global scope to the task model', function () {
     expect(Task::hasGlobalScope(ConfidentialTaskScope::class))->toBeTrue();
 });
 
-it('can be accessed by users when not confidential', function() {
-  $user = User::factory()->licensed(LicenseType::cases())->create();
+it('can be accessed by users when not confidential', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
 
-  actingAs($user);
+    actingAs($user);
 
-  $confidentialTasks = Task::factory()->count(10)->concerningStudent(Student::factory()->create())->create(['is_confidential' => true]);
-  $nonConfidentialTasks = Task::factory()->count(10)->concerningStudent(Student::factory()->create())->create(['is_confidential' => false]);
+    $confidentialTasks = Task::factory()->count(10)->concerningStudent(Student::factory()->create())->create(['is_confidential' => true]);
+    $nonConfidentialTasks = Task::factory()->count(10)->concerningStudent(Student::factory()->create())->create(['is_confidential' => false]);
 
-  $tasks = Task::query()->get();
-  expect($tasks)->toHaveCount(10);
+    $tasks = Task::query()->get();
+    expect($tasks)->toHaveCount(10);
 
-  expect($tasks->pluck('id'))
-    ->toContain(...$nonConfidentialTasks->pluck('id'));
-  
-  expect($tasks->pluck('id'))
-    ->not->toContain(...$confidentialTasks->pluck('id'));
+    expect($tasks->pluck('id'))
+        ->toContain(...$nonConfidentialTasks->pluck('id'));
+
+    expect($tasks->pluck('id'))
+        ->not->toContain(...$confidentialTasks->pluck('id'));
 });
 
-it('can be accessed when confidential by users who created it or super admins', function() {
-  $user = User::factory()->licensed(LicenseType::cases())->create();
+it('can be accessed when confidential by users who created it or super admins', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
 
-  actingAs($user);
+    actingAs($user);
 
-  $userTasks = Task::factory()->count(10)->concerningStudent(Student::factory()->create())->create([
-    'is_confidential' => true,
-    'created_by' => $user,
-  ]);
+    $userTasks = Task::factory()->count(10)->concerningStudent(Student::factory()->create())->create([
+        'is_confidential' => true,
+        'created_by' => $user,
+    ]);
 
-  $tasks = Task::query()->get();
+    $tasks = Task::query()->get();
 
-  expect($tasks->pluck('id'))
-    ->toContain(...$userTasks->pluck('id'));
+    expect($tasks->pluck('id'))
+        ->toContain(...$userTasks->pluck('id'));
 
     asSuperAdmin();
-  
+
     expect($tasks->pluck('id'))
-    ->toContain(...$userTasks->pluck('id'));
+        ->toContain(...$userTasks->pluck('id'));
 });
 
-it('can be accessed when confidential by users on a team with access', function() {
-  $team = Team::factory()->create();
-  $user = User::factory()->licensed(LicenseType::cases())->create();
-  $user->team()->associate($team)->save();
+it('can be accessed when confidential by users on a team with access', function () {
+    $team = Team::factory()->create();
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->team()->associate($team)->save();
 
-  actingAs($user);
+    actingAs($user);
 
-  $teamTasks = Task::factory()
-    ->hasAttached($team, [], 'confidentialAccessTeams')
-    ->count(10)
-    ->concerningStudent(Student::factory()->create())
-    ->create(['is_confidential' => true]);
-  
-  $otherTeamTasks = Task::factory()
-    ->hasAttached(Team::factory()->create(), [], 'confidentialAccessTeams')
-    ->count(10)
-    ->concerningStudent(Student::factory()->create())
-    ->create(['is_confidential' => true]);
+    $teamTasks = Task::factory()
+        ->hasAttached($team, [], 'confidentialAccessTeams')
+        ->count(10)
+        ->concerningStudent(Student::factory()->create())
+        ->create(['is_confidential' => true]);
 
-  $tasks = Task::query()->get();
-  expect($tasks)->toHaveCount(10);
+    $otherTeamTasks = Task::factory()
+        ->hasAttached(Team::factory()->create(), [], 'confidentialAccessTeams')
+        ->count(10)
+        ->concerningStudent(Student::factory()->create())
+        ->create(['is_confidential' => true]);
 
-  expect($tasks->pluck('id'))
-    ->toContain(...$teamTasks->pluck('id'));
-  
-  expect($tasks->pluck('id'))
-    ->not->toContain(...$otherTeamTasks->pluck('id'));
+    $tasks = Task::query()->get();
+    expect($tasks)->toHaveCount(10);
+
+    expect($tasks->pluck('id'))
+        ->toContain(...$teamTasks->pluck('id'));
+
+    expect($tasks->pluck('id'))
+        ->not->toContain(...$otherTeamTasks->pluck('id'));
 });

--- a/app-modules/task/tests/Tenant/Models/Scopes/ConfidentialTaskScopeTest.php
+++ b/app-modules/task/tests/Tenant/Models/Scopes/ConfidentialTaskScopeTest.php
@@ -110,7 +110,7 @@ it('can be accessed when confidential by users on a team with access', function 
 });
 
 it('can be accessed when confidential by users who have created a project the task is associated with', function () {
-    $user = User::factory()->create();
+    $user = User::factory()->licensed(LicenseType::cases())->create();
     $project = Project::factory()->for($user, 'createdBy')->create();
 
     actingAs($user);
@@ -122,7 +122,7 @@ it('can be accessed when confidential by users who have created a project the ta
         ->create(['is_confidential' => true]);
 
     $otherProjectTasks = Task::factory()
-        ->hasAttached(Project::factory()->create(), [], 'confidentialAccessProjects')
+        ->hasAttached(Project::factory()->for(User::factory()->licensed(LicenseType::cases())->create(), 'createdBy')->create(), [], 'confidentialAccessProjects')
         ->count(10)
         ->concerningStudent(Student::factory()->create())
         ->create(['is_confidential' => true]);

--- a/app-modules/task/tests/Tenant/Models/Scopes/ConfidentialTaskScopeTest.php
+++ b/app-modules/task/tests/Tenant/Models/Scopes/ConfidentialTaskScopeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\StudentDataModel\Models\Student;
+use AdvisingApp\Task\Models\Scopes\ConfidentialTaskScope;
+use AdvisingApp\Task\Models\Task;
+use AdvisingApp\Team\Models\Team;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Tests\asSuperAdmin;
+
+it('is applied as a global scope to the task model', function () {
+    Task::bootHasGlobalScopes();
+
+    expect(Task::hasGlobalScope(ConfidentialTaskScope::class))->toBeTrue();
+});
+
+it('can be accessed by users when not confidential', function() {
+  $user = User::factory()->licensed(LicenseType::cases())->create();
+
+  actingAs($user);
+
+  $confidentialTasks = Task::factory()->count(10)->concerningStudent(Student::factory()->create())->create(['is_confidential' => true]);
+  $nonConfidentialTasks = Task::factory()->count(10)->concerningStudent(Student::factory()->create())->create(['is_confidential' => false]);
+
+  $tasks = Task::query()->get();
+  expect($tasks)->toHaveCount(10);
+
+  expect($tasks->pluck('id'))
+    ->toContain(...$nonConfidentialTasks->pluck('id'));
+  
+  expect($tasks->pluck('id'))
+    ->not->toContain(...$confidentialTasks->pluck('id'));
+});
+
+it('can be accessed when confidential by users who created it or super admins', function() {
+  $user = User::factory()->licensed(LicenseType::cases())->create();
+
+  actingAs($user);
+
+  $userTasks = Task::factory()->count(10)->concerningStudent(Student::factory()->create())->create([
+    'is_confidential' => true,
+    'created_by' => $user,
+  ]);
+
+  $tasks = Task::query()->get();
+
+  expect($tasks->pluck('id'))
+    ->toContain(...$userTasks->pluck('id'));
+
+    asSuperAdmin();
+  
+    expect($tasks->pluck('id'))
+    ->toContain(...$userTasks->pluck('id'));
+});
+
+it('can be accessed when confidential by users on a team with access', function() {
+  $team = Team::factory()->create();
+  $user = User::factory()->licensed(LicenseType::cases())->create();
+  $user->team()->associate($team)->save();
+
+  actingAs($user);
+
+  $teamTasks = Task::factory()
+    ->hasAttached($team, [], 'confidentialAccessTeams')
+    ->count(10)
+    ->concerningStudent(Student::factory()->create())
+    ->create(['is_confidential' => true]);
+  
+  $otherTeamTasks = Task::factory()
+    ->hasAttached(Team::factory()->create(), [], 'confidentialAccessTeams')
+    ->count(10)
+    ->concerningStudent(Student::factory()->create())
+    ->create(['is_confidential' => true]);
+
+  $tasks = Task::query()->get();
+  expect($tasks)->toHaveCount(10);
+
+  expect($tasks->pluck('id'))
+    ->toContain(...$teamTasks->pluck('id'));
+  
+  expect($tasks->pluck('id'))
+    ->not->toContain(...$otherTeamTasks->pluck('id'));
+});

--- a/app-modules/task/tests/Tenant/Models/Scopes/ConfidentialTaskScopeTest.php
+++ b/app-modules/task/tests/Tenant/Models/Scopes/ConfidentialTaskScopeTest.php
@@ -120,7 +120,7 @@ it('can be accessed when confidential by users who have created a project the ta
         ->count(10)
         ->concerningStudent(Student::factory()->create())
         ->create(['is_confidential' => true]);
-    
+
     $otherProjectTasks = Task::factory()
         ->hasAttached(Project::factory()->create(), [], 'confidentialAccessProjects')
         ->count(10)

--- a/app-modules/task/tests/Tenant/Models/Scopes/ConfidentialTaskScopeTest.php
+++ b/app-modules/task/tests/Tenant/Models/Scopes/ConfidentialTaskScopeTest.php
@@ -129,7 +129,7 @@ it('can be accessed when confidential by super admins', function () {
     $confidentialTasks = Task::factory()->count(10)->concerningStudent(Student::factory()->create())->create(['is_confidential' => true]);
 
     asSuperAdmin();
-    
+
     $tasks = Task::query()->get();
 
     expect($tasks->pluck('id'))->toContain(...$confidentialTasks->pluck('id'));

--- a/app-modules/task/tests/Tenant/TaskAssignmentTest.php
+++ b/app-modules/task/tests/Tenant/TaskAssignmentTest.php
@@ -44,7 +44,7 @@ beforeEach(function () {
 });
 
 it('sends the proper notification to the assigned User', function () {
-    $task = Task::factory()->assigned()->create();
+    $task = Task::factory()->assigned()->create(['is_confidential' => false]);
 
     Notification::assertSentTo($task->assignedTo, TaskAssignedToUserNotification::class);
 
@@ -66,7 +66,7 @@ it('it properly subscriptions the creator and assigned Users to the Subscribable
         ->recycle(User::factory()->create())
         ->assigned()
         ->concerningStudent()
-        ->create();
+        ->create(['is_confidential' => false]);
 
     expect($task->createdBy->id)->toBe($task->assignedTo->id);
 
@@ -78,7 +78,7 @@ it('it properly subscriptions the creator and assigned Users to the Subscribable
     $task = Task::factory()
         ->assigned()
         ->concerningProspect()
-        ->create();
+        ->create(['is_confidential' => false]);
 
     expect($task->createdBy->id)->not->toBe($task->assignedTo->id);
 

--- a/app/Features/ConfidentialTaskFeature.php
+++ b/app/Features/ConfidentialTaskFeature.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/app/Features/ConfidentialTaskFeature.php
+++ b/app/Features/ConfidentialTaskFeature.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class ConfidentialTaskFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -292,7 +292,7 @@ it('checks the API returns Tasks', function () {
 
     Task::factory()->count($randomRecords)->create(['is_confidential' => false]);
 
-    $softDeleteTask = Task::factory()->create();
+    $softDeleteTask = Task::factory()->create(['is_confidential' => false]);
     $softDeleteTask->delete();
 
     $response = get(route('utilization-metrics'));

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -290,7 +290,7 @@ it('checks the API returns Journey Steps Executed', function () {
 it('checks the API returns Tasks', function () {
     $randomRecords = random_int(1, 10);
 
-    Task::factory()->count($randomRecords)->create();
+    Task::factory()->count($randomRecords)->create(['is_confidential' => false]);
 
     $softDeleteTask = Task::factory()->create();
     $softDeleteTask->delete();


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1754

### Technical Description

Add ability to create confidential tasks, and limit confidential tasks to only people granted access to them, on teams granted access, associated with projects granted access, super admins, and the task's creator.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

ConfidentialTasksFeature feature flag

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
