### PR TITLE
[ADVAPP-2039]: Missing content in Engagements is causing Sent Items of Unified Inbox to error out for some Tenants (Elements)

### DIFF
--- a/app-modules/engagement/src/Models/Engagement.php
+++ b/app-modules/engagement/src/Models/Engagement.php
@@ -239,14 +239,14 @@ class Engagement extends BaseModel implements Auditable, CanTriggerAutoSubscript
         );
     }
 
-    public function getSubject(): HtmlString
+    public function getSubject(): ?HtmlString
     {
-        return app(GenerateEngagementSubjectContent::class)(
+        return $this->subject ? app(GenerateEngagementSubjectContent::class)(
             $this->subject,
             $this->getMergeData(),
             $this->batch ?? $this->campaignAction ?? $this,
             $this->campaignAction ? 'data.subject' : 'subject',
-        );
+        ) : null;
     }
 
     public function getBodyMarkdown(): string
@@ -254,9 +254,9 @@ class Engagement extends BaseModel implements Auditable, CanTriggerAutoSubscript
         return stripslashes((new HtmlConverter())->convert($this->getBody()));
     }
 
-    public function getSubjectMarkdown(): string
+    public function getSubjectMarkdown(): ?string
     {
-        return stripslashes((new HtmlConverter())->convert($this->getSubject()));
+        return $this->getSubject() ? stripslashes((new HtmlConverter())->convert($this->getSubject())) : null;
     }
 
     public function getMergeData(): array


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2039

### Technical Description

Resolve issue with trying to load a subject for an Engagement when the subject is `null`, like for SMS.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
