### PR TITLE
[ADVAPP-1919]: Some users have reported that the QnA advisor fails to respond during preview

### DIFF
--- a/app-modules/ai/resources/views/filament/resources/qna-advisors/pages/preview-qna-advisor.blade.php
+++ b/app-modules/ai/resources/views/filament/resources/qna-advisors/pages/preview-qna-advisor.blade.php
@@ -38,7 +38,7 @@
         class="flex h-[calc(100dvh-16rem)] flex-col gap-y-3"
         x-data="qnaAdvisorPreview({
             csrfToken: @js(csrf_token()),
-            sendMessageUrl: @js(URL::to(URL::signedRoute('ai.qna-advisors.messages.send', ['advisor' => $this->getRecord(), 'preview' => true], absolute: false))),
+            sendMessageUrl: @js(URL::to(URL::signedRoute('ai.qna-advisors.messages.send', ['advisor' => $this->getRecord(), 'preview' => true]))),
             userId: @js(auth()->user()->id),
         })"
     >

--- a/app-modules/ai/src/Http/Middleware/EnsureQnaAdvisorEmbedIsEnabled.php
+++ b/app-modules/ai/src/Http/Middleware/EnsureQnaAdvisorEmbedIsEnabled.php
@@ -56,6 +56,10 @@ class EnsureQnaAdvisorEmbedIsEnabled
             return response()->json(status: Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
+        if ($request->hasValidSignature() && $request->query('preview')) {
+            return $next($request);
+        }
+
         if (! $advisor->is_embed_enabled) {
             return response()->json(['error' => 'Embed is not enabled for this advisor.', 'embed_enabled' => false], Response::HTTP_UNPROCESSABLE_ENTITY);
         }

--- a/app-modules/ai/src/Http/Middleware/EnsureQnaAdvisorRequestComingFromAuthorizedDomain.php
+++ b/app-modules/ai/src/Http/Middleware/EnsureQnaAdvisorRequestComingFromAuthorizedDomain.php
@@ -56,6 +56,10 @@ class EnsureQnaAdvisorRequestComingFromAuthorizedDomain
             return response()->json(status: Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
+        if ($request->hasValidSignature() && $request->query('preview')) {
+            return $next($request);
+        }
+
         $origin = $request->headers->get('origin');
 
         if (! $origin) {

--- a/app-modules/ai/src/Http/Middleware/QnaAdvisorAuthorization.php
+++ b/app-modules/ai/src/Http/Middleware/QnaAdvisorAuthorization.php
@@ -61,6 +61,10 @@ class QnaAdvisorAuthorization
             return response()->json(status: Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
+        if ($request->hasValidSignature() && $request->query('preview')) {
+            return $next($request);
+        }
+
         if (! $advisor->is_requires_authentication_enabled) {
             // This Advisor does not require an Educatable to be authorized. Allow request.
             return $next($request);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1919

### Technical Description

Skips authentication for preview URLs.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
