### PR TITLE
[ADVAPP-1830]: Introduce the ability to generate an image inline in the institutional advisor and custom advisors by selecting an image button that can turned on or off

### DIFF
--- a/app-modules/ai/database/migrations/2025_09_02_122649_add_ai_integration_image_generation_settings.php
+++ b/app-modules/ai/database/migrations/2025_09_02_122649_add_ai_integration_image_generation_settings.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 

--- a/app-modules/ai/database/migrations/2025_09_02_122649_add_ai_integration_image_generation_settings.php
+++ b/app-modules/ai/database/migrations/2025_09_02_122649_add_ai_integration_image_generation_settings.php
@@ -1,0 +1,39 @@
+<?php
+
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    /**
+     * @var array<string>
+     * */
+    private array $properties = [
+        'ai.open_ai_gpt_4o_image_generation_deployment',
+        'ai.open_ai_gpt_4o_image_generation_deployment',
+        'ai.open_ai_gpt_o3_image_generation_deployment',
+        'ai.open_ai_gpt_41_mini_image_generation_deployment',
+        'ai.open_ai_gpt_41_nano_image_generation_deployment',
+        'ai.open_ai_gpt_o4_mini_image_generation_deployment',
+        'ai.open_ai_gpt_5_image_generation_deployment',
+        'ai.open_ai_gpt_5_mini_image_generation_deployment',
+        'ai.open_ai_gpt_5_nano_image_generation_deployment',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->properties as $property) {
+            try {
+                $this->migrator->add($property, encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // Do nothing
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->properties as $property) {
+            $this->migrator->deleteIfExists($property);
+        }
+    }
+};

--- a/app-modules/ai/resources/js/chat.js
+++ b/app-modules/ai/resources/js/chat.js
@@ -44,6 +44,7 @@ document.addEventListener('alpine:init', () => {
             isSendingMessage: false,
             isRateLimited: false,
             isRetryable: true,
+            hasImageGeneration: false,
             latestMessage: '',
             message: '',
             rawIncomingResponse: '',
@@ -181,6 +182,7 @@ document.addEventListener('alpine:init', () => {
                                                     ? {
                                                           content: this.latestMessage,
                                                           files: this.$wire.files,
+                                                          has_image_generation: this.hasImageGeneration,
                                                       }
                                                     : {},
                                             ),
@@ -273,6 +275,7 @@ document.addEventListener('alpine:init', () => {
                             body: JSON.stringify({
                                 ...(prompt ? { prompt_id: prompt.id } : { content: message }),
                                 files: this.$wire.files,
+                                has_image_generation: this.hasImageGeneration,
                             }),
                         }),
                     });
@@ -310,6 +313,7 @@ document.addEventListener('alpine:init', () => {
                             body: JSON.stringify({
                                 content: this.latestMessage,
                                 files: this.$wire.files,
+                                has_image_generation: this.hasImageGeneration,
                             }),
                         }),
                     });

--- a/app-modules/ai/resources/views/components/assistant.blade.php
+++ b/app-modules/ai/resources/views/components/assistant.blade.php
@@ -667,34 +667,65 @@
                     <form x-on:submit.prevent="sendMessage()">
                         <div
                             class="w-full overflow-hidden rounded-xl border border-gray-950/5 bg-gray-50 shadow-sm dark:border-white/10 dark:bg-gray-700">
-                            <div class="flex items-center justify-start gap-x-4 gap-y-3 p-4">
-                                {{ $this->uploadFilesAction }}
+                            <div class="flex items-start justify-between gap-x-4 p-4">
+                                <div class="flex items-center justify-start gap-x-4 gap-y-3">
+                                    {{ $this->uploadFilesAction }}
 
-                                @foreach ($this->getFiles() as $file)
-                                    <x-filament::badge
-                                        :tooltip="$this->isProcessingFiles
-                                            ? 'This file is currently being parsed'
-                                            : null"
-                                        wire:target="removeUploadedFile('{{ $file->getKey() }}')"
+                                    @foreach ($this->getFiles() as $file)
+                                        <x-filament::badge
+                                            :tooltip="$this->isProcessingFiles
+                                                ? 'This file is currently being parsed'
+                                                : null"
+                                            wire:target="removeUploadedFile('{{ $file->getKey() }}')"
+                                        >
+                                            <span class="flex items-center gap-1">
+                                                @if ($this->isProcessingFiles)
+                                                    <x-filament::loading-indicator
+                                                        class="h-4 w-4 shrink-0"
+                                                        wire:loading.remove
+                                                        wire:target="removeUploadedFile('{{ $file->getKey() }}')"
+                                                    />
+                                                @endif
+                                                {{ $file->name }}
+                                            </span>
+
+                                            <x-slot
+                                                name="deleteButton"
+                                                label="Remove uploaded file {{ $file->name }}"
+                                                wire:click="removeUploadedFile('{{ $file->getKey() }}')"
+                                            ></x-slot>
+                                        </x-filament::badge>
+                                    @endforeach
+                                </div>
+
+                                @if ($this->thread->assistant->model->getService()->hasImageGeneration())
+                                    <button
+                                        class="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-semibold text-gray-800 shadow-sm ring-1 ring-gray-950/5 dark:text-gray-100 dark:ring-white/10"
+                                        type="button"
+                                        x-on:click="hasImageGeneration = ! hasImageGeneration"
+                                        x-bind:class="{
+                                            'bg-primary-500 text-white dark:bg-primary-700 dark:text-white': hasImageGeneration,
+                                        }"
                                     >
-                                        <span class="flex items-center gap-1">
-                                            @if ($this->isProcessingFiles)
-                                                <x-filament::loading-indicator
-                                                    class="h-4 w-4 shrink-0"
-                                                    wire:loading.remove
-                                                    wire:target="removeUploadedFile('{{ $file->getKey() }}')"
-                                                />
-                                            @endif
-                                            {{ $file->name }}
+                                        <span
+                                            class="shrink-0"
+                                            x-show="hasImageGeneration"
+                                        >
+                                            @svg('heroicon-c-photo', 'size-4')
                                         </span>
 
