### PR TITLE
[ADVAPP-2575]: Enhance enterprise AI by extending configuration support for GPT 5.4 mini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,3 +174,7 @@ OPEN_AI_GPT_5_MINI_MODEL=
 OPEN_AI_GPT_5_NANO_BASE_URI=https://cgbs-partner-canyon-dev-east-2.openai.azure.com/openai/v1
 OPEN_AI_GPT_5_NANO_API_KEY=
 OPEN_AI_GPT_5_NANO_MODEL=
+
+OPEN_AI_GPT_54_MINI_BASE_URI=https://cgbs-partner-canyon-dev-east-2.openai.azure.com/openai/v1
+OPEN_AI_GPT_54_MINI_API_KEY=
+OPEN_AI_GPT_54_MINI_MODEL=

--- a/app-modules/ai/database/migrations/2026_04_17_145455_add_gpt_54_mini_settings.php
+++ b/app-modules/ai/database/migrations/2026_04_17_145455_add_gpt_54_mini_settings.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Features\Gpt54MiniFeature;
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class() extends SettingsMigration {
+    public function up(): void
+    {
+        DB::transaction(function () {
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_mini_model_name');
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_mini_base_uri', config('integration-open-ai.gpt_54_mini_base_uri'), encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_mini_api_key', config('integration-open-ai.gpt_54_mini_api_key'), encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_mini_model', config('integration-open-ai.gpt_54_mini_model'), encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_mini_applicable_features', []);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            Gpt54MiniFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Gpt54MiniFeature::deactivate();
+
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_mini_base_uri');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_mini_api_key');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_mini_model');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_mini_applicable_features');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_mini_model_name');
+        });
+    }
+};

--- a/app-modules/ai/database/migrations/2026_04_17_145455_add_gpt_54_mini_settings.php
+++ b/app-modules/ai/database/migrations/2026_04_17_145455_add_gpt_54_mini_settings.php
@@ -39,7 +39,7 @@ return new class () extends SettingsMigration {
             }
 
             try {
-                $this->migrator->add('ai.open_ai_gpt_54_mini_image_generation_deployment', true);
+                $this->migrator->add('ai.open_ai_gpt_54_mini_image_generation_deployment', encrypted: true);
             } catch (SettingAlreadyExists $exception) {
                 // do nothing
             }

--- a/app-modules/ai/database/migrations/2026_04_17_145455_add_gpt_54_mini_settings.php
+++ b/app-modules/ai/database/migrations/2026_04_17_145455_add_gpt_54_mini_settings.php
@@ -4,7 +4,7 @@ use App\Features\Gpt54MiniFeature;
 use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
