### PR TITLE
[ADVAPP-1881]: Some users have reported that the merge value for contact name is missing in the case type templates

### DIFF
--- a/app-modules/case-management/src/Filament/Resources/CaseTypeResource/Pages/ManageCaseTypeEmailTemplate.php
+++ b/app-modules/case-management/src/Filament/Resources/CaseTypeResource/Pages/ManageCaseTypeEmailTemplate.php
@@ -85,7 +85,7 @@ class ManageCaseTypeEmailTemplate extends EditRecord
                     ->persistTab()
                     ->id('email-template-role-tabs')
                     ->tabs(array_map(
-                        fn(CaseTypeEmailTemplateRole $role) => Tab::make($role->getLabel())
+                        fn (CaseTypeEmailTemplateRole $role) => Tab::make($role->getLabel())
                             ->schema($this->getEmailTemplateFormSchema($role))
                             ->statePath($role->value),
                         $roles
@@ -184,7 +184,7 @@ class ManageCaseTypeEmailTemplate extends EditRecord
             ->where('type', $this->type)
             ->get();
 
-        $templates = $templates->keyBy(fn(CaseTypeEmailTemplate $template) => $template->role->value);
+        $templates = $templates->keyBy(fn (CaseTypeEmailTemplate $template) => $template->role->value);
 
         $state = [];
 

--- a/app-modules/case-management/src/Filament/Resources/CaseTypeResource/Pages/ManageCaseTypeEmailTemplate.php
+++ b/app-modules/case-management/src/Filament/Resources/CaseTypeResource/Pages/ManageCaseTypeEmailTemplate.php
@@ -85,7 +85,7 @@ class ManageCaseTypeEmailTemplate extends EditRecord
                     ->persistTab()
                     ->id('email-template-role-tabs')
                     ->tabs(array_map(
-                        fn (CaseTypeEmailTemplateRole $role) => Tab::make($role->getLabel())
+                        fn(CaseTypeEmailTemplateRole $role) => Tab::make($role->getLabel())
                             ->schema($this->getEmailTemplateFormSchema($role))
                             ->statePath($role->value),
                         $roles
@@ -140,6 +140,7 @@ class ManageCaseTypeEmailTemplate extends EditRecord
                 ->extraInputAttributes(['style' => 'min-height: 2rem; overflow-y:none;'])
                 ->disableToolbarMenus()
                 ->mergeTags([
+                    'contact name',
                     'case number',
                     'created date',
                     'updated date',
@@ -156,6 +157,7 @@ class ManageCaseTypeEmailTemplate extends EditRecord
                 ->placeholder('Enter the email body here...')
                 ->extraInputAttributes(['style' => 'min-height: 12rem;'])
                 ->mergeTags([
+                    'contact name',
                     'case number',
                     'created date',
                     'updated date',
@@ -182,7 +184,7 @@ class ManageCaseTypeEmailTemplate extends EditRecord
             ->where('type', $this->type)
             ->get();
 
-        $templates = $templates->keyBy(fn (CaseTypeEmailTemplate $template) => $template->role->value);
+        $templates = $templates->keyBy(fn(CaseTypeEmailTemplate $template) => $template->role->value);
 
         $state = [];
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1881

### Technical Description

> Solve the issue where contact name merge tag was not visible in case type email templates

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