-                                        <x-slot
-                                            name="deleteButton"
-                                            label="Remove uploaded file {{ $file->name }}"
-                                            wire:click="removeUploadedFile('{{ $file->getKey() }}')"
-                                        ></x-slot>
-                                    </x-filament::badge>
-                                @endforeach
+                                        <span
+                                            class="shrink-0"
+                                            x-show="! hasImageGeneration"
+                                        >
+                                            @svg('heroicon-c-x-mark', 'size-4')
+                                        </span>
+
+                                        Image generation:
+
+                                        <span x-text="hasImageGeneration ? 'on' : 'off'"></span>
+                                    </button>
+                                @endif
                             </div>
                             <div class="bg-white dark:bg-gray-800">
                                 <label

--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
@@ -95,6 +95,8 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->autocomplete(false),
                                 TextInput::make('open_ai_gpt_4o_model')
                                     ->label('Model'),
+                                TextInput::make('open_ai_gpt_4o_image_generation_deployment')
+                                    ->label('Image generation deployment'),
                                 Select::make('open_ai_gpt_4o_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -120,6 +122,8 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->autocomplete(false),
                                 TextInput::make('open_ai_gpt_4o_mini_model')
                                     ->label('Model'),
+                                TextInput::make('open_ai_gpt_4o_mini_image_generation_deployment')
+                                    ->label('Image generation deployment'),
                                 Select::make('open_ai_gpt_4o_mini_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -145,6 +149,8 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->autocomplete(false),
                                 TextInput::make('open_ai_gpt_o3_model')
                                     ->label('Model'),
+                                TextInput::make('open_ai_gpt_o3_image_generation_deployment')
+                                    ->label('Image generation deployment'),
                                 Select::make('open_ai_gpt_o3_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -170,6 +176,8 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->autocomplete(false),
                                 TextInput::make('open_ai_gpt_41_mini_model')
                                     ->label('Model'),
+                                TextInput::make('open_ai_gpt_41_mini_image_generation_deployment')
+                                    ->label('Image generation deployment'),
                                 Select::make('open_ai_gpt_41_mini_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -195,6 +203,8 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->autocomplete(false),
                                 TextInput::make('open_ai_gpt_41_nano_model')
                                     ->label('Model'),
+                                TextInput::make('open_ai_gpt_41_nano_image_generation_deployment')
+                                    ->label('Image generation deployment'),
                                 Select::make('open_ai_gpt_41_nano_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -220,6 +230,8 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->autocomplete(false),
                                 TextInput::make('open_ai_gpt_o4_mini_model')
                                     ->label('Model'),
+                                TextInput::make('open_ai_gpt_o4_mini_image_generation_deployment')
+                                    ->label('Image generation deployment'),
                                 Select::make('open_ai_gpt_o4_mini_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -246,6 +258,8 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->autocomplete(false),
                                 TextInput::make('open_ai_gpt_5_model')
                                     ->label('Model'),
+                                TextInput::make('open_ai_gpt_5_image_generation_deployment')
+                                    ->label('Image generation deployment'),
                                 Select::make('open_ai_gpt_5_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -272,6 +286,8 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->autocomplete(false),
                                 TextInput::make('open_ai_gpt_5_mini_model')
                                     ->label('Model'),
+                                TextInput::make('open_ai_gpt_5_mini_image_generation_deployment')
+                                    ->label('Image generation deployment'),
                                 Select::make('open_ai_gpt_5_mini_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -298,6 +314,8 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->autocomplete(false),
                                 TextInput::make('open_ai_gpt_5_nano_model')
                                     ->label('Model'),
+                                TextInput::make('open_ai_gpt_5_nano_image_generation_deployment')
+                                    ->label('Image generation deployment'),
                                 Select::make('open_ai_gpt_5_nano_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)

--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
@@ -96,7 +96,7 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_4o_model')
                                     ->label('Model'),
                                 TextInput::make('open_ai_gpt_4o_image_generation_deployment')
-                                    ->label('Image generation deployment'),
+                                    ->label('Image generation model'),
                                 Select::make('open_ai_gpt_4o_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -123,7 +123,7 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_4o_mini_model')
                                     ->label('Model'),
                                 TextInput::make('open_ai_gpt_4o_mini_image_generation_deployment')
-                                    ->label('Image generation deployment'),
+                                    ->label('Image generation model'),
                                 Select::make('open_ai_gpt_4o_mini_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -150,7 +150,7 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_o3_model')
                                     ->label('Model'),
                                 TextInput::make('open_ai_gpt_o3_image_generation_deployment')
-                                    ->label('Image generation deployment'),
+                                    ->label('Image generation model'),
                                 Select::make('open_ai_gpt_o3_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -177,7 +177,7 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_41_mini_model')
                                     ->label('Model'),
                                 TextInput::make('open_ai_gpt_41_mini_image_generation_deployment')
-                                    ->label('Image generation deployment'),
+                                    ->label('Image generation model'),
                                 Select::make('open_ai_gpt_41_mini_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -204,7 +204,7 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_41_nano_model')
                                     ->label('Model'),
                                 TextInput::make('open_ai_gpt_41_nano_image_generation_deployment')
-                                    ->label('Image generation deployment'),
+                                    ->label('Image generation model'),
                                 Select::make('open_ai_gpt_41_nano_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -231,7 +231,7 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_o4_mini_model')
                                     ->label('Model'),
                                 TextInput::make('open_ai_gpt_o4_mini_image_generation_deployment')
-                                    ->label('Image generation deployment'),
+                                    ->label('Image generation model'),
                                 Select::make('open_ai_gpt_o4_mini_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -259,7 +259,7 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_5_model')
                                     ->label('Model'),
                                 TextInput::make('open_ai_gpt_5_image_generation_deployment')
-                                    ->label('Image generation deployment'),
+                                    ->label('Image generation model'),
                                 Select::make('open_ai_gpt_5_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -287,7 +287,7 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_5_mini_model')
                                     ->label('Model'),
                                 TextInput::make('open_ai_gpt_5_mini_image_generation_deployment')
-                                    ->label('Image generation deployment'),
+                                    ->label('Image generation model'),
                                 Select::make('open_ai_gpt_5_mini_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
@@ -315,7 +315,7 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_5_nano_model')
                                     ->label('Model'),
                                 TextInput::make('open_ai_gpt_5_nano_image_generation_deployment')
-                                    ->label('Image generation deployment'),
+                                    ->label('Image generation model'),
                                 Select::make('open_ai_gpt_5_nano_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)

--- a/app-modules/ai/src/Http/Controllers/Advisors/RetryMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/Advisors/RetryMessageController.php
@@ -65,6 +65,7 @@ class RetryMessageController
                 $thread,
                 $request->validated('content'),
                 AiMessageFile::query()->whereKey($request->validated('files'))->get()->all(),
+                $request->validated('has_image_generation') ?? false,
             ));
 
             return response()->json([]);

--- a/app-modules/ai/src/Http/Controllers/Advisors/SendMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/Advisors/SendMessageController.php
@@ -66,6 +66,7 @@ class SendMessageController
                 $thread,
                 $request->validated('prompt_id') ? Prompt::find($request->validated('prompt_id')) : $request->validated('content'),
                 AiMessageFile::query()->whereKey($request->validated('files'))->get()->all(),
+                $request->validated('has_image_generation') ?? false,
             ));
 
             return response()->json([]);

--- a/app-modules/ai/src/Http/Requests/Advisors/RetryMessageRequest.php
+++ b/app-modules/ai/src/Http/Requests/Advisors/RetryMessageRequest.php
@@ -62,6 +62,7 @@ class RetryMessageRequest extends FormRequest
             'content' => ['required', 'string', 'max:1000'],
             'files' => ['array', 'max:1'],
             'files.*' => [Rule::exists(AiMessageFile::class, 'id')],
+            'has_image_generation' => ['nullable', 'boolean'],
         ];
     }
 }

--- a/app-modules/ai/src/Http/Requests/Advisors/SendMessageRequest.php
+++ b/app-modules/ai/src/Http/Requests/Advisors/SendMessageRequest.php
@@ -64,6 +64,7 @@ class SendMessageRequest extends FormRequest
             'files' => ['array', 'max:1'],
             'files.*' => [Rule::exists(AiMessageFile::class, 'id')],
             'prompt_id' => ['nullable', 'uuid', Rule::exists(Prompt::class, 'id')],
+            'has_image_generation' => ['nullable', 'boolean'],
         ];
     }
 }

--- a/app-modules/ai/src/Jobs/Advisors/RetryAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/RetryAdvisorMessage.php
@@ -68,6 +68,7 @@ class RetryAdvisorMessage implements ShouldQueue
         protected AiThread $thread,
         protected string $content,
         protected array $files = [],
+        protected bool $hasImageGeneration = false,
     ) {}
 
     public function handle(): void
