### PR TITLE
[ADVAPP-1959]: Improve the unified inbox by adding an status as to whether the message is from a prospect or a student

### DIFF
--- a/app-modules/engagement/src/Filament/Pages/Inbox.php
+++ b/app-modules/engagement/src/Filament/Pages/Inbox.php
@@ -49,10 +49,8 @@ use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
-use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
 class Inbox extends Page implements HasTable

--- a/app-modules/engagement/src/Filament/Pages/Inbox.php
+++ b/app-modules/engagement/src/Filament/Pages/Inbox.php
@@ -94,7 +94,7 @@ class Inbox extends Page implements HasTable
                     ->badge(),
                 TextColumn::make('sender_type')
                     ->label('Relation')
-                    ->formatStateUsing(fn(EngagementResponse $record) => ucwords($record->sender_type)),
+                    ->formatStateUsing(fn (EngagementResponse $record) => ucwords($record->sender_type)),
                 TextColumn::make('from')
                     ->state(function (EngagementResponse $record): ?string {
                         return (($record->sender instanceof Student) || ($record->sender instanceof Prospect))

--- a/app-modules/engagement/src/Filament/Pages/Inbox.php
+++ b/app-modules/engagement/src/Filament/Pages/Inbox.php
@@ -92,6 +92,9 @@ class Inbox extends Page implements HasTable
                     ->badge(),
                 TextColumn::make('status')
                     ->badge(),
+                TextColumn::make('sender_type')
+                    ->label('Relation')
+                    ->formatStateUsing(fn(EngagementResponse $record) => ucwords($record->sender_type)),
                 TextColumn::make('from')
                     ->state(function (EngagementResponse $record): ?string {
                         return (($record->sender instanceof Student) || ($record->sender instanceof Prospect))

--- a/app-modules/engagement/src/Filament/Pages/Inbox.php
+++ b/app-modules/engagement/src/Filament/Pages/Inbox.php
@@ -49,7 +49,10 @@ use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
 
 class Inbox extends Page implements HasTable
@@ -94,7 +97,8 @@ class Inbox extends Page implements HasTable
                     ->badge(),
                 TextColumn::make('sender_type')
                     ->label('Relation')
-                    ->formatStateUsing(fn (EngagementResponse $record) => ucwords($record->sender_type)),
+                    ->formatStateUsing(fn (EngagementResponse $record) => ucwords($record->sender_type))
+                    ->sortable(),
                 TextColumn::make('from')
                     ->state(function (EngagementResponse $record): ?string {
                         return (($record->sender instanceof Student) || ($record->sender instanceof Prospect))
@@ -116,6 +120,14 @@ class Inbox extends Page implements HasTable
             ->actions([
                 ViewAction::make()
                     ->url(fn (EngagementResponse $record): string => ViewEngagementResponse::getUrl(['record' => $record])),
+            ])
+            ->filters([
+                SelectFilter::make('sender_type')
+                    ->label('Relation')
+                    ->options([
+                        'student' => 'Student',
+                        'prospect' => 'Prospect',
+                    ]),
             ])
             ->recordUrl(fn (EngagementResponse $record): string => ViewEngagementResponse::getUrl(['record' => $record]))
             ->defaultSort('sent_at', 'desc')

--- a/app-modules/engagement/src/Filament/Pages/SentItems.php
+++ b/app-modules/engagement/src/Filament/Pages/SentItems.php
@@ -96,7 +96,7 @@ class SentItems extends Page implements HasTable
                     ->state(fn (Engagement $record) => EngagementDisplayStatus::getStatus($record)),
                 TextColumn::make('recipient_type')
                     ->label('Relation')
-                    ->formatStateUsing(fn(Engagement $record) => ucwords($record->recipient_type)),
+                    ->formatStateUsing(fn (Engagement $record) => ucwords($record->recipient_type)),
                 TextColumn::make('user.name')
                     ->label('From'),
                 TextColumn::make('recipient.full_name')

--- a/app-modules/engagement/src/Filament/Pages/SentItems.php
+++ b/app-modules/engagement/src/Filament/Pages/SentItems.php
@@ -94,9 +94,6 @@ class SentItems extends Page implements HasTable
                 TextColumn::make('status')
                     ->badge()
                     ->state(fn (Engagement $record) => EngagementDisplayStatus::getStatus($record)),
-                TextColumn::make('recipient_type')
-                    ->label('Relation')
-                    ->formatStateUsing(fn (Engagement $record) => ucwords($record->recipient_type)),
                 TextColumn::make('user.name')
                     ->label('From'),
                 TextColumn::make('recipient.full_name')

--- a/app-modules/engagement/src/Filament/Pages/SentItems.php
+++ b/app-modules/engagement/src/Filament/Pages/SentItems.php
@@ -94,6 +94,9 @@ class SentItems extends Page implements HasTable
                 TextColumn::make('status')
                     ->badge()
                     ->state(fn (Engagement $record) => EngagementDisplayStatus::getStatus($record)),
+                TextColumn::make('recipient_type')
+                    ->label('Relation')
+                    ->formatStateUsing(fn(Engagement $record) => ucwords($record->recipient_type)),
                 TextColumn::make('user.name')
                     ->label('From'),
                 TextColumn::make('recipient.full_name')

--- a/app-modules/engagement/tests/Tenant/Filament/Pages/InboxTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Pages/InboxTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2025, Canyon GBS LLC. All rights reserved.
+
+    Advising App™ is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS LLC respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS™ and Advising App™ are registered trademarks of
+      Canyon GBS LLC, and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS LLC.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Engagement\Filament\Pages\Inbox;
 use AdvisingApp\Engagement\Models\EngagementResponse;
 use AdvisingApp\Prospect\Models\Prospect;
@@ -12,7 +46,7 @@ it('is gated with proper access control', function () {})->todo();
 
 it('displays the correct details', function () {})->todo();
 
-it('can properly filter sender type', function() {
+it('can properly filter sender type', function () {
     asSuperAdmin();
 
     $prospectEngagementResponses = EngagementResponse::factory()->count(5)->create(['sender_type' => (new Prospect())->getMorphClass()]);

--- a/app-modules/engagement/tests/Tenant/Filament/Pages/InboxTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Pages/InboxTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use AdvisingApp\Engagement\Filament\Pages\Inbox;
+use AdvisingApp\Engagement\Models\EngagementResponse;
+use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Models\Student;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('is gated with proper access control', function () {})->todo();
+
+it('displays the correct details', function () {})->todo();
+
+it('can properly filter sender type', function() {
+    asSuperAdmin();
+
+    $prospectEngagementResponses = EngagementResponse::factory()->count(5)->create(['sender_type' => (new Prospect())->getMorphClass()]);
+    $studentEngagementResponses = EngagementResponse::factory()->count(5)->create(['sender_type' => (new Student())->getMorphClass()]);
+
+    livewire(Inbox::class)
+        ->set('tableRecordsPerPage', 10)
+        ->assertCanSeeTableRecords($prospectEngagementResponses->merge($studentEngagementResponses))
+        ->filterTable('sender_type', 'student')
+        ->assertCanSeeTableRecords($studentEngagementResponses)
+        ->assertCanNotSeeTableRecords($prospectEngagementResponses)
+        ->filterTable('sender_type', 'prospect')
+        ->assertCanSeeTableRecords($prospectEngagementResponses)
+        ->assertCanNotSeeTableRecords($studentEngagementResponses);
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1959

### Technical Description

Add relations column to unified inbox to display if the sender/recipient is a student or prospect

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
