### PR TITLE
[ADVAPP-2588]: Ensure the user lands on the initial page they attempted to navigate to when visiting a link when first unauthenticated

### DIFF
--- a/app-modules/authorization/src/Filament/Pages/Auth/Login.php
+++ b/app-modules/authorization/src/Filament/Pages/Auth/Login.php
@@ -195,7 +195,7 @@ class Login extends \Filament\Auth\Pages\Login
 
                 session()->regenerate();
 
-                redirect()->route('filament.admin.pages.dashboard');
+                redirect()->intended(Filament::getUrl());
             });
     }
 

--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -56,12 +56,18 @@ class SocialiteController extends Controller
 {
     public function redirect(SocialiteProvider $provider, Request $request)
     {
+        $intendedUrl = $request->session()->pull('url.intended');
+
         // Regenerate session and logout user to try to fix InvalidStateException
         if ($request->hasSession()) {
             $request->session()->regenerate(true);
         }
 
         auth()->guard('web')->logout();
+
+        if ($intendedUrl) {
+            $request->session()->put('url.intended', $intendedUrl);
+        }
 
         $driver = $provider->driver()
             ->setConfig($provider->config());
@@ -133,6 +139,6 @@ class SocialiteController extends Controller
 
         session(['auth_via' => $provider]);
 
-        return redirect()->to(Filament::getUrl());
+        return redirect()->intended(Filament::getUrl());
     }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2588

### Technical Description

Use `redirect()->intended()` after authentication (passing in a fallback URL if there is no intended URL). Before regenerating sessions during the login process, persist the intended URL from the old to the new session to ensure that it doesn't get lost.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