@@ -101,7 +102,8 @@ class RetryAdvisorMessage implements ShouldQueue
         try {
             $stream = $aiService->retryMessage(
                 message: $message,
-                files: $this->files
+                files: $this->files,
+                hasImageGeneration: $this->hasImageGeneration,
             );
         } catch (Throwable $exception) {
             report($exception);

--- a/app-modules/ai/src/Jobs/Advisors/RetryAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/RetryAdvisorMessage.php
@@ -42,6 +42,7 @@ use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiMessageFile;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Support\StreamingChunks\Finish;
+use AdvisingApp\Ai\Support\StreamingChunks\Image;
 use AdvisingApp\Ai\Support\StreamingChunks\Meta;
 use AdvisingApp\Ai\Support\StreamingChunks\Text;
 use Illuminate\Bus\Queueable;
@@ -50,6 +51,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Throwable;
 
 class RetryAdvisorMessage implements ShouldQueue
@@ -98,6 +100,7 @@ class RetryAdvisorMessage implements ShouldQueue
 
         $response = new AiMessage();
         $response->thread()->associate($this->thread);
+        $response->content = '';
 
         try {
             $stream = $aiService->retryMessage(
@@ -132,6 +135,14 @@ class RetryAdvisorMessage implements ShouldQueue
                 $finishChunk = $chunk;
 
                 continue;
+            }
+
+            if ($chunk instanceof Image) {
+                $media = $this->thread->addMediaFromBase64($chunk->content)
+                    ->usingFileName(Str::random() . '.' . $chunk->format)
+                    ->toMediaCollection('generated_images', diskName: 's3-public');
+
+                $chunk = new Text("![Generated image]({$media->getUrl()})");
             }
 
             if ($chunk instanceof Text) {

--- a/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
@@ -69,6 +69,7 @@ class SendAdvisorMessage implements ShouldQueue
         protected AiThread $thread,
         protected string | Prompt $content,
         protected array $files = [],
+        protected bool $hasImageGeneration = false,
     ) {}
 
     public function handle(): void
@@ -122,7 +123,8 @@ class SendAdvisorMessage implements ShouldQueue
         try {
             $stream = $aiService->sendMessage(
                 message: $message,
-                files: $this->files
+                files: $this->files,
+                hasImageGeneration: $this->hasImageGeneration,
             );
         } catch (Throwable $exception) {
             report($exception);

--- a/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
@@ -43,6 +43,7 @@ use AdvisingApp\Ai\Models\AiMessageFile;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Models\Prompt;
 use AdvisingApp\Ai\Support\StreamingChunks\Finish;
+use AdvisingApp\Ai\Support\StreamingChunks\Image;
 use AdvisingApp\Ai\Support\StreamingChunks\Meta;
 use AdvisingApp\Ai\Support\StreamingChunks\Text;
 use Illuminate\Bus\Queueable;
@@ -51,6 +52,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Throwable;
 
 class SendAdvisorMessage implements ShouldQueue
@@ -119,6 +121,7 @@ class SendAdvisorMessage implements ShouldQueue
 
         $response = new AiMessage();
         $response->thread()->associate($this->thread);
+        $response->content = '';
 
         try {
             $stream = $aiService->sendMessage(
@@ -153,6 +156,14 @@ class SendAdvisorMessage implements ShouldQueue
                 $finishChunk = $chunk;
 
                 continue;
+            }
+
+            if ($chunk instanceof Image) {
+                $media = $this->thread->addMediaFromBase64($chunk->content)
+                    ->usingFileName(Str::random() . '.' . $chunk->format)
+                    ->toMediaCollection('generated_images', diskName: 's3-public');
+
+                $chunk = new Text("![Generated image]({$media->getUrl()})");
             }
 
             if ($chunk instanceof Text) {

--- a/app-modules/ai/src/Models/AiThread.php
+++ b/app-modules/ai/src/Models/AiThread.php
@@ -51,15 +51,18 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Livewire\Wireable;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
 
 /**
  * @mixin IdeHelperAiThread
  */
-class AiThread extends BaseModel implements Wireable
+class AiThread extends BaseModel implements HasMedia, Wireable
 {
     use CanAddAssistantLicenseGlobalScope;
     use SoftDeletes;
     use Prunable;
+    use InteractsWithMedia;
 
     protected $fillable = [
         'thread_id',
@@ -143,6 +146,11 @@ class AiThread extends BaseModel implements Wireable
     public static function fromLivewire($value)
     {
         return AiThread::query()->find($value['id']);
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('generated_images');
     }
 
     protected function lastEngagedAt(): Attribute

--- a/app-modules/ai/src/Services/Contracts/AiService.php
+++ b/app-modules/ai/src/Services/Contracts/AiService.php
@@ -74,7 +74,7 @@ interface AiService
      * The method should return a new unsaved `AiMessage` model with the content
      * from the AI service set only, the other attributes will be set later.
      */
-    public function sendMessage(AiMessage $message, array $files): Closure;
+    public function sendMessage(AiMessage $message, array $files, bool $hasImageGeneration = false): Closure;
 
     /**
      * This method is passed an `AiMessage` model and should recover the
@@ -85,7 +85,7 @@ interface AiService
      * The method should return a new unsaved `AiMessage` model with the content
      * from the AI service set only, the other attributes will be set later.
      */
-    public function retryMessage(AiMessage $message, array $files): Closure;
+    public function retryMessage(AiMessage $message, array $files, bool $hasImageGeneration = false): Closure;
 
     public function completeResponse(AiMessage $response): Closure;
 
@@ -114,4 +114,6 @@ interface AiService
      * @param array<string, mixed> $options
      */
     public function getResearchRequestRequestSection(ResearchRequest $researchRequest, string $prompt, string $content, array $options, Closure $nextRequestOptions): Generator;
+
+    public function hasImageGeneration(): bool;
 }

--- a/app-modules/ai/src/Services/TestAiService.php
+++ b/app-modules/ai/src/Services/TestAiService.php
@@ -80,7 +80,7 @@ class TestAiService implements AiService
         throw new Exception('Plain text streaming is not supported by this service.');
     }
 
-    public function sendMessage(AiMessage $message, array $files): Closure
+    public function sendMessage(AiMessage $message, array $files, bool $hasImageGeneration = false): Closure
     {
         $message->context = fake()->paragraph();
         $message->save();
@@ -106,7 +106,7 @@ class TestAiService implements AiService
         };
     }
 
-    public function retryMessage(AiMessage $message, array $files): Closure
+    public function retryMessage(AiMessage $message, array $files, bool $hasImageGeneration = false): Closure
     {
         return $this->sendMessage($message, $files);
     }
@@ -159,4 +159,9 @@ class TestAiService implements AiService
     }
 
     public function afterResearchRequestSearchQueriesParsed(ResearchRequest $researchRequest): void {}
+
+    public function hasImageGeneration(): bool
+    {
+        return false;
+    }
 }

--- a/app-modules/ai/src/Settings/AiIntegrationsSettings.php
+++ b/app-modules/ai/src/Settings/AiIntegrationsSettings.php
@@ -48,6 +48,8 @@ class AiIntegrationsSettings extends Settings
 
     public ?string $open_ai_gpt_4o_model = null;
 
+    public ?string $open_ai_gpt_4o_image_generation_deployment = null;
+
     /**
      * @var array<string>
      */
@@ -60,6 +62,8 @@ class AiIntegrationsSettings extends Settings
     public ?string $open_ai_gpt_4o_mini_api_key = null;
 
     public ?string $open_ai_gpt_4o_mini_model = null;
+
+    public ?string $open_ai_gpt_4o_mini_image_generation_deployment = null;
 
     /**
      * @var array<string>
@@ -74,6 +78,8 @@ class AiIntegrationsSettings extends Settings
 
     public ?string $open_ai_gpt_o3_model = null;
 
+    public ?string $open_ai_gpt_o3_image_generation_deployment = null;
+
     /**
      * @var array<string>
      */
@@ -86,6 +92,8 @@ class AiIntegrationsSettings extends Settings
     public ?string $open_ai_gpt_41_mini_api_key = null;
 
     public ?string $open_ai_gpt_41_mini_model = null;
+
+    public ?string $open_ai_gpt_41_mini_image_generation_deployment = null;
 
     /**
      * @var array<string>
@@ -100,6 +108,8 @@ class AiIntegrationsSettings extends Settings
 
     public ?string $open_ai_gpt_41_nano_model = null;
 
+    public ?string $open_ai_gpt_41_nano_image_generation_deployment = null;
+
     /**
      * @var array<string>
      */
@@ -112,6 +122,8 @@ class AiIntegrationsSettings extends Settings
     public ?string $open_ai_gpt_o4_mini_api_key = null;
 
     public ?string $open_ai_gpt_o4_mini_model = null;
+
+    public ?string $open_ai_gpt_o4_mini_image_generation_deployment = null;
 
     /**
      * @var array<string>
@@ -126,6 +138,8 @@ class AiIntegrationsSettings extends Settings
 
     public ?string $open_ai_gpt_5_model = null;
 
+    public ?string $open_ai_gpt_5_image_generation_deployment = null;
+
     /**
      * @var array<string>
      */
@@ -139,6 +153,8 @@ class AiIntegrationsSettings extends Settings
 
     public ?string $open_ai_gpt_5_mini_model = null;
 
+    public ?string $open_ai_gpt_5_mini_image_generation_deployment = null;
+
     /**
      * @var array<string>
      */
@@ -151,6 +167,8 @@ class AiIntegrationsSettings extends Settings
     public ?string $open_ai_gpt_5_nano_api_key = null;
 
     public ?string $open_ai_gpt_5_nano_model = null;
+
+    public ?string $open_ai_gpt_5_nano_image_generation_deployment = null;
 
     /**
      * @var array<string>
@@ -181,30 +199,39 @@ class AiIntegrationsSettings extends Settings
             'open_ai_gpt_4o_base_uri',
             'open_ai_gpt_4o_api_key',
             'open_ai_gpt_4o_model',
+            'open_ai_gpt_4o_image_generation_deployment',
             'open_ai_gpt_4o_mini_base_uri',
             'open_ai_gpt_4o_mini_api_key',
             'open_ai_gpt_4o_mini_model',
+            'open_ai_gpt_4o_image_generation_deployment',
             'open_ai_gpt_o3_base_uri',
             'open_ai_gpt_o3_api_key',
             'open_ai_gpt_o3_model',
+            'open_ai_gpt_o3_image_generation_deployment',
             'open_ai_gpt_41_mini_base_uri',
             'open_ai_gpt_41_mini_api_key',
             'open_ai_gpt_41_mini_model',
+            'open_ai_gpt_41_mini_image_generation_deployment',
             'open_ai_gpt_41_nano_base_uri',
             'open_ai_gpt_41_nano_api_key',
             'open_ai_gpt_41_nano_model',
+            'open_ai_gpt_41_nano_image_generation_deployment',
             'open_ai_gpt_o4_mini_base_uri',
             'open_ai_gpt_o4_mini_api_key',
             'open_ai_gpt_o4_mini_model',
+            'open_ai_gpt_o4_mini_image_generation_deployment',
             'open_ai_gpt_5_base_uri',
             'open_ai_gpt_5_api_key',
             'open_ai_gpt_5_model',
+            'open_ai_gpt_5_image_generation_deployment',
             'open_ai_gpt_5_mini_base_uri',
             'open_ai_gpt_5_mini_api_key',
             'open_ai_gpt_5_mini_model',
+            'open_ai_gpt_5_mini_image_generation_deployment',
             'open_ai_gpt_5_nano_base_uri',
             'open_ai_gpt_5_nano_api_key',
             'open_ai_gpt_5_nano_model',
+            'open_ai_gpt_5_nano_image_generation_deployment',
             'jina_deepsearch_v1_api_key',
             'llamaparse_api_key',
         ];

--- a/app-modules/ai/src/Support/StreamingChunks/Image.php
+++ b/app-modules/ai/src/Support/StreamingChunks/Image.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Ai\Support\StreamingChunks;
+
+readonly class Image
+{
+    public function __construct(
+        public string $content,
+        public string $format,
+    ) {}
+}

--- a/app-modules/integration-open-ai/src/Prism/AzureOpenAi.php
+++ b/app-modules/integration-open-ai/src/Prism/AzureOpenAi.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\IntegrationOpenAi\Prism;
 
 use AdvisingApp\IntegrationOpenAi\Prism\AzureOpenAi\Handlers\Stream;
 use AdvisingApp\IntegrationOpenAi\Prism\AzureOpenAi\Handlers\Structured;
+use AdvisingApp\IntegrationOpenAi\Prism\AzureOpenAi\Handlers\Text;
 use App\Features\OpenAiResponsesApiSettingsFeature;
 use Generator;
 use Illuminate\Http\Client\PendingRequest;
@@ -47,6 +48,7 @@ use Prism\Prism\Providers\OpenAI\OpenAI;
 use Prism\Prism\Structured\Request as StructuredRequest;
 use Prism\Prism\Structured\Response as StructuredResponse;
 use Prism\Prism\Text\Request as TextRequest;
+use Prism\Prism\Text\Response as TextResponse;
 
 class AzureOpenAi extends OpenAI
 {
@@ -74,6 +76,17 @@ class AzureOpenAi extends OpenAI
         return $handler->handle($request);
     }
 
+    #[Override]
+    public function text(TextRequest $request): TextResponse
+    {
+        $handler = new Text($this->client(
+            $request->clientOptions(),
+            $request->clientRetry()
+        ));
+
+        return $handler->handle($request);
+    }
+
     /**
      * @param  array<string, mixed>  $options
      * @param  array<mixed>  $retry
@@ -88,6 +101,7 @@ class AzureOpenAi extends OpenAI
             ->withQueryParameters(['api-version' => $options['apiVersion']])
             ->withOptions(Arr::except($options, ['apiKey', 'apiVersion', 'deployment', 'headers']))
             ->when($retry !== [], fn ($client) => $client->retry(...$retry))
-            ->baseUrl(OpenAiResponsesApiSettingsFeature::active() ? "{$options['deployment']}/v1" : $options['deployment']);
+            ->baseUrl(OpenAiResponsesApiSettingsFeature::active() ? "{$options['deployment']}/v1" : $options['deployment'])
+            ->timeout(500);
     }
 }

--- a/app-modules/integration-open-ai/src/Prism/AzureOpenAi.php
+++ b/app-modules/integration-open-ai/src/Prism/AzureOpenAi.php
@@ -83,9 +83,10 @@ class AzureOpenAi extends OpenAI
         return $this->baseClient()
             ->withHeaders([
                 'api-key' => $options['apiKey'],
+                ...$options['headers'] ?? [],
             ])
             ->withQueryParameters(['api-version' => $options['apiVersion']])
-            ->withOptions(Arr::except($options, ['apiKey', 'apiVersion', 'deployment']))
+            ->withOptions(Arr::except($options, ['apiKey', 'apiVersion', 'deployment', 'headers']))
             ->when($retry !== [], fn ($client) => $client->retry(...$retry))
             ->baseUrl(OpenAiResponsesApiSettingsFeature::active() ? "{$options['deployment']}/v1" : $options['deployment']);
     }

--- a/app-modules/integration-open-ai/src/Prism/AzureOpenAi/Handlers/Text.php
+++ b/app-modules/integration-open-ai/src/Prism/AzureOpenAi/Handlers/Text.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\IntegrationOpenAi\Prism\AzureOpenAi\Handlers;
+
+use Illuminate\Http\Client\Response as ClientResponse;
+use Illuminate\Support\Arr;
+use Prism\Prism\Providers\OpenAI\Handlers\Text as BaseText;
+use Prism\Prism\Providers\OpenAI\Maps\MessageMap;
+use Prism\Prism\Providers\OpenAI\Maps\ToolCallMap;
+use Prism\Prism\Providers\OpenAI\Maps\ToolChoiceMap;
+use Prism\Prism\Text\Request;
+use Prism\Prism\Text\Step;
+use Prism\Prism\ValueObjects\Meta;
+use Prism\Prism\ValueObjects\ToolResult;
+use Prism\Prism\ValueObjects\Usage;
+
+class Text extends BaseText
+{
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  ToolResult[]  $toolResults
+     */
+    protected function addStep(array $data, Request $request, ClientResponse $clientResponse, array $toolResults = []): void
+    {
+        $this->responseBuilder->addStep(new Step(
+            text: data_get($data, 'output.{last}.content.0.text') ?? '',
+            finishReason: $this->mapFinishReason($data),
+            toolCalls: ToolCallMap::map(array_filter(data_get($data, 'output', []), fn (array $output): bool => $output['type'] === 'function_call')),
+            toolResults: $toolResults,
+            usage: new Usage(
+                promptTokens: data_get($data, 'usage.input_tokens', 0) - data_get($data, 'usage.input_tokens_details.cached_tokens', 0),
+                completionTokens: data_get($data, 'usage.output_tokens'),
+                cacheReadInputTokens: data_get($data, 'usage.input_tokens_details.cached_tokens'),
+                thoughtTokens: data_get($data, 'usage.output_token_details.reasoning_tokens'),
+            ),
+            meta: new Meta(
+                id: data_get($data, 'id'),
+                model: data_get($data, 'model'),
+            ),
+            messages: $request->messages(),
+            additionalContent: [
+                'generated_images' => array_filter($data['output'] ?? [], fn (array $output): bool => $output['type'] === 'image_generation_call'),
+            ],
+            systemPrompts: $request->systemPrompts(),
+        ));
+    }
+
+    protected function sendRequest(Request $request): ClientResponse
+    {
+        return $this->client->post(
+            'responses',
+            array_merge([
+                'model' => $request->model(),
+                'input' => (new MessageMap($request->messages(), $request->systemPrompts()))(),
+                'max_output_tokens' => $request->maxTokens(),
+            ], Arr::whereNotNull([
+                'temperature' => $request->temperature(),
+                'top_p' => $request->topP(),
+                'metadata' => $request->providerOptions('metadata'),
+                // 'tools' => $this->buildTools($request),
+                // 'tool_choice' => ToolChoiceMap::map($request->toolChoice()),
+                'previous_response_id' => $request->providerOptions('previous_response_id'),
+                'truncation' => $request->providerOptions('truncation'),
+                'tools' => $request->providerOptions('tools'),
+                'tool_choice' => $request->providerOptions('tool_choice'),
+            ]))
+        );
+    }
+}

--- a/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
+++ b/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
@@ -237,7 +237,7 @@ abstract class BaseOpenAiService implements AiService
      * @param array<string, mixed> $options
      * @param ?array<Message> $messages
      */
-    public function streamRaw(string $prompt, string $content, array $files = [], bool $shouldTrack = true, array $options = [], ?array $messages = null): Closure
+    public function streamRaw(string $prompt, string $content, array $files = [], bool $shouldTrack = true, array $options = [], ?array $messages = null, bool $hasImageGeneration = false): Closure
     {
         $aiSettings = app(AiSettings::class);
 
@@ -250,32 +250,86 @@ abstract class BaseOpenAiService implements AiService
                     'apiKey' => $this->getApiKey(),
                     'apiVersion' => $this->getApiVersion(),
                     'deployment' => $this->getDeployment(),
+                    ...($hasImageGeneration ? ['headers' => ['x-ms-oai-image-generation-deployment' => $this->getImageGenerationDeployment()]] : []),
                 ])
                 ->withProviderOptions([
                     'instructions' => $prompt,
                     'truncation' => 'auto',
-                    ...(filled($vectorStoreId) ? [
-                        'tools' => [[
-                            'type' => 'file_search',
-                            'vector_store_ids' => [$vectorStoreId],
-                        ]],
+                    ...((filled($vectorStoreId) || $hasImageGeneration) ? [
+                        'tools' => [
+                            ...filled($vectorStoreId) ? [[
+                                'type' => 'file_search',
+                                'vector_store_ids' => [$vectorStoreId],
+                            ]] : [],
+                            ...$hasImageGeneration ? [[
+                                'type' => 'image_generation',
+                            ]] : [],
+                        ],
                     ] : []),
                     ...$options,
                 ]);
 
             if (filled($messages)) {
-                $request = $request->withMessages($messages);
+                $request->withMessages($messages);
             } else {
-                $request = $request->withPrompt($content);
+                $request->withPrompt($content);
             }
 
-            $stream = $request
+            $request
                 ->withMaxTokens($aiSettings->max_tokens->getTokens())
-                ->usingTemperature($this->hasTemperature() ? $aiSettings->temperature : null)
-                ->asStream();
+                ->usingTemperature($this->hasTemperature() ? $aiSettings->temperature : null);
 
-            return function () use ($shouldTrack, $stream): Generator {
+            if ($hasImageGeneration) {
+                return function () use ($shouldTrack, $request): Generator {
+                    try {
+                        $response = $request->asText();
+
+                        if (filled($response->meta->id)) {
+                            yield new Meta(
+                                messageId: $response->meta->id,
+                                nextRequestOptions: ['previous_response_id' => $response->meta->id],
+                            );
+                        }
+
+                        if (filled($response->text)) {
+                            yield new Text($response->text);
+                        }
+
+                        yield new Finish(
+                            isIncomplete: $response->finishReason === FinishReason::Length,
+                            error: ($response->finishReason === FinishReason::Error) ? 'Something went wrong' : null,
+                        );
+                    } catch (PrismRateLimitedException $exception) {
+                        foreach ($exception->rateLimits as $rateLimit) {
+                            if ($rateLimit->resetsAt?->isFuture()) {
+                                yield new Finish(
+                                    rateLimitResetsAt: $rateLimit->resetsAt,
+                                );
+
+                                break;
+                            }
+                        }
+                    } catch (Throwable $exception) {
+                        report($exception);
+
+                        yield new Finish(
+                            error: 'Something went wrong',
+                        );
+                    }
+
+                    if ($shouldTrack) {
+                        dispatch(new RecordTrackedEvent(
+                            type: TrackedEventType::AiExchange,
+                            occurredAt: now(),
+                        ));
+                    }
+                };
+            }
+
+            return function () use ($shouldTrack, $request): Generator {
                 try {
+                    $stream = $request->asStream();
+
                     foreach ($stream as $chunk) {
                         if (
                             ($chunk->chunkType === ChunkType::Meta) &&
@@ -336,12 +390,17 @@ abstract class BaseOpenAiService implements AiService
         }
     }
 
+    public function hasImageGeneration(): bool
+    {
+        return filled($this->getImageGenerationDeployment());
+    }
+
     /**
      * @param array<AiMessageFile> $files
      */
-    public function sendMessage(AiMessage $message, array $files): Closure
+    public function sendMessage(AiMessage $message, array $files, bool $hasImageGeneration = false): Closure
     {
-        return $this->sendNewMessage($message, $files);
+        return $this->sendNewMessage($message, $files, $hasImageGeneration);
     }
 
     public function getMessagePreviousResponseId(AiMessage $message): ?string
@@ -379,15 +438,15 @@ abstract class BaseOpenAiService implements AiService
 
     public function completeResponse(AiMessage $response): Closure
     {
-        return $this->sendNewMessage($response, [], new UserMessage('Continue generating the response, do not mention that I told you as I will paste it directly after the last message.'));
+        return $this->sendNewMessage($response, [], userMessage: new UserMessage('Continue generating the response, do not mention that I told you as I will paste it directly after the last message.'));
     }
 
     /**
      * @param array<AiMessageFile> $files
      */
-    public function retryMessage(AiMessage $message, array $files): Closure
+    public function retryMessage(AiMessage $message, array $files, bool $hasImageGeneration = false): Closure
     {
-        return $this->sendNewMessage($message, $files);
+        return $this->sendNewMessage($message, $files, $hasImageGeneration);
     }
 
     public function getMaxAssistantInstructionsLength(): int
@@ -506,11 +565,20 @@ abstract class BaseOpenAiService implements AiService
         });
     }
 
+    public function getImageGenerationDeployment(): ?string
+    {
+        return null;
+    }
+
     /**
      * @param array<AiMessageFile> $files
      */
-    protected function sendNewMessage(AiMessage $message, array $files, ?UserMessage $userMessage = null): Closure
+    protected function sendNewMessage(AiMessage $message, array $files, bool $hasImageGeneration = false, ?UserMessage $userMessage = null): Closure
     {
+        if ($hasImageGeneration && (! $this->hasImageGeneration())) {
+            $hasImageGeneration = false;
+        }
+
         $previousMessages = [];
 
         $previousResponseId = $this->getMessagePreviousResponseId($message);
@@ -559,20 +627,23 @@ abstract class BaseOpenAiService implements AiService
                             'effort' => $aiSettings->reasoning_effort->value,
                         ],
                     ] : []),
