### PR TITLE
[ADVAPP-1856]: Some users have reported that the student Program modal contains a labeling error where “Graduation Date” is incorrectly displayed as “Graduration Date"

### DIFF
--- a/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/ProgramsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentResource/RelationManagers/ProgramsRelationManager.php
@@ -289,7 +289,7 @@ class ProgramsRelationManager extends RelationManager
                     ->format('Y-m-d H:i:s')
                     ->displayFormat('Y-m-d H:i:s'),
                 DateTimePicker::make('graduation_dt')
-                    ->label('Graduration Date')
+                    ->label('Graduation Date')
                     ->closeOnDateSelection(),
                 TextInput::make('catalog_year')
                     ->label('Catalog Year'),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue
- https://canyongbs.atlassian.net/browse/ADVAPP-1856

### Technical Description
- Fix misspelling of Graduation Date

### Any deployment steps required?
- No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?
- No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
