### PR TITLE
[ADVAPP-2585]: Some users have reported that the Form request flow in the Student/Prospect holistic profiles do not have all fields properly required

### DIFF
--- a/app-modules/form/src/Filament/Actions/RequestFormSubmission.php
+++ b/app-modules/form/src/Filament/Actions/RequestFormSubmission.php
@@ -59,6 +59,7 @@ class RequestFormSubmission extends Action
                 ->schema([
                     Select::make('form_id')
                         ->label('Form')
+                        ->required()
                         ->options(fn (): array => Form::query()
                             ->where('is_authenticated', true)
                             ->limit(50)

--- a/app-modules/form/tests/Tenant/Filament/Actions/RequestFormSubmissionTest.php
+++ b/app-modules/form/tests/Tenant/Filament/Actions/RequestFormSubmissionTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of

--- a/app-modules/form/tests/Tenant/Filament/Actions/RequestFormSubmissionTest.php
+++ b/app-modules/form/tests/Tenant/Filament/Actions/RequestFormSubmissionTest.php
@@ -1,0 +1,377 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\Form\Actions\DeliverFormSubmissionRequestByEmail;
+use AdvisingApp\Form\Actions\DeliverFormSubmissionRequestBySms;
+use AdvisingApp\Form\Enums\FormSubmissionRequestDeliveryMethod;
+use AdvisingApp\Form\Models\Form;
+use AdvisingApp\Form\Models\FormSubmission;
+use AdvisingApp\StudentDataModel\Filament\Resources\Students\Pages\ViewStudent;
+use AdvisingApp\StudentDataModel\Filament\Resources\Students\RelationManagers\FormSubmissionsRelationManager;
+use AdvisingApp\StudentDataModel\Models\Student;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('requires form_id to submit the request', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => null,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Email->value,
+        ])
+        ->assertHasTableActionErrors(['form_id' => 'required']);
+});
+
+it('can request a form submission via email', function () {
+    Queue::fake();
+
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    asSuperAdmin($user);
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Email->value,
+            'request_note' => 'Please fill out this form.',
+        ])
+        ->assertHasNoTableActionErrors();
+
+    $submission = $student->formSubmissions()->first();
+
+    expect($submission)->not->toBeNull()
+        ->and($submission->form_id)->toBe($form->id)
+        ->and($submission->request_method)->toBe(FormSubmissionRequestDeliveryMethod::Email)
+        ->and($submission->request_note)->toBe('Please fill out this form.')
+        ->and($submission->requester_id)->toBe($user->id)
+        ->and($submission->submitted_at)->toBeNull()
+        ->and($submission->canceled_at)->toBeNull();
+});
+
+it('can request a form submission via sms', function () {
+    Queue::fake();
+
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    asSuperAdmin($user);
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Sms->value,
+            'request_note' => 'Please complete this survey.',
+        ])
+        ->assertHasNoTableActionErrors();
+
+    $submission = $student->formSubmissions()->first();
+
+    expect($submission)->not->toBeNull()
+        ->and($submission->request_method)->toBe(FormSubmissionRequestDeliveryMethod::Sms);
+});
+
+it('defaults request_method to email', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+        ])
+        ->assertHasNoTableActionErrors();
+
+    $submission = $student->formSubmissions()->first();
+
+    expect($submission)->not->toBeNull()
+        ->and($submission->request_method)->toBe(FormSubmissionRequestDeliveryMethod::Email);
+});
+
+it('allows request_note to be optional', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Email->value,
+            'request_note' => null,
+        ])
+        ->assertHasNoTableActionErrors();
+
+    $submission = $student->formSubmissions()->first();
+
+    expect($submission)->not->toBeNull()
+        ->and($submission->request_note)->toBeNull();
+});
+
+it('only lists forms with authentication enabled in the form select', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    Student::factory()->create();
+    $authenticatedForm = Form::factory()->create(['is_authenticated' => true]);
+    $unauthenticatedForm = Form::factory()->create(['is_authenticated' => false]);
+
+    $options = Form::query()
+        ->where('is_authenticated', true)
+        ->limit(50)
+        ->pluck('name', 'id')
+        ->all();
+
+    expect($options)->toHaveKey($authenticatedForm->id)
+        ->and($options)->not->toHaveKey($unauthenticatedForm->id);
+});
+
+it('reuses an existing requested submission for the same form instead of creating a new one', function () {
+    Queue::fake();
+
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    asSuperAdmin($user);
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    $existingSubmission = FormSubmission::factory()->create([
+        'form_id' => $form->id,
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => null,
+        'canceled_at' => null,
+        'request_method' => FormSubmissionRequestDeliveryMethod::Email,
+        'request_note' => 'Old note',
+    ]);
+    $existingSubmission->requester()->associate($user);
+    $existingSubmission->save();
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Sms->value,
+            'request_note' => 'Updated note',
+        ])
+        ->assertHasNoTableActionErrors();
+
+    expect($student->formSubmissions()->count())->toBe(1);
+
+    $submission = $student->formSubmissions()->first();
+
+    expect($submission->id)->toBe($existingSubmission->id)
+        ->and($submission->request_method)->toBe(FormSubmissionRequestDeliveryMethod::Sms)
+        ->and($submission->request_note)->toBe('Updated note');
+});
+
+it('creates a new submission when existing one is already submitted', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    FormSubmission::factory()->create([
+        'form_id' => $form->id,
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Email->value,
+        ])
+        ->assertHasNoTableActionErrors();
+
+    expect($student->formSubmissions()->count())->toBe(2);
+});
+
+it('creates a new submission when existing one is canceled', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    FormSubmission::factory()->create([
+        'form_id' => $form->id,
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => null,
+        'canceled_at' => now(),
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Email->value,
+        ])
+        ->assertHasNoTableActionErrors();
+
+    expect($student->formSubmissions()->count())->toBe(2);
+});
+
+it('associates the current authenticated user as the requester', function () {
+    Queue::fake();
+
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    asSuperAdmin($user);
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Email->value,
+        ])
+        ->assertHasNoTableActionErrors();
+
+    $submission = $student->formSubmissions()->first();
+
+    expect($submission->requester_id)->toBe($user->id)
+        ->and($submission->requester->is($user))->toBeTrue();
+});
+
+it('dispatches the delivery job after creating the submission', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Email->value,
+        ])
+        ->assertHasNoTableActionErrors();
+
+    Queue::assertPushed(DeliverFormSubmissionRequestByEmail::class);
+});
+
+it('dispatches the sms delivery job when sms method is selected', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Sms->value,
+        ])
+        ->assertHasNoTableActionErrors();
+
+    Queue::assertPushed(DeliverFormSubmissionRequestBySms::class);
+});
+
+it('sends a success notification after the request is sent', function () {
+    Queue::fake();
+
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+    $form = Form::factory()->create(['is_authenticated' => true]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction('Request', data: [
+            'form_id' => $form->id,
+            'request_method' => FormSubmissionRequestDeliveryMethod::Email->value,
+        ])
+        ->assertHasNoTableActionErrors()
+        ->assertNotified('Form request sent');
+});

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/Students/RelationManagers/FormSubmissionsRelationManagerTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/Students/RelationManagers/FormSubmissionsRelationManagerTest.php
@@ -1,0 +1,424 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Form\Enums\FormSubmissionRequestDeliveryMethod;
+use AdvisingApp\Form\Enums\FormSubmissionStatus;
+use AdvisingApp\Form\Models\Form;
+use AdvisingApp\Form\Models\FormSubmission;
+use AdvisingApp\StudentDataModel\Filament\Resources\Students\Pages\ViewStudent;
+use AdvisingApp\StudentDataModel\Filament\Resources\Students\RelationManagers\FormSubmissionsRelationManager;
+use AdvisingApp\StudentDataModel\Models\Student;
+use App\Models\User;
+use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\ViewAction;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('is hidden when the OnlineForms feature is disabled', function () {
+    $student = Student::factory()->create();
+
+    $licenseSettings = app(LicenseSettings::class);
+    $licenseSettings->data->addons->onlineForms = false;
+    $licenseSettings->save();
+
+    asSuperAdmin();
+
+    livewire(ViewStudent::class, [
+        'record' => $student->getKey(),
+    ])
+        ->assertOk()
+        ->assertDontSeeLivewire(FormSubmissionsRelationManager::class);
+});
+
+it('is visible when the OnlineForms feature is enabled', function () {
+    $student = Student::factory()->create();
+
+    $licenseSettings = app(LicenseSettings::class);
+    $licenseSettings->data->addons->onlineForms = true;
+    $licenseSettings->save();
+
+    asSuperAdmin();
+
+    livewire(ViewStudent::class, [
+        'record' => $student->getKey(),
+    ])
+        ->assertOk()
+        ->assertSeeLivewire(FormSubmissionsRelationManager::class);
+});
+
+it('can list form submissions for a student', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    $submissions = FormSubmission::factory()->count(3)->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->assertCanSeeTableRecords($submissions);
+});
+
+it('does not show submissions belonging to other students', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+    $otherStudent = Student::factory()->create();
+
+    $ownSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+    ]);
+
+    $otherSubmission = FormSubmission::factory()->create([
+        'author_type' => $otherStudent->getMorphClass(),
+        'author_id' => $otherStudent->getKey(),
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->assertCanSeeTableRecords([$ownSubmission])
+        ->assertCanNotSeeTableRecords([$otherSubmission]);
+});
+
+it('has the expected table columns', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->assertTableColumnExists('submissible.name')
+        ->assertTableColumnExists('status')
+        ->assertTableColumnExists('submitted_at')
+        ->assertTableColumnExists('requester.name')
+        ->assertTableColumnExists('requested_at');
+});
+
+it('can search submissions by form name', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    $matchingForm = Form::factory()->create(['name' => 'Enrollment Application']);
+    $nonMatchingForm = Form::factory()->create(['name' => 'Exit Survey']);
+
+    $matchingSubmission = FormSubmission::factory()->create([
+        'form_id' => $matchingForm->id,
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+    ]);
+
+    $nonMatchingSubmission = FormSubmission::factory()->create([
+        'form_id' => $nonMatchingForm->id,
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->searchTable('Enrollment')
+        ->assertCanSeeTableRecords([$matchingSubmission])
+        ->assertCanNotSeeTableRecords([$nonMatchingSubmission]);
+});
+
+it('can sort submissions by submitted_at', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    $olderSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => now()->subDays(5),
+    ]);
+
+    $newerSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->sortTable('submitted_at')
+        ->assertCanSeeTableRecords([$olderSubmission, $newerSubmission], inOrder: true)
+        ->sortTable('submitted_at', 'desc')
+        ->assertCanSeeTableRecords([$newerSubmission, $olderSubmission], inOrder: true);
+});
+
+it('can filter submissions by status', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    $requestedSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => null,
+        'canceled_at' => null,
+        'request_method' => FormSubmissionRequestDeliveryMethod::Email,
+    ]);
+
+    $submittedSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    $canceledSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => null,
+        'canceled_at' => now(),
+        'request_method' => FormSubmissionRequestDeliveryMethod::Email,
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->filterTable('status', FormSubmissionStatus::Requested->value)
+        ->assertCanSeeTableRecords([$requestedSubmission])
+        ->assertCanNotSeeTableRecords([$submittedSubmission, $canceledSubmission])
+        ->filterTable('status', FormSubmissionStatus::Submitted->value)
+        ->assertCanSeeTableRecords([$submittedSubmission])
+        ->assertCanNotSeeTableRecords([$requestedSubmission, $canceledSubmission])
+         ->filterTable('status', FormSubmissionStatus::Canceled->value)
+        ->assertCanSeeTableRecords([$canceledSubmission])
+        ->assertCanNotSeeTableRecords([$submittedSubmission, $requestedSubmission]);
+});
+
+it('shows the view action only for submitted submissions', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    $submittedSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    $requestedSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => null,
+        'canceled_at' => null,
+        'request_method' => FormSubmissionRequestDeliveryMethod::Email,
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->assertTableActionVisible(ViewAction::class, $submittedSubmission)
+        ->assertTableActionHidden(ViewAction::class, $requestedSubmission);
+});
+
+it('hides the view action for canceled submissions', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    $canceledSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => null,
+        'canceled_at' => now(),
+        'request_method' => FormSubmissionRequestDeliveryMethod::Email,
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->assertTableActionHidden(ViewAction::class, $canceledSubmission);
+});
+
+it('can delete a form submission', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    $submission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableAction(DeleteAction::class, $submission);
+
+    expect($student->formSubmissions()->count())->toBe(0);
+});
+
+it('has the bulk delete action available', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->assertTableBulkActionExists(DeleteBulkAction::class);
+});
+
+it('can bulk delete form submissions', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    $submissions = FormSubmission::factory()->count(3)->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->callTableBulkAction(DeleteBulkAction::class, $submissions);
+
+    expect($student->formSubmissions()->count())->toBe(0);
+});
+
+it('displays the requester name for submissions that have a requester', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+    $requester = User::factory()->create(['name' => 'John Requester']);
+
+    $submission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => null,
+        'canceled_at' => null,
+        'request_method' => FormSubmissionRequestDeliveryMethod::Email,
+    ]);
+    $submission->requester()->associate($requester);
+    $submission->save();
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->assertTableColumnStateSet('requester.name', 'John Requester', $submission);
+});
+
+it('shows requested_at only when a requester is present', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+    $requester = User::factory()->create();
+
+    $requestedSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => null,
+        'canceled_at' => null,
+        'request_method' => FormSubmissionRequestDeliveryMethod::Email,
+    ]);
+    $requestedSubmission->requester()->associate($requester);
+    $requestedSubmission->save();
+
+    $directSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->assertTableColumnStateNotSet('requested_at', null, $requestedSubmission)
+        ->assertTableColumnStateSet('requested_at', null, $directSubmission);
+});
+
+it('shows the correct status badge for each submission state', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    $requestedSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => null,
+        'canceled_at' => null,
+        'request_method' => FormSubmissionRequestDeliveryMethod::Email,
+    ]);
+
+    $submittedSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    $canceledSubmission = FormSubmission::factory()->create([
+        'author_type' => $student->getMorphClass(),
+        'author_id' => $student->getKey(),
+        'submitted_at' => null,
+        'canceled_at' => now(),
+        'request_method' => FormSubmissionRequestDeliveryMethod::Email,
+    ]);
+
+    livewire(FormSubmissionsRelationManager::class, [
+        'ownerRecord' => $student,
+        'pageClass' => ViewStudent::class,
+    ])
+        ->assertTableColumnStateSet('status', FormSubmissionStatus::Requested, $requestedSubmission)
+        ->assertTableColumnStateSet('status', FormSubmissionStatus::Submitted, $submittedSubmission)
+        ->assertTableColumnStateSet('status', FormSubmissionStatus::Canceled, $canceledSubmission);
+});

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/Students/RelationManagers/FormSubmissionsRelationManagerTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/Students/RelationManagers/FormSubmissionsRelationManagerTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of
@@ -232,7 +232,7 @@ it('can filter submissions by status', function () {
         ->filterTable('status', FormSubmissionStatus::Submitted->value)
         ->assertCanSeeTableRecords([$submittedSubmission])
         ->assertCanNotSeeTableRecords([$requestedSubmission, $canceledSubmission])
-         ->filterTable('status', FormSubmissionStatus::Canceled->value)
+        ->filterTable('status', FormSubmissionStatus::Canceled->value)
         ->assertCanSeeTableRecords([$canceledSubmission])
         ->assertCanNotSeeTableRecords([$submittedSubmission, $requestedSubmission]);
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2585

### Technical Description

> On Form Request in Prospect/Student Holistic page make Form select field required.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No
---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