-                    ...(filled($vectorStoreIds) ? [
-                        'tool_choice' => filled($files) ? [
-                            'type' => 'file_search',
-                        ] : 'auto',
-                        'tools' => [[
-                            'type' => 'file_search',
-                            'vector_store_ids' => $vectorStoreIds,
-                        ]],
+                    ...((filled($vectorStoreIds) || $hasImageGeneration) ? [
+                        'tools' => [
+                            ...filled($vectorStoreIds) ? [[
+                                'type' => 'file_search',
+                                'vector_store_ids' => [$vectorStoreIds],
+                            ]] : [],
+                            ...$hasImageGeneration ? [[
+                                'type' => 'image_generation',
+                            ]] : [],
+                        ],
                     ] : []),
                 ],
                 messages: [
                     ...$previousMessages,
                     $userMessage ?? new UserMessage($message->content),
                 ],
+                hasImageGeneration: $hasImageGeneration,
             );
         } catch (Throwable $exception) {
             report($exception);

--- a/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
+++ b/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
@@ -45,6 +45,7 @@ use AdvisingApp\Ai\Services\Contracts\AiService;
 use AdvisingApp\Ai\Settings\AiIntegrationsSettings;
 use AdvisingApp\Ai\Settings\AiSettings;
 use AdvisingApp\Ai\Support\StreamingChunks\Finish;
+use AdvisingApp\Ai\Support\StreamingChunks\Image;
 use AdvisingApp\Ai\Support\StreamingChunks\Meta;
 use AdvisingApp\Ai\Support\StreamingChunks\Text;
 use AdvisingApp\IntegrationOpenAi\Models\OpenAiVectorStore;
@@ -293,6 +294,15 @@ abstract class BaseOpenAiService implements AiService
 
                         if (filled($response->text)) {
                             yield new Text($response->text);
+                        }
+
+                        if (filled($response->additionalContent['generated_images'] ?? [])) {
+                            foreach ($response->additionalContent['generated_images'] as $image) {
+                                yield new Image(
+                                    content: $image['result'],
+                                    format: $image['output_format'],
+                                );
+                            }
                         }
 
                         yield new Finish(
@@ -635,6 +645,7 @@ abstract class BaseOpenAiService implements AiService
                             ]] : [],
                             ...$hasImageGeneration ? [[
                                 'type' => 'image_generation',
+                                'output_format' => 'jpeg',
                             ]] : [],
                         ],
                     ] : []),

