### PR TITLE
[ADVAPP-2000]: Some users have reported that one of the summary cards in QnA Advisor report is incorrectly labeled

### DIFF
--- a/app-modules/report/src/Filament/Widgets/QnaAdvisorReportStats.php
+++ b/app-modules/report/src/Filament/Widgets/QnaAdvisorReportStats.php
@@ -117,7 +117,7 @@ class QnaAdvisorReportStats extends StatsOverviewReportWidget
             );
 
         return [
-            Stat::make($this->getStartDate() ?? 'none', Number::abbreviate($qnaAdvisors, maxPrecision: 2)),
+            Stat::make('QnA Advisors', Number::abbreviate($qnaAdvisors, maxPrecision: 2)),
             Stat::make('Students', Number::abbreviate($studentsCount, maxPrecision: 2)),
             Stat::make('Prospects', Number::abbreviate($prospectsCount, maxPrecision: 2)),
             Stat::make('Unauthenticated', Number::abbreviate($unauthenticatedCount, maxPrecision: 2)),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2000

### Technical Description

Fix name of stat card in QnA Advisor Report.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
