### PR TITLE
[ADVAPP-1973]: Update the Resource Hub article view to display tabs for content, properties and metadata

### DIFF
--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticleResource/Pages/ViewResourceHubArticle.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticleResource/Pages/ViewResourceHubArticle.php
@@ -42,6 +42,8 @@ use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\Tabs;
+use Filament\Infolists\Components\Tabs\Tab;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Components\ViewEntry;
 use Filament\Infolists\Infolist;
@@ -75,42 +77,45 @@ class ViewResourceHubArticle extends ViewRecord
     {
         return $infolist
             ->schema([
-                Section::make('Article Information')
-                    ->collapsed()
-                    ->schema([
-                        TextEntry::make('title')
-                            ->label('Article Title')
-                            ->columnSpanFull(),
-                        TextEntry::make('notes')
-                            ->label('Notes')
-                            ->columnSpanFull(),
-                        TextEntry::make('public')
-                            ->label('Public')
-                            ->formatStateUsing(fn (bool $state): string => $state ? 'Yes' : 'No'),
-                        TextEntry::make('views_count')
-                            ->label('Views')
-                            ->state(fn (ResourceHubArticle $record): int => $record->views()->count()),
+                Tabs::make()
+                    ->tabs([
+                        Tab::make('Properties')
+                            ->schema([
+                                TextEntry::make('title')
+                                    ->label('Article Title')
+                                    ->columnSpanFull(),
+                                TextEntry::make('notes')
+                                    ->label('Notes')
+                                    ->columnSpanFull(),
+                                TextEntry::make('public')
+                                    ->label('Public')
+                                    ->formatStateUsing(fn (bool $state): string => $state ? 'Yes' : 'No'),
+                                TextEntry::make('views_count')
+                                    ->label('Views')
+                                    ->state(fn (ResourceHubArticle $record): int => $record->views()->count()),
+                            ])
+                            ->columns(2),
+                        Tab::make('Content')
+                            ->schema([
+                                ViewEntry::make('article_details')
+                                    ->label('Article Details')
+                                    ->columnSpanFull()
+                                    ->view('filament.infolists.components.html'),
+                            ]),
+                        Tab::make('Metadata')
+                            ->schema([
+                                TextEntry::make('status.name')
+                                    ->label('Status'),
+                                TextEntry::make('quality.name')
+                                    ->label('Quality'),
+                                TextEntry::make('category.name')
+                                    ->label('Category'),
+                                TextEntry::make('division.name')
+                                    ->label('Division'),
+                            ]),
                     ])
-                    ->columns(2),
-                Section::make()
-                    ->schema([
-                        ViewEntry::make('article_details')
-                            ->label('Article Details')
-                            ->columnSpanFull()
-                            ->view('filament.infolists.components.html'),
-                    ]),
-                Section::make('Article Metadata')
-                    ->collapsed()
-                    ->schema([
-                        TextEntry::make('status.name')
-                            ->label('Status'),
-                        TextEntry::make('quality.name')
-                            ->label('Quality'),
-                        TextEntry::make('category.name')
-                            ->label('Category'),
-                        TextEntry::make('division.name')
-                            ->label('Division'),
-                    ]),
+                    ->activeTab(2)
+                    ->columnSpanFull()
             ]);
     }
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-1973

### Technical Description

Change Resource Hub article view page to use tabs

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