--- a/app-modules/integration-open-ai/src/Services/BaseOpenAiService/Concerns/InteractsWithResearchRequests.php
+++ b/app-modules/integration-open-ai/src/Services/BaseOpenAiService/Concerns/InteractsWithResearchRequests.php
@@ -76,9 +76,6 @@ trait InteractsWithResearchRequests
                 ]),
             ]),
             providerOptions: [
-                'tool_choice' => [
-                    'type' => 'file_search',
-                ],
                 'tools' => [[
                     'type' => 'file_search',
                     'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
@@ -168,9 +165,6 @@ trait InteractsWithResearchRequests
                 'requiredFields' => ['abstract', 'introduction', 'sections', 'conclusion'],
             ]),
             providerOptions: [
-                'tool_choice' => [
-                    'type' => 'file_search',
-                ],
                 'tools' => [[
                     'type' => 'file_search',
                     'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
@@ -203,9 +197,6 @@ trait InteractsWithResearchRequests
                     'deployment' => $this->getDeployment(),
                 ])
                 ->withProviderOptions([
-                    'tool_choice' => [
-                        'type' => 'file_search',
-                    ],
                     'tools' => [[
                         'type' => 'file_search',
                         'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt41MiniService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt41MiniService.php
@@ -52,4 +52,9 @@ class OpenAiGpt41MiniService extends BaseOpenAiService
     {
         return $this->settings->open_ai_gpt_41_mini_base_uri ?? config('integration-open-ai.gpt_41_mini_base_uri');
     }
+
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_41_mini_image_generation_deployment;
+    }
 }

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt41NanoService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt41NanoService.php
@@ -52,4 +52,9 @@ class OpenAiGpt41NanoService extends BaseOpenAiService
     {
         return $this->settings->open_ai_gpt_41_nano_base_uri ?? config('integration-open-ai.gpt_41_nano_base_uri');
     }
+
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_41_nano_image_generation_deployment;
+    }
 }

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt4oMiniService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt4oMiniService.php
@@ -52,4 +52,9 @@ class OpenAiGpt4oMiniService extends BaseOpenAiService
     {
         return $this->settings->open_ai_gpt_4o_mini_base_uri ?? config('integration-open-ai.gpt_4o_mini_base_uri');
     }
+
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_4o_mini_image_generation_deployment;
+    }
 }

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt4oService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt4oService.php
@@ -52,4 +52,9 @@ class OpenAiGpt4oService extends BaseOpenAiService
     {
         return $this->settings->open_ai_gpt_4o_base_uri ?? config('integration-open-ai.gpt_4o_base_uri');
     }
