### PR TITLE
[ADVAPP-1875]: Improve image rendering by allowing a user to download an image

### DIFF
--- a/app-modules/ai/resources/js/chat.js
+++ b/app-modules/ai/resources/js/chat.js
@@ -47,14 +47,14 @@ const addImageDownloadButtons = (htmlContent) => {
         if (!image.getAttribute('data-id')) return;
 
         const wrapper = document.createElement('div');
-        wrapper.className = 'relative group my-8 not-prose';
+        wrapper.className = 'relative my-8 not-prose';
 
         const newImage = image.cloneNode(true);
         newImage.className = 'max-w-full h-auto rounded-lg';
 
         const downloadLink = document.createElement('a');
         downloadLink.className =
-            'image-download-btn absolute top-2 right-2 bg-black text-white rounded-md p-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-black inline-flex items-center justify-center';
+            'image-download-btn absolute top-2 right-2 bg-black text-white rounded-md p-2 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-black inline-flex items-center justify-center';
         downloadLink.href = '#';
         downloadLink.title = 'Download image';
         downloadLink.setAttribute('aria-label', 'Download image');

--- a/app-modules/ai/resources/js/chat.js
+++ b/app-modules/ai/resources/js/chat.js
@@ -34,10 +34,49 @@
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
 
+const addImageDownloadButtons = (htmlContent) => {
+    if (!htmlContent || typeof htmlContent !== 'string') {
+        return htmlContent;
+    }
+
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = htmlContent;
+    const images = tempDiv.querySelectorAll('img[data-id]');
+    
+    images.forEach(image => {
+        if (!image.getAttribute('data-id')) return;
+        
+        const wrapper = document.createElement('div');
+        wrapper.className = 'relative group my-8 not-prose';
+        
+        const newImage = image.cloneNode(true);
+        newImage.className = 'max-w-full h-auto rounded-lg';
+        
+        const downloadLink = document.createElement('a');
+        downloadLink.className = 'image-download-btn absolute top-2 right-2 bg-black text-white rounded-md p-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-black inline-flex items-center justify-center';
+        downloadLink.href = '#';
+        downloadLink.title = 'Download image';
+        downloadLink.setAttribute('aria-label', 'Download image');
+        downloadLink.setAttribute('data-media-uuid', image.getAttribute('data-id'));
+        downloadLink.innerHTML = `
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
+                <path d="M8.75 2.75a.75.75 0 0 0-1.5 0v5.69L5.03 6.22a.75.75 0 0 0-1.06 1.06l3.5 3.5a.75.75 0 0 0 1.06 0l3.5-3.5a.75.75 0 0 0-1.06-1.06L8.75 8.44V2.75Z" />
+                <path d="M3.5 9.75a.75.75 0 0 0-1.5 0v1.5A2.75 2.75 0 0 0 4.75 14h6.5A2.75 2.75 0 0 0 14 11.25v-1.5a.75.75 0 0 0-1.5 0v1.5c0 .69-.56 1.25-1.25 1.25h-6.5c-.69 0-1.25-.56-1.25-1.25v-1.5Z" />
+            </svg>
+        `;
+        
+        wrapper.appendChild(newImage);
+        wrapper.appendChild(downloadLink);
+        image.parentElement.replaceChild(wrapper, image);
+    });
+    
+    return tempDiv.innerHTML;
+}
+
 document.addEventListener('alpine:init', () => {
     Alpine.data(
         'chat',
-        ({ csrfToken, retryMessageUrl, sendMessageUrl, completeResponseUrl, showThreadUrl, userId, threadId }) => ({
+        ({ csrfToken, retryMessageUrl, sendMessageUrl, completeResponseUrl, showThreadUrl, downloadImageUrl, userId, threadId }) => ({
             error: null,
             isIncomplete: false,
             isLoading: true,
@@ -56,8 +95,61 @@ document.addEventListener('alpine:init', () => {
             hasSetUpNewMessageForResponse: false,
             isCompletingPreviousResponse: false,
             responseTimeout: null,
+            downloadImageUrl,
+            csrfToken,
+            clickHandler: null,
 
             init: async function () {
+                this.clickHandler = async (event) => {
+                    const downloadBtn = event.target.closest('.image-download-btn');
+                    if (!downloadBtn) return;
+
+                    event.preventDefault();
+                    const mediaUuid = downloadBtn.getAttribute('data-media-uuid');
+                    if (!mediaUuid) return;
+                    
+                    try {
+                        const response = await fetch(this.downloadImageUrl, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': this.csrfToken,
+                            },
+                            body: JSON.stringify({
+                                media_uuid: mediaUuid
+                            })
+                        });
+                        
+                        if (!response.ok) {
+                            const errorData = await response.json();
+                            throw new Error(errorData.error || 'Download failed');
+                        }
+                        
+                        const contentDisposition = response.headers.get('content-disposition');
+                        let filename = 'image.png';
+                        if (contentDisposition) {
+                            const matches = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/.exec(contentDisposition);
+                            if (matches != null && matches[1]) {
+                                filename = matches[1].replace(/['"]/g, '');
+                            }
+                        }
+                        
+                        const blob = await response.blob();
+                        const url = window.URL.createObjectURL(blob);
+                        
+                        const tempLink = document.createElement('a');
+                        tempLink.href = url;
+                        tempLink.download = filename;
+                        tempLink.style.display = 'none';
+                        document.body.appendChild(tempLink);
+                        tempLink.click();
+                        document.body.removeChild(tempLink);
+                        window.URL.revokeObjectURL(url);
+                    } catch (error) {}
+                };
+                
+                document.addEventListener('click', this.clickHandler);
+
                 this.render();
 
                 setInterval(this.render.bind(this), 500);
@@ -88,8 +180,14 @@ document.addEventListener('alpine:init', () => {
                         this.pendingResponse = this.pendingResponse.slice(combined.length);
 
                         if (this.messages.length > 0) {
+                            const parsedMarkdown = marked.parse(this.rawIncomingResponse);
+                            const htmlWithDownloadButtons = addImageDownloadButtons(parsedMarkdown);
                             this.messages[this.messages.length - 1].content = DOMPurify.sanitize(
-                                marked.parse(this.rawIncomingResponse),
+                                htmlWithDownloadButtons,
+                                {
+                                    ADD_TAGS: ['a'],
+                                    ADD_ATTR: ['href', 'aria-label', 'title', 'data-media-uuid', 'data-id', 'class', 'src', 'alt']
+                                }
                             );
                         }
                     }
@@ -103,7 +201,21 @@ document.addEventListener('alpine:init', () => {
                 });
 
                 const thread = await showThreadResponse.json();
-                this.messages = thread.messages;
+                this.messages = thread.messages.map((message) => {
+                    if (message.content && !message.user_id) {
+                        const parsedMarkdown = marked.parse(message.content);
+                        const htmlWithDownloadButtons = addImageDownloadButtons(parsedMarkdown);
+                        message.content = DOMPurify.sanitize(
+                            htmlWithDownloadButtons,
+                            {
+                                ADD_TAGS: ['a'],
+                                ADD_ATTR: ['href', 'aria-label', 'title', 'data-media-uuid', 'data-id', 'class', 'src', 'alt']
+                            }
+                        );
+                    }
+
+                    return message;
+                })
                 this.users = thread.users;
 
                 Echo.private(`advisor-thread-${threadId}`)
@@ -144,8 +256,14 @@ document.addEventListener('alpine:init', () => {
                             this.pendingResponse = '';
 
                             if (this.messages.length > 0) {
+                                const parsedMarkdown = marked.parse(this.rawIncomingResponse);
+                                const htmlWithDownloadButtons = addImageDownloadButtons(parsedMarkdown);
                                 this.messages[this.messages.length - 1].content = DOMPurify.sanitize(
-                                    marked.parse(this.rawIncomingResponse),
+                                    htmlWithDownloadButtons,
+                                    {
+                                        ADD_TAGS: ['a'],
+                                        ADD_ATTR: ['href', 'aria-label', 'title', 'data-media-uuid', 'data-id', 'class', 'src', 'alt']
+                                    }
                                 );
                             }
                         }
@@ -398,6 +516,15 @@ document.addEventListener('alpine:init', () => {
                     this.$refs.messageInput.style.height = '5rem';
                     this.$refs.messageInput.style.height = `min(${this.$refs.messageInput.scrollHeight}px, 25dvh)`;
                 }
+            },
+
+            destroy: function () {
+                if (this.clickHandler) {
+                    document.removeEventListener('click', this.clickHandler);
+                    this.clickHandler = null;
+                }
+                
+                this.clearResponseTimeout();
             },
         }),
     );

--- a/app-modules/ai/resources/js/chat.js
+++ b/app-modules/ai/resources/js/chat.js
@@ -42,18 +42,19 @@ const addImageDownloadButtons = (htmlContent) => {
     const tempDiv = document.createElement('div');
     tempDiv.innerHTML = htmlContent;
     const images = tempDiv.querySelectorAll('img[data-id]');
-    
-    images.forEach(image => {
+
+    images.forEach((image) => {
         if (!image.getAttribute('data-id')) return;
-        
+
         const wrapper = document.createElement('div');
         wrapper.className = 'relative group my-8 not-prose';
-        
+
         const newImage = image.cloneNode(true);
         newImage.className = 'max-w-full h-auto rounded-lg';
-        
+
         const downloadLink = document.createElement('a');
-        downloadLink.className = 'image-download-btn absolute top-2 right-2 bg-black text-white rounded-md p-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-black inline-flex items-center justify-center';
+        downloadLink.className =
+            'image-download-btn absolute top-2 right-2 bg-black text-white rounded-md p-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-black inline-flex items-center justify-center';
         downloadLink.href = '#';
         downloadLink.title = 'Download image';
         downloadLink.setAttribute('aria-label', 'Download image');
@@ -64,19 +65,28 @@ const addImageDownloadButtons = (htmlContent) => {
                 <path d="M3.5 9.75a.75.75 0 0 0-1.5 0v1.5A2.75 2.75 0 0 0 4.75 14h6.5A2.75 2.75 0 0 0 14 11.25v-1.5a.75.75 0 0 0-1.5 0v1.5c0 .69-.56 1.25-1.25 1.25h-6.5c-.69 0-1.25-.56-1.25-1.25v-1.5Z" />
             </svg>
         `;
-        
+
         wrapper.appendChild(newImage);
         wrapper.appendChild(downloadLink);
         image.parentElement.replaceChild(wrapper, image);
     });
-    
+
     return tempDiv.innerHTML;
-}
+};
 
 document.addEventListener('alpine:init', () => {
     Alpine.data(
         'chat',
-        ({ csrfToken, retryMessageUrl, sendMessageUrl, completeResponseUrl, showThreadUrl, downloadImageUrl, userId, threadId }) => ({
+        ({
+            csrfToken,
+            retryMessageUrl,
+            sendMessageUrl,
+            completeResponseUrl,
+            showThreadUrl,
+            downloadImageUrl,
+            userId,
+            threadId,
+        }) => ({
             error: null,
             isIncomplete: false,
             isLoading: true,
@@ -107,7 +117,7 @@ document.addEventListener('alpine:init', () => {
                     event.preventDefault();
                     const mediaUuid = downloadBtn.getAttribute('data-media-uuid');
                     if (!mediaUuid) return;
-                    
+
                     try {
                         const response = await fetch(this.downloadImageUrl, {
                             method: 'POST',
@@ -116,15 +126,15 @@ document.addEventListener('alpine:init', () => {
                                 'X-CSRF-TOKEN': this.csrfToken,
                             },
                             body: JSON.stringify({
-                                media_uuid: mediaUuid
-                            })
+                                media_uuid: mediaUuid,
+                            }),
                         });
-                        
+
                         if (!response.ok) {
                             const errorData = await response.json();
                             throw new Error(errorData.error || 'Download failed');
                         }
-                        
+
                         const contentDisposition = response.headers.get('content-disposition');
                         let filename = 'image.png';
                         if (contentDisposition) {
@@ -133,10 +143,10 @@ document.addEventListener('alpine:init', () => {
                                 filename = matches[1].replace(/['"]/g, '');
                             }
                         }
-                        
+
                         const blob = await response.blob();
                         const url = window.URL.createObjectURL(blob);
-                        
+
                         const tempLink = document.createElement('a');
                         tempLink.href = url;
                         tempLink.download = filename;
@@ -147,7 +157,7 @@ document.addEventListener('alpine:init', () => {
                         window.URL.revokeObjectURL(url);
                     } catch (error) {}
                 };
-                
+
                 document.addEventListener('click', this.clickHandler);
 
                 this.render();
@@ -186,8 +196,17 @@ document.addEventListener('alpine:init', () => {
                                 htmlWithDownloadButtons,
                                 {
                                     ADD_TAGS: ['a'],
-                                    ADD_ATTR: ['href', 'aria-label', 'title', 'data-media-uuid', 'data-id', 'class', 'src', 'alt']
-                                }
+                                    ADD_ATTR: [
+                                        'href',
+                                        'aria-label',
+                                        'title',
+                                        'data-media-uuid',
+                                        'data-id',
+                                        'class',
+                                        'src',
+                                        'alt',
+                                    ],
+                                },
                             );
                         }
                     }
@@ -205,17 +224,23 @@ document.addEventListener('alpine:init', () => {
                     if (message.content && !message.user_id) {
                         const parsedMarkdown = marked.parse(message.content);
                         const htmlWithDownloadButtons = addImageDownloadButtons(parsedMarkdown);
-                        message.content = DOMPurify.sanitize(
-                            htmlWithDownloadButtons,
-                            {
-                                ADD_TAGS: ['a'],
-                                ADD_ATTR: ['href', 'aria-label', 'title', 'data-media-uuid', 'data-id', 'class', 'src', 'alt']
-                            }
-                        );
+                        message.content = DOMPurify.sanitize(htmlWithDownloadButtons, {
+                            ADD_TAGS: ['a'],
+                            ADD_ATTR: [
+                                'href',
+                                'aria-label',
+                                'title',
+                                'data-media-uuid',
+                                'data-id',
+                                'class',
+                                'src',
+                                'alt',
+                            ],
+                        });
                     }
 
                     return message;
-                })
+                });
                 this.users = thread.users;
 
                 Echo.private(`advisor-thread-${threadId}`)
@@ -262,8 +287,17 @@ document.addEventListener('alpine:init', () => {
                                     htmlWithDownloadButtons,
                                     {
                                         ADD_TAGS: ['a'],
-                                        ADD_ATTR: ['href', 'aria-label', 'title', 'data-media-uuid', 'data-id', 'class', 'src', 'alt']
-                                    }
+                                        ADD_ATTR: [
+                                            'href',
+                                            'aria-label',
+                                            'title',
+                                            'data-media-uuid',
+                                            'data-id',
+                                            'class',
+                                            'src',
+                                            'alt',
+                                        ],
+                                    },
                                 );
                             }
                         }
@@ -523,7 +557,7 @@ document.addEventListener('alpine:init', () => {
                     document.removeEventListener('click', this.clickHandler);
                     this.clickHandler = null;
                 }
-                
+
                 this.clearResponseTimeout();
             },
         }),

--- a/app-modules/ai/resources/views/components/assistant.blade.php
+++ b/app-modules/ai/resources/views/components/assistant.blade.php
@@ -33,6 +33,7 @@
 --}}
 @php
     use Filament\Support\Enums\ActionSize;
+    use Illuminate\Support\Facades\URL;
     use Illuminate\Support\Facades\Vite;
 @endphp
 
@@ -487,6 +488,7 @@
                     sendMessageUrl: @js(route('ai.advisors.threads.messages.send', ['thread' => $this->thread])),
                     completeResponseUrl: @js(route('ai.advisors.threads.messages.complete-response', ['thread' => $this->thread])),
                     showThreadUrl: @js(route('ai.advisors.threads.show', ['thread' => $this->thread])),
+                    downloadImageUrl: @js(URL::signedRoute('ai.advisors.threads.download-image', ['thread' => $this->thread], now()->addHours(24))),
                     userId: @js(auth()->user()->id),
                     threadId: @js($this->thread->id)
                 })"

--- a/app-modules/ai/routes/web.php
+++ b/app-modules/ai/routes/web.php
@@ -38,6 +38,7 @@ use AdvisingApp\Ai\Http\Controllers\Advisors\CompleteResponseController;
 use AdvisingApp\Ai\Http\Controllers\Advisors\RetryMessageController;
 use AdvisingApp\Ai\Http\Controllers\Advisors\SendMessageController;
 use AdvisingApp\Ai\Http\Controllers\Advisors\ShowThreadController;
+use AdvisingApp\Ai\Http\Controllers\DownloadImageController;
 use AdvisingApp\Ai\Http\Controllers\QnaAdvisors\PreviewAdvisorEmbedController;
 use Illuminate\Support\Facades\Route;
 
@@ -55,6 +56,10 @@ Route::middleware(['web', 'auth'])
 
         Route::post('ai/advisors/threads/{thread}/messages/complete-response', CompleteResponseController::class)
             ->name('advisors.threads.messages.complete-response');
+
+        Route::post('ai/advisors/threads/{thread}/download-image', DownloadImageController::class)
+            ->middleware('signed')
+            ->name('advisors.threads.download-image');
 
         Route::get('ai/qna-advisors/{advisor}/preview-embed', PreviewAdvisorEmbedController::class)
             ->name('qna-advisors.preview-embed');

--- a/app-modules/ai/routes/web.php
+++ b/app-modules/ai/routes/web.php
@@ -35,10 +35,10 @@
 */
 
 use AdvisingApp\Ai\Http\Controllers\Advisors\CompleteResponseController;
+use AdvisingApp\Ai\Http\Controllers\Advisors\DownloadImageController;
 use AdvisingApp\Ai\Http\Controllers\Advisors\RetryMessageController;
 use AdvisingApp\Ai\Http\Controllers\Advisors\SendMessageController;
 use AdvisingApp\Ai\Http\Controllers\Advisors\ShowThreadController;
-use AdvisingApp\Ai\Http\Controllers\DownloadImageController;
 use AdvisingApp\Ai\Http\Controllers\QnaAdvisors\PreviewAdvisorEmbedController;
 use Illuminate\Support\Facades\Route;
 

--- a/app-modules/ai/src/Http/Controllers/Advisors/DownloadImageController.php
+++ b/app-modules/ai/src/Http/Controllers/Advisors/DownloadImageController.php
@@ -34,7 +34,7 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Ai\Http\Controllers;
+namespace AdvisingApp\Ai\Http\Controllers\Advisors;
 
 use AdvisingApp\Ai\Models\AiThread;
 use Illuminate\Http\Request;

--- a/app-modules/ai/src/Http/Controllers/Advisors/ShowThreadController.php
+++ b/app-modules/ai/src/Http/Controllers/Advisors/ShowThreadController.php
@@ -68,7 +68,8 @@ class ShowThreadController
                                 $message->user,
                                 fn (Stringable $string): Stringable => $string
                                     ->pipe(nl2br(...))
-                                    ->stripTags(allowedTags: ['br']),
+                                    ->stripTags(allowedTags: ['br'])
+                                    ->sanitizeHtml(),
                             ),
                     ];
                 })

--- a/app-modules/ai/src/Http/Controllers/Advisors/ShowThreadController.php
+++ b/app-modules/ai/src/Http/Controllers/Advisors/ShowThreadController.php
@@ -69,9 +69,7 @@ class ShowThreadController
                                 fn (Stringable $string): Stringable => $string
                                     ->pipe(nl2br(...))
                                     ->stripTags(allowedTags: ['br']),
-                                fn (Stringable $string): Stringable => $string->markdown(),
-                            )
-                            ->sanitizeHtml(),
+                            ),
                     ];
                 })
                 ->all(),

--- a/app-modules/ai/src/Http/Controllers/DownloadImageController.php
+++ b/app-modules/ai/src/Http/Controllers/DownloadImageController.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS LLC respects the intellectual property rights of others and expects the
       same in return. Canyon GBS™ and Advising App™ are registered trademarks of
@@ -37,13 +37,9 @@
 namespace AdvisingApp\Ai\Http\Controllers;
 
 use AdvisingApp\Ai\Models\AiThread;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Routing\Controller;
-use Illuminate\Support\Facades\URL;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class DownloadImageController extends Controller
 {

--- a/app-modules/ai/src/Http/Controllers/DownloadImageController.php
+++ b/app-modules/ai/src/Http/Controllers/DownloadImageController.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Ai\Http\Controllers;
+
+use AdvisingApp\Ai\Models\AiThread;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\URL;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class DownloadImageController extends Controller
+{
+    public function __invoke(Request $request, AiThread $thread): Media
+    {
+        $request->validate([
+            'media_uuid' => ['required', 'string', 'uuid'],
+        ]);
+
+        return Media::query()
+            ->whereMorphedTo('model', $thread)
+            ->where('collection_name', 'generated_images')
+            ->where('uuid', $request->input('media_uuid'))
+            ->firstOrFail();
+    }
+}

--- a/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
@@ -157,7 +157,7 @@ class SendAdvisorMessage implements ShouldQueue
                     ->usingFileName(Str::random() . '.' . $chunk->format)
                     ->toMediaCollection('generated_images', diskName: 's3-public');
 
-                $chunk = new Text("![Generated image]({$media->getUrl()})");
+                $chunk = new Text('<img src="' . $media->getUrl() . '" alt="Generated image" data-id="' . $media->uuid . '" />');
             }
 
             if ($chunk instanceof Text) {

--- a/app-modules/ai/tests/Tenant/Feature/Http/Controllers/Advisors/ShowThreadControllerTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Http/Controllers/Advisors/ShowThreadControllerTest.php
@@ -120,50 +120,6 @@ it('removes HTML tags from messages sent by users', function () {
         ]);
 });
 
-it('converts messages sent by assistants into Markdown', function () {
-    asSuperAdmin();
-
-    $thread = AiThread::factory()
-        ->for(AiAssistant::factory()->create([
-            'application' => AiAssistantApplication::Test,
-            'is_default' => true,
-            'model' => AiModel::Test,
-        ]), 'assistant')
-        ->for(auth()->user())
-        ->has(AiMessage::factory()->state([
-            'content' => 'Hello, world!',
-            'user_id' => null,
-        ]), 'messages')
-        ->create();
-
-    get(route('ai.advisors.threads.show', ['thread' => $thread]))
-        ->assertJsonFragment([
-            'content' => '<p>Hello, world!</p>' . PHP_EOL,
-        ]);
-});
-
-it('removes unsafe HTML from messages sent by assistants', function () {
-    asSuperAdmin();
-
-    $thread = AiThread::factory()
-        ->for(AiAssistant::factory()->create([
-            'application' => AiAssistantApplication::Test,
-            'is_default' => true,
-            'model' => AiModel::Test,
-        ]), 'assistant')
-        ->for(auth()->user())
-        ->has(AiMessage::factory()->state([
-            'content' => '<script>alert("Hello, world!")</script>',
-            'user_id' => null,
-        ]), 'messages')
-        ->create();
-
-    get(route('ai.advisors.threads.show', ['thread' => $thread]))
-        ->assertJsonFragment([
-            'content' => '&lt;script&gt;alert(&#34;Hello, world!&#34;)&lt;/script&gt;' . PHP_EOL,
-        ]);
-});
-
 it('lists users involved in a thread once', function () {
     asSuperAdmin();
 


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1875

### Technical Description

Adds download buttons to generated images, if they have a `data-id` attribute when generated.

Moves markdown conversion and HTML sanitisation from backend to frontend then a thread is loaded, so the same functions can be used for existing messages and newly-received messages.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
