### PR TITLE
[ADVAPP-2579]: Enhance enterprise AI features by including web search when helpful

### DIFF
--- a/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
+++ b/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
@@ -188,6 +188,14 @@ abstract class BaseOpenAiService implements AiService
         try {
             $vectorStoreId = $this->getReadyVectorStoreId($files, $filesContext);
 
+            $tools = [
+                ...filled($vectorStoreId) ? [[
+                    'type' => 'file_search',
+                    'vector_store_ids' => [$vectorStoreId],
+                ]] : [],
+                ['type' => 'web_search'],
+            ];
+
             $request = Prism::text()
                 ->using('azure_open_ai', $this->getModel())
                 ->withClientOptions([
@@ -198,12 +206,7 @@ abstract class BaseOpenAiService implements AiService
                 ->withProviderOptions([
                     'instructions' => $prompt,
                     'truncation' => 'auto',
-                    ...(filled($vectorStoreId) ? [
-                        'tools' => [[
-                            'type' => 'file_search',
-                            'vector_store_ids' => [$vectorStoreId],
-                        ]],
-                    ] : []),
+                    'tools' => $tools,
                     ...$options,
                 ])
                 ->withPrompt($content)
@@ -317,6 +320,17 @@ abstract class BaseOpenAiService implements AiService
         try {
             $vectorStoreId = $this->getReadyVectorStoreId($files, $filesContext);
 
+            $tools = [
+                ...filled($vectorStoreId) ? [[
+                    'type' => 'file_search',
+                    'vector_store_ids' => [$vectorStoreId],
+                ]] : [],
+                ...$hasImageGeneration ? [[
+                    'type' => 'image_generation',
+                ]] : [],
+                ['type' => 'web_search'],
+            ];
+
             $request = Prism::text()
                 ->using('azure_open_ai', $this->getModel())
                 ->withClientOptions([
@@ -328,17 +342,7 @@ abstract class BaseOpenAiService implements AiService
                 ->withProviderOptions([
                     ...(filled($prompt) ? ['instructions' => $prompt] : []),
                     'truncation' => 'auto',
-                    ...((filled($vectorStoreId) || $hasImageGeneration) ? [
-                        'tools' => [
-                            ...filled($vectorStoreId) ? [[
-                                'type' => 'file_search',
-                                'vector_store_ids' => [$vectorStoreId],
-                            ]] : [],
-                            ...$hasImageGeneration ? [[
-                                'type' => 'image_generation',
-                            ]] : [],
-                        ],
-                    ] : []),
+                    'tools' => $tools,
                     ...$options,
                 ]);
 
@@ -811,6 +815,18 @@ abstract class BaseOpenAiService implements AiService
                 ], $message->thread->assistant),
             ]));
 
+            $tools = [
+                ...filled($vectorStoreIds) ? [[
+                    'type' => 'file_search',
+                    'vector_store_ids' => $vectorStoreIds,
+                ]] : [],
+                ...$hasImageGeneration ? [[
+                    'type' => 'image_generation',
+                    'output_format' => 'jpeg',
+                ]] : [],
+                ['type' => 'web_search'],
+            ];
+
             return $this->streamRaw(
                 prompt: $this->hasReasoning() ? null : $instructions,
                 options: [
@@ -820,18 +836,7 @@ abstract class BaseOpenAiService implements AiService
                             'effort' => $aiSettings->reasoning_effort->value,
                         ],
                     ] : []),
-                    ...((filled($vectorStoreIds) || $hasImageGeneration) ? [
-                        'tools' => [
-                            ...filled($vectorStoreIds) ? [[
-                                'type' => 'file_search',
-                                'vector_store_ids' => $vectorStoreIds,
-                            ]] : [],
-                            ...$hasImageGeneration ? [[
-                                'type' => 'image_generation',
-                                'output_format' => 'jpeg',
-                            ]] : [],
-                        ],
-                    ] : []),
+                    'tools' => $tools,
                 ],
                 messages: [
                     ...$previousMessages,

--- a/app-modules/integration-open-ai/src/Services/BaseOpenAiService/Concerns/InteractsWithResearchRequests.php
+++ b/app-modules/integration-open-ai/src/Services/BaseOpenAiService/Concerns/InteractsWithResearchRequests.php
@@ -76,10 +76,13 @@ trait InteractsWithResearchRequests
                 ]),
             ]),
             providerOptions: [
-                'tools' => [[
-                    'type' => 'file_search',
-                    'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
-                ]],
+                'tools' => [
+                    [
+                        'type' => 'file_search',
+                        'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
+                    ],
+                    ['type' => 'web_search'],
+                ],
             ],
         )['description'] ?? [];
     }