-return new class() extends SettingsMigration {
+return new class () extends SettingsMigration {
     public function up(): void
     {
         DB::transaction(function () {
@@ -38,6 +38,12 @@ return new class() extends SettingsMigration {
                 // do nothing
             }
 
+            try {
+                $this->migrator->add('ai.open_ai_gpt_54_mini_image_generation_deployment', true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
             Gpt54MiniFeature::activate();
         });
     }
@@ -52,6 +58,7 @@ return new class() extends SettingsMigration {
             $this->migrator->deleteIfExists('ai.open_ai_gpt_54_mini_model');
             $this->migrator->deleteIfExists('ai.open_ai_gpt_54_mini_applicable_features');
             $this->migrator->deleteIfExists('ai.open_ai_gpt_54_mini_model_name');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_54_mini_image_generation_deployment');
         });
     }
 };

--- a/app-modules/ai/database/migrations/2026_04_17_145455_add_gpt_54_mini_settings.php
+++ b/app-modules/ai/database/migrations/2026_04_17_145455_add_gpt_54_mini_settings.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\Gpt54MiniFeature;
 use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;

--- a/app-modules/ai/src/Enums/AiModel.php
+++ b/app-modules/ai/src/Enums/AiModel.php
@@ -43,6 +43,7 @@ use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt41MiniService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt41NanoService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt4oMiniService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt4oService;
+use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt54MiniService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt5MiniService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt5NanoService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt5Service;
@@ -70,6 +71,8 @@ enum AiModel: string implements HasLabel
 
     case OpenAiGpt5Mini = 'openai_gpt_5_mini';
 
+    case OpenAiGpt54Mini = 'openai_gpt_54_mini';
+
     case OpenAiGpt5Nano = 'openai_gpt_5_nano';
 
     case OpenAiGptTest = 'openai_gpt_test';
@@ -93,6 +96,7 @@ enum AiModel: string implements HasLabel
             self::OpenAiGptO4Mini => $aiIntegrationSettings->open_ai_gpt_o4_mini_model_name ?? 'Canyon o4 mini',
             self::OpenAiGpt5 => $aiIntegrationSettings->open_ai_gpt_5_model_name ?? 'Canyon 5',
             self::OpenAiGpt5Mini => $aiIntegrationSettings->open_ai_gpt_5_mini_model_name ?? 'Canyon 5 mini',
+            self::OpenAiGpt54Mini => $aiIntegrationSettings->open_ai_gpt_54_mini_model_name ?? 'Canyon 5.4 mini',
             self::OpenAiGpt5Nano => $aiIntegrationSettings->open_ai_gpt_5_nano_model_name ?? 'Canyon 5 nano',
             self::JinaDeepSearchV1 => $aiIntegrationSettings->jina_deepsearch_v1_model_name ?? 'Canyon Deep Search',
             self::LlamaParse => $aiIntegrationSettings->llamaparse_model_name ?? 'Canyon Parsing Service',
@@ -117,6 +121,7 @@ enum AiModel: string implements HasLabel
             self::OpenAiGptO4Mini => $aiIntegrationSettings->open_ai_gpt_o4_mini_applicable_features,
             self::OpenAiGpt5 => $aiIntegrationSettings->open_ai_gpt_5_applicable_features,
             self::OpenAiGpt5Mini => $aiIntegrationSettings->open_ai_gpt_5_mini_applicable_features,
+            self::OpenAiGpt54Mini => $aiIntegrationSettings->open_ai_gpt_54_mini_applicable_features,
             self::OpenAiGpt5Nano => $aiIntegrationSettings->open_ai_gpt_5_nano_applicable_features,
             self::JinaDeepSearchV1 => $aiIntegrationSettings->jina_deepsearch_v1_applicable_features,
             self::LlamaParse => [],
@@ -150,6 +155,7 @@ enum AiModel: string implements HasLabel
             self::OpenAiGpt5 => OpenAiGpt5Service::class,
             self::OpenAiGpt5Mini => OpenAiGpt5MiniService::class,
             self::OpenAiGpt5Nano => OpenAiGpt5NanoService::class,
+            self::OpenAiGpt54Mini => OpenAiGpt54MiniService::class,
             self::OpenAiGptTest => OpenAiGptTestService::class,
             self::Test => TestAiService::class,
             default => throw new Exception('No Service class found for this model.'),

--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
@@ -346,7 +346,7 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->options(AiModelApplicabilityFeature::class)
                                     ->multiple()
                                     ->nestedRecursiveRules([Rule::enum(AiModelApplicabilityFeature::class)]),
-                            ])->visible(fn() => Gpt54MiniFeature::active()),
+                            ])->visible(fn () => Gpt54MiniFeature::active()),
                     ]),
                 Section::make('Jina AI')
                     ->collapsible()

--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Ai\Filament\Pages;
 
 use AdvisingApp\Ai\Enums\AiModelApplicabilityFeature;
 use AdvisingApp\Ai\Settings\AiIntegrationsSettings;
+use App\Features\Gpt54MiniFeature;
 use App\Filament\Clusters\GlobalArtificialIntelligence;
 use App\Models\User;
 use Filament\Forms\Components\Select;
@@ -319,6 +320,33 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                     ->multiple()
                                     ->nestedRecursiveRules([Rule::enum(AiModelApplicabilityFeature::class)]),
                             ]),
+                        Section::make('GPT 5.4 mini')
+                            ->collapsible()
+                            ->schema([
+                                TextInput::make('open_ai_gpt_54_mini_model_name')
+                                    ->label('Model Name')
+                                    ->placeholder('Canyon 5.4 mini')
+                                    ->string()
+                                    ->maxLength(255)
+                                    ->nullable(),
+                                TextInput::make('open_ai_gpt_54_mini_base_uri')
+                                    ->label('Base URI')
+                                    ->placeholder('https://example.openai.azure.com/openai')
+                                    ->url(),
+                                TextInput::make('open_ai_gpt_54_mini_api_key')
+                                    ->label('API Key')
+                                    ->password()
+                                    ->autocomplete(false),
+                                TextInput::make('open_ai_gpt_54_mini_model')
+                                    ->label('Model'),
+                                TextInput::make('open_ai_gpt_54_mini_image_generation_deployment')
+                                    ->label('Image generation model'),
+                                Select::make('open_ai_gpt_54_mini_applicable_features')
+                                    ->label('Applicability')
+                                    ->options(AiModelApplicabilityFeature::class)
+                                    ->multiple()
+                                    ->nestedRecursiveRules([Rule::enum(AiModelApplicabilityFeature::class)]),
+                            ])->visible(fn() => Gpt54MiniFeature::active()),
                     ]),
                 Section::make('Jina AI')
                     ->collapsible()

