### PR TITLE
[ADVAPP-2040]: Missing sentBy relationship (most likely a deleted user) causes the Student Message Details report table to throw an error and now load rows after a certain point

### DIFF
--- a/app-modules/report/src/Filament/Widgets/ProspectMessagesDetailTable.php
+++ b/app-modules/report/src/Filament/Widgets/ProspectMessagesDetailTable.php
@@ -138,17 +138,17 @@ class ProspectMessagesDetailTable extends BaseWidget
                             END {$direction}
                         ", [$studentModel->getMorphClass(), $prospectModel->getMorphClass(), $userModel->getMorphClass()]);
                     })
-                    ->state(fn (HolisticEngagement $record): ?string => match ($record->sentBy::class) {
+                    ->state(fn (HolisticEngagement $record): ?string => $record->sentBy ? match ($record->sentBy::class) {
                         Student::class, Prospect::class => $record->sentBy->{$record->sentBy->displayNameKey()},
                         User::class => $record->sentBy->name,
                         null => 'System',
                         default => throw new Exception('Invalid sender type'),
-                    })
-                    ->url(fn (HolisticEngagement $record): ?string => match ($record->sentBy::class) {
+                    } : null)
+                    ->url(fn (HolisticEngagement $record): ?string => $record->sentBy ? match ($record->sentBy::class) {
                         Student::class => StudentResource::getUrl('view', ['record' => $record->sentBy->getKey()]),
                         Prospect::class => ProspectResource::getUrl('view', ['record' => $record->sentBy->getKey()]),
                         default => null,
-                    })
+                    } : null)
                     ->openUrlInNewTab(),
                 TextColumn::make('sent_to')
                     ->label('Sent To')

--- a/app-modules/report/src/Filament/Widgets/ProspectMessagesDetailTable.php
+++ b/app-modules/report/src/Filament/Widgets/ProspectMessagesDetailTable.php
@@ -141,7 +141,6 @@ class ProspectMessagesDetailTable extends BaseWidget
                     ->state(fn (HolisticEngagement $record): ?string => $record->sentBy ? match ($record->sentBy::class) {
                         Student::class, Prospect::class => $record->sentBy->{$record->sentBy->displayNameKey()},
                         User::class => $record->sentBy->name,
-                        null => 'System',
                         default => throw new Exception('Invalid sender type'),
                     } : null)
                     ->url(fn (HolisticEngagement $record): ?string => $record->sentBy ? match ($record->sentBy::class) {

--- a/app-modules/report/src/Filament/Widgets/StudentMessagesDetailTable.php
+++ b/app-modules/report/src/Filament/Widgets/StudentMessagesDetailTable.php
@@ -141,17 +141,16 @@ class StudentMessagesDetailTable extends BaseWidget
                             END {$direction}
                         ", [$studentModel->getMorphClass(), $prospectModel->getMorphClass(), $userModel->getMorphClass()]);
                     })
-                    ->state(fn (HolisticEngagement $record): ?string => match ($record->sentBy::class) {
+                    ->state(fn (HolisticEngagement $record): ?string => $record->sentBy ? match ($record->sentBy::class) {
                         Student::class, Prospect::class => $record->sentBy->{$record->sentBy->displayNameKey()},
                         User::class => $record->sentBy->name,
-                        null => 'System',
                         default => throw new Exception('Invalid sender type'),
-                    })
-                    ->url(fn (HolisticEngagement $record): ?string => match ($record->sentBy::class) {
+                    } : null)
+                    ->url(fn (HolisticEngagement $record): ?string => $record->sentBy ? match ($record->sentBy::class) {
                         Student::class => StudentResource::getUrl('view', ['record' => $record->sentBy->getKey()]),
                         Prospect::class => ProspectResource::getUrl('view', ['record' => $record->sentBy->getKey()]),
                         default => null,
-                    })
+                    } : null)
                     ->openUrlInNewTab(),
                 TextColumn::make('sent_to')
                     ->label('Sent To')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2040

### Technical Description

Fix issue when the User that sent an Engagement is deleted or missing somehow in the Student and Prospect Message Detail report.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
