### PR TITLE
[ADVAPP-2042]: Places in the code are referencing a missing/wrong route portal.case.show

### DIFF
--- a/app-modules/case-management/src/Notifications/Concerns/HandlesCaseTemplateContent.php
+++ b/app-modules/case-management/src/Notifications/Concerns/HandlesCaseTemplateContent.php
@@ -109,9 +109,13 @@ trait HandlesCaseTemplateContent
                 $block['type'] === 'tiptapBlock' &&
                 ($block['attrs']['type'] ?? null) === 'caseTypeEmailTemplateButtonBlock'
             ) {
-                $block['attrs']['data']['url'] = $urlType == CaseTypeEmailTemplateRole::Customer ? route('portal.case.show', $this->case) : CaseResource::getUrl('view', [
-                    'record' => $this->case,
-                ]);
+                $block['attrs']['data']['url'] = $urlType == CaseTypeEmailTemplateRole::Customer
+                    ? null
+                    // This can be restored if/when we add case management to the portal
+                    // ? route('portal.case.show', $this->case)
+                    : CaseResource::getUrl('view', [
+                        'record' => $this->case,
+                    ]);
             }
 
             if (

--- a/app-modules/case-management/src/Notifications/EducatableCaseAssignedNotification.php
+++ b/app-modules/case-management/src/Notifications/EducatableCaseAssignedNotification.php
@@ -88,8 +88,9 @@ class EducatableCaseAssignedNotification extends Notification implements ShouldQ
                 ->settings($this->resolveNotificationSetting($notifiable))
                 ->subject("Your case {$this->case->case_number} has been assigned to agent")
                 ->greeting("Hello {$name},")
-                ->line("We’ve assigned an agent to your case {$this->case->case_number}. They will review it and follow up shortly.")
-                ->action('View case', route('portal.case.show', $this->case));
+                ->line("We've assigned an agent to your case {$this->case->case_number}. They will review it and follow up shortly.");
+            // This can be restored if/when we add case management to the portal
+            // ->action('View case', route('portal.case.show', $this->case));
         }
 
         $subject = $this->getSubject($template->subject);

--- a/app-modules/case-management/src/Notifications/EducatableCaseStatusChangeNotification.php
+++ b/app-modules/case-management/src/Notifications/EducatableCaseStatusChangeNotification.php
@@ -88,8 +88,9 @@ class EducatableCaseStatusChangeNotification extends Notification implements Sho
                 ->settings($this->resolveNotificationSetting($notifiable))
                 ->subject("Status update: Case {$this->case->case_number} is now {$this->case->status?->name}")
                 ->greeting("Hello {$name},")
-                ->line("The status of your case {$this->case->case_number} has been updated to: {$this->case->status?->name}.")
-                ->action('View Case', route('portal.case.show', $this->case));
+                ->line("The status of your case {$this->case->case_number} has been updated to: {$this->case->status?->name}.");
+            // This can be restored if/when we add case management to the portal
+            // ->action('View Case', route('portal.case.show', $this->case));
         }
 
         $subject = $this->getSubject($template->subject);

--- a/app-modules/case-management/src/Notifications/EducatableCaseUpdatedNotification.php
+++ b/app-modules/case-management/src/Notifications/EducatableCaseUpdatedNotification.php
@@ -88,8 +88,9 @@ class EducatableCaseUpdatedNotification extends Notification implements ShouldQu
                 ->settings($this->resolveNotificationSetting($notifiable))
                 ->subject("There’s an update on your case {$this->case->case_number}")
                 ->greeting("Hello {$name},")
-                ->line("There’s been a new update to your case {$this->case->case_number}. Please check the latest details.")
-                ->action('View case', route('portal.case.show', $this->case));
+                ->line("There’s been a new update to your case {$this->case->case_number}. Please check the latest details.");
+            // This can be restored if/when we add case management to the portal
+            // ->action('View case', route('portal.case.show', $this->case));
         }
 
         $subject = $this->getSubject($template->subject);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2042

### Technical Description

Some routes were added when we duplicated some functionality from Aiding App. These routes do not currently exist in Advising App and so therefore throw errors if called.

Decided to comment them out for now instead of deleting them as they may very well be added in the near future.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

_______________________________________________

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