@@ -165,10 +168,13 @@ trait InteractsWithResearchRequests
                 'requiredFields' => ['abstract', 'introduction', 'sections', 'conclusion'],
             ]),
             providerOptions: [
-                'tools' => [[
-                    'type' => 'file_search',
-                    'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
-                ]],
+                'tools' => [
+                    [
+                        'type' => 'file_search',
+                        'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
+                    ],
+                    ['type' => 'web_search'],
+                ],
             ],
             responseId: $responseId,
         );
@@ -197,10 +203,13 @@ trait InteractsWithResearchRequests
                     'deployment' => $this->getDeployment(),
                 ])
                 ->withProviderOptions([
-                    'tools' => [[
-                        'type' => 'file_search',
-                        'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
-                    ]],
+                    'tools' => [
+                        [
+                            'type' => 'file_search',
+                            'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
+                        ],
+                        ['type' => 'web_search'],
+                    ],
                     'truncation' => 'auto',
                     ...$options,
                 ])

--- a/app-modules/integration-open-ai/src/Services/BaseOpenAiService/Concerns/InteractsWithResearchRequests.php
+++ b/app-modules/integration-open-ai/src/Services/BaseOpenAiService/Concerns/InteractsWithResearchRequests.php
@@ -76,13 +76,10 @@ trait InteractsWithResearchRequests
                 ]),
             ]),
             providerOptions: [
-                'tools' => [
-                    [
-                        'type' => 'file_search',
-                        'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
-                    ],
-                    ['type' => 'web_search'],
-                ],
+                'tools' => [[
+                    'type' => 'file_search',
+                    'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
+                ]],
             ],
         )['description'] ?? [];
     }
@@ -168,13 +165,10 @@ trait InteractsWithResearchRequests
                 'requiredFields' => ['abstract', 'introduction', 'sections', 'conclusion'],
             ]),
             providerOptions: [
-                'tools' => [
-                    [
-                        'type' => 'file_search',
-                        'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
-                    ],
-                    ['type' => 'web_search'],
-                ],
+                'tools' => [[
+                    'type' => 'file_search',
+                    'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
+                ]],
             ],
             responseId: $responseId,
         );
@@ -203,13 +197,10 @@ trait InteractsWithResearchRequests
                     'deployment' => $this->getDeployment(),
                 ])
                 ->withProviderOptions([
-                    'tools' => [
-                        [
-                            'type' => 'file_search',
-                            'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
-                        ],
-                        ['type' => 'web_search'],
-                    ],
+                    'tools' => [[
+                        'type' => 'file_search',
+                        'vector_store_ids' => $this->getReadyResearchRequestVectorStoreIds($researchRequest),
+                    ]],
                     'truncation' => 'auto',
                     ...$options,
                 ])

--- a/app-modules/integration-open-ai/tests/Tenant/Feature/Services/OpenAiGptTestServiceTest.php
+++ b/app-modules/integration-open-ai/tests/Tenant/Feature/Services/OpenAiGptTestServiceTest.php
@@ -45,11 +45,13 @@ use AdvisingApp\IntegrationOpenAi\Models\OpenAiVectorStore;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGptTestService;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Jobs\RecordTrackedEvent;
+use AdvisingApp\Research\Models\ResearchRequest;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Prism;
+use Prism\Prism\Testing\StructuredResponseFake;
 use Prism\Prism\Testing\TextResponseFake;
 
 use function Tests\asSuperAdmin;