--- a/app-modules/ai/src/Settings/AiIntegrationsSettings.php
+++ b/app-modules/ai/src/Settings/AiIntegrationsSettings.php
@@ -247,6 +247,10 @@ class AiIntegrationsSettings extends Settings
             'open_ai_gpt_5_nano_api_key',
             'open_ai_gpt_5_nano_model',
             'open_ai_gpt_5_nano_image_generation_deployment',
+            'open_ai_gpt_54_mini_base_uri',
+            'open_ai_gpt_54_mini_api_key',
+            'open_ai_gpt_54_mini_model',
+            'open_ai_gpt_54_mini_image_generation_deployment',
             'jina_deepsearch_v1_api_key',
             'llamaparse_api_key',
         ];

--- a/app-modules/ai/src/Settings/AiIntegrationsSettings.php
+++ b/app-modules/ai/src/Settings/AiIntegrationsSettings.php
@@ -170,6 +170,21 @@ class AiIntegrationsSettings extends Settings
 
     public ?string $open_ai_gpt_5_nano_image_generation_deployment = null;
 
+    public ?string $open_ai_gpt_54_mini_model_name = null;
+
+    public ?string $open_ai_gpt_54_mini_base_uri = null;
+
+    public ?string $open_ai_gpt_54_mini_api_key = null;
+
+    public ?string $open_ai_gpt_54_mini_model = null;
+
+    public ?string $open_ai_gpt_54_mini_image_generation_deployment = null;
+
+    /**
+     * @var array<string>
+     */
+    public array $open_ai_gpt_54_mini_applicable_features = [];
+
     /**
      * @var array<string>
      */

--- a/app-modules/integration-open-ai/config/integration-open-ai.php
+++ b/app-modules/integration-open-ai/config/integration-open-ai.php
@@ -100,4 +100,10 @@ return [
     'gpt_5_nano_api_key' => env('OPEN_AI_GPT_5_NANO_API_KEY'),
 
     'gpt_5_nano_model' => env('OPEN_AI_GPT_5_NANO_MODEL'),
+
+    'gpt_54_mini_base_uri' => env('OPEN_AI_GPT_54_MINI_BASE_URI'),
+
+    'gpt_54_mini_api_key' => env('OPEN_AI_GPT_54_MINI_API_KEY'),
+
+    'gpt_54_mini_model' => env('OPEN_AI_GPT_54_MINI_MODEL'),
 ];

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt54MiniService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt54MiniService.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\IntegrationOpenAi\Services;
+
+class OpenAiGpt54MiniService extends BaseOpenAiService
+{
+    public function getApiKey(): string
+    {
+        return $this->settings->open_ai_gpt_54_mini_api_key ?? config('integration-open-ai.gpt_54_mini_api_key');
+    }
+
+    public function getModel(): string
+    {
+        return $this->settings->open_ai_gpt_54_mini_model ?? config('integration-open-ai.gpt_54_mini_model');
+    }
+
+    public function getDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_54_mini_base_uri ?? config('integration-open-ai.gpt_54_mini_base_uri');
+    }
+
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_54_mini_image_generation_deployment;
+    }
+}

--- a/app/Features/Gpt54MiniFeature.php
+++ b/app/Features/Gpt54MiniFeature.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class Gpt54MiniFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Features/Gpt54MiniFeature.php
+++ b/app/Features/Gpt54MiniFeature.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2575

### Technical Description

> Enhance enterprise AI by extending configuration support for GPT 5.4 mini

### Any deployment steps required?

Add the following keys to the `.env.example` file:

```
OPEN_AI_GPT_54_MINI_BASE_URI=
OPEN_AI_GPT_54_MINI_API_KEY=
OPEN_AI_GPT_54_MINI_MODEL=

```


### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> Yes, `Gpt54MiniFeature`

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