+
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_4o_image_generation_deployment;
+    }
 }

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt5MiniService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt5MiniService.php
@@ -53,6 +53,11 @@ class OpenAiGpt5MiniService extends BaseOpenAiService
         return $this->settings->open_ai_gpt_5_mini_base_uri ?? config('integration-open-ai.gpt_5_mini_base_uri');
     }
 
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_5_mini_image_generation_deployment;
+    }
+
     public function hasTemperature(): bool
     {
         return false;

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt5NanoService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt5NanoService.php
@@ -53,6 +53,11 @@ class OpenAiGpt5NanoService extends BaseOpenAiService
         return $this->settings->open_ai_gpt_5_nano_base_uri ?? config('integration-open-ai.gpt_5_nano_base_uri');
     }
 
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_5_nano_image_generation_deployment;
+    }
+
     public function hasTemperature(): bool
     {
         return false;

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt5Service.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt5Service.php
@@ -53,6 +53,11 @@ class OpenAiGpt5Service extends BaseOpenAiService
         return $this->settings->open_ai_gpt_5_base_uri ?? config('integration-open-ai.gpt_5_base_uri');
     }
 
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_5_image_generation_deployment;
+    }
+
     public function hasTemperature(): bool
     {
         return false;

--- a/app-modules/integration-open-ai/src/Services/OpenAiGptO3Service.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGptO3Service.php
@@ -53,6 +53,11 @@ class OpenAiGptO3Service extends BaseOpenAiService
         return $this->settings->open_ai_gpt_o3_base_uri ?? config('integration-open-ai.gpt_o3_base_uri');
     }
 
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_o3_image_generation_deployment;
+    }
+
     public function hasReasoning(): bool
     {
         return true;

--- a/app-modules/integration-open-ai/src/Services/OpenAiGptO4MiniService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGptO4MiniService.php
@@ -53,6 +53,11 @@ class OpenAiGptO4MiniService extends BaseOpenAiService
         return $this->settings->open_ai_gpt_o4_mini_base_uri ?? config('integration-open-ai.gpt_o4_mini_base_uri');
     }
 
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_o4_mini_image_generation_deployment;
+    }
+
     public function hasReasoning(): bool
     {
         return true;


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1830

### Technical Description

Uses the non-streaming Responses API with the "image generation" tool to generate images based on a prompt. The feature can be enabled per-model by providing an image generation model within the same region as the text deployment. It also needs to be enabled per-chat using the new button in the UI.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