@@ -89,6 +91,95 @@ it('can send a message', function () {
         ->toHaveCount(1)
         ->each
         ->toHaveProperties(['type' => TrackedEventType::AiExchange]);
+});
+
+it('includes the web_search tool on every outbound message', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $service = app(OpenAiGptTestService::class);
+
+    $message = AiMessage::factory()
+        ->for(AiThread::factory()
+            ->for(AiAssistant::factory()->state([
+                'application' => AiAssistantApplication::PersonalAssistant,
+                'is_default' => true,
+                'model' => AiModel::OpenAiGptTest,
+            ]), 'assistant')
+            ->for(auth()->user()), 'thread')
+        ->make();
+
+    $fake = Prism::fake([
+        TextResponseFake::make()
+            ->withText(strrev($message->content))
+            ->withFinishReason(FinishReason::Stop),
+    ]);
+
+    $stream = $service->sendMessage($message, files: []);
+
+    iterator_to_array($stream());
+
+    $fake->assertRequest(function (array $requests) {
+        expect($requests)->toHaveCount(1);
+
+        $tools = $requests[0]->providerOptions('tools');
+
+        expect($tools)->toBeArray();
+        expect(array_column($tools, 'type'))->toContain('web_search');
+    });
+});
+
+it('includes the web_search tool when streaming a prompt', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $service = app(OpenAiGptTestService::class);
+
+    $fake = Prism::fake([
+        TextResponseFake::make()
+            ->withText(Str::random())
+            ->withFinishReason(FinishReason::Stop),
+    ]);
+
+    $stream = $service->stream(Str::random(), Str::random(), files: []);
+
+    iterator_to_array($stream());
+
+    $fake->assertRequest(function (array $requests) {
+        expect($requests)->toHaveCount(1);
+
+        $tools = $requests[0]->providerOptions('tools');
+
+        expect($tools)->toBeArray();
+        expect(array_column($tools, 'type'))->toContain('web_search');
+    });
+});
+
+it('includes the web_search tool when generating research request search queries', function () {
+    asSuperAdmin();
+
+    $service = app(OpenAiGptTestService::class);
+
+    $researchRequest = ResearchRequest::factory()->create();
+
+    $fake = Prism::fake([
+        StructuredResponseFake::make()
+            ->withStructured(['description' => []])
+            ->withFinishReason(FinishReason::Stop),
+    ]);
+
+    $service->getResearchRequestRequestSearchQueries($researchRequest, Str::random(), Str::random());
+
+    $fake->assertRequest(function (array $requests) {
+        expect($requests)->toHaveCount(1);
+
+        $tools = $requests[0]->providerOptions('tools');
+
+        expect($tools)->toBeArray();
+        expect(array_column($tools, 'type'))->toContain('web_search');
+    });
 });
 
 it('can complete a message response', function () {

--- a/app-modules/integration-open-ai/tests/Tenant/Feature/Services/OpenAiGptTestServiceTest.php
+++ b/app-modules/integration-open-ai/tests/Tenant/Feature/Services/OpenAiGptTestServiceTest.php
@@ -45,13 +45,11 @@ use AdvisingApp\IntegrationOpenAi\Models\OpenAiVectorStore;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGptTestService;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Jobs\RecordTrackedEvent;
-use AdvisingApp\Research\Models\ResearchRequest;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
 use Prism\Prism\Enums\FinishReason;
 use Prism\Prism\Prism;
-use Prism\Prism\Testing\StructuredResponseFake;
 use Prism\Prism\Testing\TextResponseFake;
 
 use function Tests\asSuperAdmin;
@@ -146,31 +144,6 @@ it('includes the web_search tool when streaming a prompt', function () {
     $stream = $service->stream(Str::random(), Str::random(), files: []);
 
     iterator_to_array($stream());
-
-    $fake->assertRequest(function (array $requests) {
-        expect($requests)->toHaveCount(1);
-
-        $tools = $requests[0]->providerOptions('tools');
-
-        expect($tools)->toBeArray();
-        expect(array_column($tools, 'type'))->toContain('web_search');
-    });
-});
-
-it('includes the web_search tool when generating research request search queries', function () {
-    asSuperAdmin();
-
-    $service = app(OpenAiGptTestService::class);
-
-    $researchRequest = ResearchRequest::factory()->create();
-
-    $fake = Prism::fake([
-        StructuredResponseFake::make()
-            ->withStructured(['description' => []])
-            ->withFinishReason(FinishReason::Stop),
-    ]);
-
-    $service->getResearchRequestRequestSearchQueries($researchRequest, Str::random(), Str::random());
 
     $fake->assertRequest(function (array $requests) {
         expect($requests)->toHaveCount(1);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2579

### Technical Description

> Enable web_search tool on OpenAI Responses for enterprise AI. Adds the Azure OpenAI web_search tool alongside the existing file_search tool across all Responses API call sites in BaseOpenAiService (stream, streamRaw, sendNewMessage). Unlike file_search, web_search is unconditional and does not depend on a vector store being present.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
