### PR TITLE
[ADVAPP-1976]: Some users have reported that adding the placeholder image removes images previously displayed in chat thread rather than only adding the placeholder in the relevant message

### DIFF
--- a/app-modules/ai/resources/views/components/assistant.blade.php
+++ b/app-modules/ai/resources/views/components/assistant.blade.php
@@ -33,7 +33,6 @@
 --}}
 @php
     use Filament\Support\Enums\ActionSize;
-    use Illuminate\Support\Facades\URL;
     use Illuminate\Support\Facades\Vite;
 @endphp
 
@@ -488,7 +487,7 @@
                     sendMessageUrl: @js(route('ai.advisors.threads.messages.send', ['thread' => $this->thread])),
                     completeResponseUrl: @js(route('ai.advisors.threads.messages.complete-response', ['thread' => $this->thread])),
                     showThreadUrl: @js(route('ai.advisors.threads.show', ['thread' => $this->thread])),
-                    downloadImageUrl: @js(URL::signedRoute('ai.advisors.threads.download-image', ['thread' => $this->thread], now()->addHours(24))),
+                    downloadImageUrl: @js(route('ai.advisors.threads.download-image', ['thread' => $this->thread])),
                     userId: @js(auth()->user()->id),
                     threadId: @js($this->thread->id)
                 })"

--- a/app-modules/ai/routes/web.php
+++ b/app-modules/ai/routes/web.php
@@ -58,7 +58,6 @@ Route::middleware(['web', 'auth'])
             ->name('advisors.threads.messages.complete-response');
 
         Route::post('ai/advisors/threads/{thread}/download-image', DownloadImageController::class)
-            ->middleware('signed')
             ->name('advisors.threads.download-image');
 
         Route::get('ai/qna-advisors/{advisor}/preview-embed', PreviewAdvisorEmbedController::class)

--- a/app-modules/ai/src/Http/Requests/Advisors/DownloadImageRequest.php
+++ b/app-modules/ai/src/Http/Requests/Advisors/DownloadImageRequest.php
@@ -34,21 +34,30 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Ai\Http\Controllers\Advisors;
+namespace AdvisingApp\Ai\Http\Requests\Advisors;
 
-use AdvisingApp\Ai\Http\Requests\Advisors\DownloadImageRequest;
-use AdvisingApp\Ai\Models\AiThread;
-use Illuminate\Routing\Controller;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
 
-class DownloadImageController extends Controller
+class DownloadImageRequest extends FormRequest
 {
-    public function __invoke(DownloadImageRequest $request, AiThread $thread): Media
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
     {
-        return Media::query()
-            ->whereMorphedTo('model', $thread)
-            ->where('collection_name', 'generated_images')
-            ->where('uuid', $request->input('media_uuid'))
-            ->firstOrFail();
+        return $this->thread->user()->is(auth()->user());
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'media_uuid' => ['required', 'string', 'uuid'],
+        ];
     }
 }


### PR DESCRIPTION
Signed-off-by: Dan Harrin <dan.harrin@canyongbs.com>

### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1976

### Technical Description

When the temporary URL that is passed to the Alpine component is regenerated, like when a Livewire request runs, the Alpine component is reinitialised which removes any messages that exist in the UI but not in the database yet. As such, keep the URL consistent so that it is not generated each time, so the Alpine component doesnt reload, so the messages persist correctly. Add thread auth to the controller instead, like the other endpoints have.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
