### PR TITLE
[ADVAPP-2610]: Improve the monitoring and deactivation of calendars when authorization is revoked during the event sync process

### DIFF
--- a/app-modules/meeting-center/database/factories/CalendarFactory.php
+++ b/app-modules/meeting-center/database/factories/CalendarFactory.php
@@ -53,6 +53,10 @@ class CalendarFactory extends Factory
         return [
             'provider_type' => CalendarProvider::Google,
             'provider_email' => $this->faker->safeEmail(),
+            'provider_id' => $this->faker->uuid(),
+            'oauth_token' => $this->faker->sha256(),
+            'oauth_refresh_token' => $this->faker->sha256(),
+            'oauth_token_expires_at' => now()->addHour(),
         ];
     }
 }

--- a/app-modules/meeting-center/resources/views/filament/components/disconnected-calendar-members.blade.php
+++ b/app-modules/meeting-center/resources/views/filament/components/disconnected-calendar-members.blade.php
@@ -1,3 +1,36 @@
+{{--
+    <COPYRIGHT>
+    
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+    
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+    
+    Notice:
+    
+    - You may not provide the software to third parties as a hosted or managed
+    service, where the service provides users with access to any substantial set of
+    the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+    in the software, and you may not remove or obscure any functionality in the
+    software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+    of the licensor in the software. Any use of the licensor’s trademarks is subject
+    to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+    same in return. Canyon GBS® and Advising App® are registered trademarks of
+    Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+    vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+    Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+    in the Elastic License 2.0.
+    
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+    
+    </COPYRIGHT>
+--}}
 <ul class="list-none space-y-1">
     @foreach ($directUsers as $user)
         <li>{{ $user->name }}</li>

--- a/app-modules/meeting-center/resources/views/filament/components/disconnected-calendar-members.blade.php
+++ b/app-modules/meeting-center/resources/views/filament/components/disconnected-calendar-members.blade.php
@@ -1,0 +1,16 @@
+<ul class="list-none space-y-1">
+    @foreach ($directUsers as $user)
+        <li>{{ $user->name }}</li>
+    @endforeach
+
+    @foreach ($teamGroups as $teamName => $users)
+        <li class="mt-2">
+            <strong>{{ $teamName }}</strong>
+            <ul class="list-none pl-4 mt-1 space-y-1">
+                @foreach ($users as $user)
+                    <li>{{ $user->name }}</li>
+                @endforeach
+            </ul>
+        </li>
+    @endforeach
+</ul>

--- a/app-modules/meeting-center/src/Actions/GetAvailableGroupAppointmentSlots.php
+++ b/app-modules/meeting-center/src/Actions/GetAvailableGroupAppointmentSlots.php
@@ -57,7 +57,7 @@ class GetAvailableGroupAppointmentSlots
         if ($forMember) {
             $members = collect([$forMember]);
         } else {
-            $members = $bookingGroup->allMembers();
+            $members = $bookingGroup->connectedMembers();
         }
 
         if ($members->isEmpty()) {

--- a/app-modules/meeting-center/src/Filament/Pages/ManagePersonalBookingPage.php
+++ b/app-modules/meeting-center/src/Filament/Pages/ManagePersonalBookingPage.php
@@ -90,7 +90,7 @@ class ManagePersonalBookingPage extends ProfilePage
         $hasHours = $this->userHasHoursConfigured($user);
         $bookingPage = PersonalBookingPage::query()->whereBelongsTo($user)->first();
         $hasCrmLicense = $user->hasAnyLicense([LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]);
-        $bookingPageEnabled = $bookingPage?->is_enabled ?? false;
+        $bookingPageEnabled = $bookingPage->is_enabled ?? false;
 
         return $schema
             ->columns(1)

--- a/app-modules/meeting-center/src/Filament/Pages/ManagePersonalBookingPage.php
+++ b/app-modules/meeting-center/src/Filament/Pages/ManagePersonalBookingPage.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\MeetingCenter\Filament\Pages;
 
 use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\MeetingCenter\Filament\Resources\CalendarEvents\CalendarEventResource;
 use AdvisingApp\MeetingCenter\Models\Calendar;
 use AdvisingApp\MeetingCenter\Models\PersonalBookingPage;
 use App\Filament\Forms\Components\DailyHoursRepeater;
@@ -49,6 +50,7 @@ use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Callout;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
@@ -84,18 +86,30 @@ class ManagePersonalBookingPage extends ProfilePage
     {
         $user = auth()->user();
         assert($user instanceof User);
-        $hasCalendar = Calendar::query()->whereBelongsTo($user)->exists();
+        $hasCalendar = Calendar::query()->whereBelongsTo($user)->whereNotNull('oauth_token')->exists();
         $hasHours = $this->userHasHoursConfigured($user);
         $bookingPage = PersonalBookingPage::query()->whereBelongsTo($user)->first();
         $hasCrmLicense = $user->hasAnyLicense([LicenseType::RetentionCrm, LicenseType::RecruitmentCrm]);
+        $bookingPageEnabled = $bookingPage?->is_enabled ?? false;
 
         return $schema
             ->columns(1)
             ->components([
+                Callout::make('Your calendar connection has been revoked.')
+                    ->danger()
+                    ->description('Your personal booking page has been temporarily disabled. Please reconnect your calendar to re-enable it.')
+                    ->actions([
+                        Action::make('reconnect_calendar')
+                            ->label('Reconnect your calendar')
+                            ->url(CalendarEventResource::getUrl())
+                            ->color('danger')
+                            ->outlined(),
+                    ])
+                    ->visible(! $hasCalendar && $bookingPageEnabled),
                 Section::make()
                     ->belowContent(
                         match (true) {
-                            ! $hasCalendar => 'This feature is only available if your Google or Outlook calendar is connected.',
+                            ! $hasCalendar && ! $bookingPageEnabled => 'This feature is only available if your Google or Outlook calendar is connected.',
                             ! $hasHours => 'This feature requires you to configure your office hours or working hours first.',
                             default => null,
                         }
@@ -270,7 +284,7 @@ class ManagePersonalBookingPage extends ProfilePage
         $user = auth()->user();
         assert($user instanceof User);
         $bookingPage = PersonalBookingPage::query()->whereBelongsTo($user)->first();
-        $hasCalendar = Calendar::query()->whereBelongsTo($user)->exists();
+        $hasCalendar = Calendar::query()->whereBelongsTo($user)->whereNotNull('oauth_token')->exists();
 
         if ($bookingPage) {
             return [

--- a/app-modules/meeting-center/src/Filament/Resources/BookingGroups/Pages/CreateBookingGroup.php
+++ b/app-modules/meeting-center/src/Filament/Resources/BookingGroups/Pages/CreateBookingGroup.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\MeetingCenter\Filament\Resources\BookingGroups\Pages;
 
 use AdvisingApp\MeetingCenter\Enums\BookingGroupBookWith;
 use AdvisingApp\MeetingCenter\Filament\Resources\BookingGroups\BookingGroupResource;
+use AdvisingApp\Team\Models\Team;
 use App\Filament\Forms\Components\DailyHoursRepeater;
 use App\Filament\Forms\Components\DurationInput;
 use App\Models\User;
@@ -48,11 +49,13 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Resources\Pages\CreateRecord;
+use Filament\Schemas\Components\Callout;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Js;
 use Illuminate\Support\Str;
 
@@ -141,7 +144,7 @@ class CreateBookingGroup extends CreateRecord
 
                                     $hasCalendar = User::query()
                                         ->whereKey($value)
-                                        ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('provider_id'))
+                                        ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
                                         ->exists();
 
                                     if (! $hasCalendar) {
@@ -150,6 +153,54 @@ class CreateBookingGroup extends CreateRecord
                                 };
                             },
                         ]),
+                    Callout::make('Some group members do not have a connected calendar and will be skipped during bookings.')
+                        ->warning()
+                        ->description(function (Get $get): HtmlString {
+                            $selectedUserIds = array_values(array_filter(is_array($get('users')) ? $get('users') : []));
+                            $selectedTeamIds = array_values(array_filter(is_array($get('teams')) ? $get('teams') : []));
+
+                            $directUsers = User::query()
+                                ->whereIn('id', $selectedUserIds)
+                                ->whereDoesntHave('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+                                ->orderBy('name')
+                                ->get();
+
+                            $teamGroups = collect();
+
+                            foreach (Team::query()->whereIn('id', $selectedTeamIds)->orderBy('name')->get() as $team) {
+                                $disconnected = User::query()
+                                    ->where('team_id', $team->id)
+                                    ->whereDoesntHave('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+                                    ->orderBy('name')
+                                    ->get();
+
+                                if ($disconnected->isNotEmpty()) {
+                                    $teamGroups->put($team->name, $disconnected);
+                                }
+                            }
+
+                            return new HtmlString(view('meeting-center::filament.components.disconnected-calendar-members', [
+                                'directUsers' => $directUsers,
+                                'teamGroups' => $teamGroups,
+                            ])->render());
+                        })
+                        ->visible(function (Get $get): bool {
+                            $selectedUserIds = array_values(array_filter(is_array($get('users')) ? $get('users') : []));
+                            $selectedTeamIds = array_values(array_filter(is_array($get('teams')) ? $get('teams') : []));
+
+                            if (User::query()
+                                ->whereIn('id', $selectedUserIds)
+                                ->whereDoesntHave('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+                                ->exists()) {
+                                return true;
+                            }
+
+                            return ! empty($selectedTeamIds) && User::query()
+                                ->whereIn('team_id', $selectedTeamIds)
+                                ->whereDoesntHave('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+                                ->exists();
+                        })
+                        ->columnSpanFull(),
                 ]),
             Section::make('Availability')
                 ->schema([

--- a/app-modules/meeting-center/src/Filament/Resources/BookingGroups/Pages/EditBookingGroup.php
+++ b/app-modules/meeting-center/src/Filament/Resources/BookingGroups/Pages/EditBookingGroup.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\MeetingCenter\Filament\Resources\BookingGroups\Pages;
 use AdvisingApp\MeetingCenter\Enums\BookingGroupBookWith;
 use AdvisingApp\MeetingCenter\Filament\Resources\BookingGroups\BookingGroupResource;
 use AdvisingApp\MeetingCenter\Models\BookingGroup;
+use AdvisingApp\Team\Models\Team;
 use App\Filament\Forms\Components\DailyHoursRepeater;
 use App\Filament\Forms\Components\DurationInput;
 use App\Filament\Resources\Pages\EditRecord\Concerns\EditPageRedirection;
@@ -52,11 +53,13 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Schemas\Components\Callout;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Js;
 use Illuminate\Support\Str;
 
@@ -72,10 +75,6 @@ class EditBookingGroup extends EditRecord
 
     public function form(Schema $schema): Schema
     {
-        $bookingGroup = $this->getRecord();
-
-        assert($bookingGroup instanceof BookingGroup);
-
         return $schema->components([
             Section::make('Booking Group Details')
                 ->schema([
@@ -155,7 +154,7 @@ class EditBookingGroup extends EditRecord
 
                                     $hasCalendar = User::query()
                                         ->whereKey($value)
-                                        ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('provider_id'))
+                                        ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
                                         ->exists();
 
                                     if (! $hasCalendar) {
@@ -164,6 +163,54 @@ class EditBookingGroup extends EditRecord
                                 };
                             },
                         ]),
+                    Callout::make('Some group members do not have a connected calendar and will be skipped during bookings.')
+                        ->warning()
+                        ->description(function (Get $get): HtmlString {
+                            $selectedUserIds = array_values(array_filter(is_array($get('users')) ? $get('users') : []));
+                            $selectedTeamIds = array_values(array_filter(is_array($get('teams')) ? $get('teams') : []));
+
+                            $directUsers = User::query()
+                                ->whereIn('id', $selectedUserIds)
+                                ->whereDoesntHave('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+                                ->orderBy('name')
+                                ->get();
+
+                            $teamGroups = collect();
+
+                            foreach (Team::query()->whereIn('id', $selectedTeamIds)->orderBy('name')->get() as $team) {
+                                $disconnected = User::query()
+                                    ->where('team_id', $team->id)
+                                    ->whereDoesntHave('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+                                    ->orderBy('name')
+                                    ->get();
+
+                                if ($disconnected->isNotEmpty()) {
+                                    $teamGroups->put($team->name, $disconnected);
+                                }
+                            }
+
+                            return new HtmlString(view('meeting-center::filament.components.disconnected-calendar-members', [
+                                'directUsers' => $directUsers,
+                                'teamGroups' => $teamGroups,
+                            ])->render());
+                        })
+                        ->visible(function (Get $get): bool {
+                            $selectedUserIds = array_values(array_filter(is_array($get('users')) ? $get('users') : []));
+                            $selectedTeamIds = array_values(array_filter(is_array($get('teams')) ? $get('teams') : []));
+
+                            if (User::query()
+                                ->whereIn('id', $selectedUserIds)
+                                ->whereDoesntHave('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+                                ->exists()) {
+                                return true;
+                            }
+
+                            return ! empty($selectedTeamIds) && User::query()
+                                ->whereIn('team_id', $selectedTeamIds)
+                                ->whereDoesntHave('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+                                ->exists();
+                        })
+                        ->columnSpanFull(),
                 ]),
             Section::make('Availability')
                 ->schema([

--- a/app-modules/meeting-center/src/Filament/Resources/BookingGroups/Pages/ViewBookingGroup.php
+++ b/app-modules/meeting-center/src/Filament/Resources/BookingGroups/Pages/ViewBookingGroup.php
@@ -42,8 +42,10 @@ use Filament\Actions\Action;
 use Filament\Actions\EditAction;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Resources\Pages\ViewRecord;
+use Filament\Schemas\Components\Callout;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Illuminate\Support\HtmlString;
 
 class ViewBookingGroup extends ViewRecord
 {
@@ -55,6 +57,10 @@ class ViewBookingGroup extends ViewRecord
 
     public function infolist(Schema $schema): Schema
     {
+        $bookingGroup = $this->getRecord();
+
+        assert($bookingGroup instanceof BookingGroup);
+
         return $schema->schema([
             Section::make()
                 ->schema([
@@ -70,6 +76,22 @@ class ViewBookingGroup extends ViewRecord
                         ->placeholder('N/A')
                         ->badge()
                         ->label('Teams'),
+                    Callout::make('Some group members do not have a connected calendar and will be skipped during bookings.')
+                        ->warning()
+                        ->description(function () use ($bookingGroup): HtmlString {
+                            $data = $bookingGroup->disconnectedCalendarMembers();
+
+                            return new HtmlString(view('meeting-center::filament.components.disconnected-calendar-members', [
+                                'directUsers' => $data['directUsers'],
+                                'teamGroups' => $data['teamGroups'],
+                            ])->render());
+                        })
+                        ->visible(function () use ($bookingGroup): bool {
+                            $data = $bookingGroup->disconnectedCalendarMembers();
+
+                            return $data['directUsers']->isNotEmpty() || $data['teamGroups']->isNotEmpty();
+                        })
+                        ->columnSpanFull(),
                 ]),
         ]);
     }

--- a/app-modules/meeting-center/src/Filament/Resources/CalendarEvents/Pages/ListCalendarEvents.php
+++ b/app-modules/meeting-center/src/Filament/Resources/CalendarEvents/Pages/ListCalendarEvents.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\MeetingCenter\Filament\Resources\CalendarEvents\Pages;
 
+use AdvisingApp\MeetingCenter\Exceptions\CouldNotRefreshToken;
 use AdvisingApp\MeetingCenter\Filament\Resources\CalendarEvents\CalendarEventResource;
 use AdvisingApp\MeetingCenter\Jobs\SyncCalendar;
 use AdvisingApp\MeetingCenter\Managers\CalendarManager;
@@ -102,7 +103,17 @@ class ListCalendarEvents extends ListRecords
                         $calendarManager = resolve(CalendarManager::class)
                             ->driver($calendar->provider_type->value);
 
-                        return $calendarManager->getCalendars($calendar);
+                        try {
+                            return $calendarManager->getCalendars($calendar);
+                        } catch (CouldNotRefreshToken) {
+                            Notification::make()
+                                ->danger()
+                                ->title('Your calendar connection has been revoked.')
+                                ->body('Please reconnect your calendar to continue.')
+                                ->send();
+
+                            return [];
+                        }
                     })
                     ->required(),
             ])
@@ -116,9 +127,19 @@ class ListCalendarEvents extends ListRecords
                 $calendar = $user->calendar;
                 $calendar->provider_id = $data['provider_id'];
 
-                $calendars = resolve(CalendarManager::class)
-                    ->driver($calendar->provider_type->value)
-                    ->getCalendars($calendar);
+                try {
+                    $calendars = resolve(CalendarManager::class)
+                        ->driver($calendar->provider_type->value)
+                        ->getCalendars($calendar);
+                } catch (CouldNotRefreshToken) {
+                    Notification::make()
+                        ->danger()
+                        ->title('Your calendar connection has been revoked.')
+                        ->body('Please reconnect your calendar to continue.')
+                        ->send();
+
+                    return;
+                }
 
                 $calendar->name = $calendars[$data['provider_id']];
 

--- a/app-modules/meeting-center/src/Http/Controllers/PersonalBookingPageWidgetController.php
+++ b/app-modules/meeting-center/src/Http/Controllers/PersonalBookingPageWidgetController.php
@@ -135,8 +135,14 @@ class PersonalBookingPageWidgetController extends Controller
         $bookingPage = PersonalBookingPage::query()
             ->where('slug', $slug)
             ->where('is_enabled', true)
-            ->with('user')
+            ->with(['user', 'user.calendar'])
             ->firstOrFail();
+
+        if (! $bookingPage->user->calendar?->oauth_token) {
+            return response()->json([
+                'blocks' => [],
+            ]);
+        }
 
         $year = $request->integer('year', now()->year);
         $month = $request->integer('month', now()->month);
@@ -164,7 +170,7 @@ class PersonalBookingPageWidgetController extends Controller
 
         $user = $bookingPage->user;
 
-        if (! $user->calendar) {
+        if (! $user->calendar?->oauth_token) {
             return response()->json([
                 'success' => false,
                 'message' => 'Calendar is not configured for this user.',

--- a/app-modules/meeting-center/src/Jobs/RefreshCalendarRefreshToken.php
+++ b/app-modules/meeting-center/src/Jobs/RefreshCalendarRefreshToken.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\MeetingCenter\Jobs;
 
+use AdvisingApp\MeetingCenter\Exceptions\CouldNotRefreshToken;
 use AdvisingApp\MeetingCenter\Managers\CalendarManager;
 use AdvisingApp\MeetingCenter\Managers\Contracts\CalendarInterface;
 use AdvisingApp\MeetingCenter\Models\Calendar;
@@ -63,6 +64,11 @@ class RefreshCalendarRefreshToken implements ShouldQueue
         $calendarManager = resolve(CalendarManager::class)
             ->driver($this->calendar->provider_type->value);
 
-        $calendarManager->refreshToken($this->calendar);
+        try {
+            $calendarManager->refreshToken($this->calendar);
+        } catch (CouldNotRefreshToken $exception) {
+            // Tokens have been cleared and the user has been notified; nothing further needed.
+            $this->fail($exception);
+        }
     }
 }

--- a/app-modules/meeting-center/src/Managers/GoogleCalendarManager.php
+++ b/app-modules/meeting-center/src/Managers/GoogleCalendarManager.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\MeetingCenter\Managers;
 
 use AdvisingApp\MeetingCenter\Enums\EventTransparency;
+use AdvisingApp\MeetingCenter\Exceptions\CouldNotRefreshToken;
 use AdvisingApp\MeetingCenter\Managers\Contracts\CalendarInterface;
 use AdvisingApp\MeetingCenter\Models\Calendar;
 use AdvisingApp\MeetingCenter\Models\CalendarEvent;
@@ -291,7 +292,7 @@ class GoogleCalendarManager implements CalendarInterface
 
             $calendar->user->notify(new CalendarRequiresReconnectNotification($calendar));
 
-            throw $e;
+            throw new CouldNotRefreshToken(message: $e->getMessage(), previous: $e);
         }
 
         return $calendar;

--- a/app-modules/meeting-center/src/Managers/OutlookCalendarManager.php
+++ b/app-modules/meeting-center/src/Managers/OutlookCalendarManager.php
@@ -293,6 +293,8 @@ class OutlookCalendarManager implements CalendarInterface
     public function refreshToken(Calendar $calendar): Calendar
     {
         if (blank($calendar->oauth_refresh_token)) {
+            $this->disconnectAndNotify($calendar);
+
             throw new CouldNotRefreshToken(message: 'No refresh token available for calendar.');
         }
 

--- a/app-modules/meeting-center/src/Models/BookingGroup.php
+++ b/app-modules/meeting-center/src/Models/BookingGroup.php
@@ -43,6 +43,7 @@ use AdvisingApp\Team\Models\Team;
 use App\Models\BaseModel;
 use App\Models\User;
 use CanyonGBS\Common\Models\Concerns\HasUserSaveTracking;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -169,5 +170,59 @@ class BookingGroup extends BaseModel implements Auditable
             : new Collection();
 
         return $directUsers->merge($teamMembers)->unique('id')->values();
+    }
+
+    /**
+     * @return Collection<int, User>
+     */
+    public function connectedMembers(): Collection
+    {
+        $directUsers = $this->users()
+            ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+            ->get();
+
+        $teamIds = $this->teams()->pluck('teams.id');
+
+        $teamMembers = $teamIds->isNotEmpty()
+            ? User::query()
+                ->whereIn('team_id', $teamIds)
+                ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+                ->get()
+            : new Collection();
+
+        return $directUsers->merge($teamMembers)->unique('id')->values();
+    }
+
+    /**
+     * @return array{directUsers: Collection<int, User>, teamGroups: Collection<string, Collection<int, User>>}
+     */
+    public function disconnectedCalendarMembers(): array
+    {
+        $disconnectedDirectUsers = $this->users()
+            ->whereDoesntHave('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+            ->orderBy('name')
+            ->get();
+
+        $teamIds = $this->teams()->pluck('teams.id');
+        $teamsWithDisconnected = collect();
+
+        if ($teamIds->isNotEmpty()) {
+            foreach ($this->teams()->orderBy('name')->get() as $team) {
+                $disconnected = User::query()
+                    ->where('team_id', $team->id)
+                    ->whereDoesntHave('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
+                    ->orderBy('name')
+                    ->get();
+
+                if ($disconnected->isNotEmpty()) {
+                    $teamsWithDisconnected->put($team->name, $disconnected);
+                }
+            }
+        }
+
+        return [
+            'directUsers' => $disconnectedDirectUsers,
+            'teamGroups' => $teamsWithDisconnected,
+        ];
     }
 }

--- a/app-modules/meeting-center/src/Observers/CalendarEventObserver.php
+++ b/app-modules/meeting-center/src/Observers/CalendarEventObserver.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\MeetingCenter\Observers;
 
+use AdvisingApp\MeetingCenter\Exceptions\CouldNotRefreshToken;
 use AdvisingApp\MeetingCenter\Managers\CalendarManager;
 use AdvisingApp\MeetingCenter\Models\CalendarEvent;
 
@@ -44,27 +45,39 @@ class CalendarEventObserver
     public function created(CalendarEvent $event): void
     {
         if ($event->calendar) {
-            resolve(CalendarManager::class)
-                ->driver($event->calendar->provider_type->value)
-                ->createEvent($event);
+            try {
+                resolve(CalendarManager::class)
+                    ->driver($event->calendar->provider_type->value)
+                    ->createEvent($event);
+            } catch (CouldNotRefreshToken) {
+                // Tokens have been cleared and the user has been notified; nothing further needed.
+            }
         }
     }
 
     public function updated(CalendarEvent $event): void
     {
         if ($event->calendar) {
-            resolve(CalendarManager::class)
-                ->driver($event->calendar->provider_type->value)
-                ->updateEvent($event);
+            try {
+                resolve(CalendarManager::class)
+                    ->driver($event->calendar->provider_type->value)
+                    ->updateEvent($event);
+            } catch (CouldNotRefreshToken) {
+                // Tokens have been cleared and the user has been notified; nothing further needed.
+            }
         }
     }
 
     public function deleted(CalendarEvent $event): void
     {
         if ($event->calendar) {
-            resolve(CalendarManager::class)
-                ->driver($event->calendar->provider_type->value)
-                ->deleteEvent($event);
+            try {
+                resolve(CalendarManager::class)
+                    ->driver($event->calendar->provider_type->value)
+                    ->deleteEvent($event);
+            } catch (CouldNotRefreshToken) {
+                // Tokens have been cleared and the user has been notified; nothing further needed.
+            }
         }
     }
 }

--- a/app-modules/meeting-center/src/Services/BookingGroup/Assigners/AvailabilityMemberAssigner.php
+++ b/app-modules/meeting-center/src/Services/BookingGroup/Assigners/AvailabilityMemberAssigner.php
@@ -57,7 +57,7 @@ class AvailabilityMemberAssigner implements BookingGroupMemberAssigner
 
         $eligibleMembers = User::query()
             ->whereIn('users.id', $memberIds)
-            ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('provider_id'))
+            ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
             ->get();
 
         if ($eligibleMembers->isEmpty()) {
@@ -136,7 +136,7 @@ class AvailabilityMemberAssigner implements BookingGroupMemberAssigner
         if ($lastAssignee && $tiedMemberIds->contains($lastAssignee->id)) {
             $user = User::query()
                 ->whereIn('users.id', $tiedMemberIds)
-                ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('provider_id'))
+                ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
                 ->where('name', '>=', $lastAssignee->name)
                 ->where(fn (Builder $query) => $query
                     ->where('name', '!=', $lastAssignee->name)
@@ -152,7 +152,7 @@ class AvailabilityMemberAssigner implements BookingGroupMemberAssigner
 
         return User::query()
             ->whereIn('users.id', $tiedMemberIds)
-            ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('provider_id'))
+            ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
             ->orderBy('name')
             ->orderBy('users.id')
             ->first();

--- a/app-modules/meeting-center/src/Services/BookingGroup/Assigners/RoundRobinMemberAssigner.php
+++ b/app-modules/meeting-center/src/Services/BookingGroup/Assigners/RoundRobinMemberAssigner.php
@@ -57,7 +57,7 @@ class RoundRobinMemberAssigner implements BookingGroupMemberAssigner
         if ($lastAssignee) {
             $user = User::query()
                 ->whereIn('users.id', $memberIds)
-                ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('provider_id'))
+                ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
                 ->where('name', '>=', $lastAssignee->name)
                 ->where(fn (Builder $query) => $query
                     ->where('name', '!=', $lastAssignee->name)
@@ -70,7 +70,7 @@ class RoundRobinMemberAssigner implements BookingGroupMemberAssigner
         if ($user === null) {
             $user = User::query()
                 ->whereIn('users.id', $memberIds)
-                ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('provider_id'))
+                ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
                 ->orderBy('name')
                 ->orderBy('users.id')
                 ->first();

--- a/app-modules/meeting-center/src/Services/BookingGroup/Bookers/AllBooker.php
+++ b/app-modules/meeting-center/src/Services/BookingGroup/Bookers/AllBooker.php
@@ -74,7 +74,7 @@ class AllBooker extends BookingGroupBooker
             ], 422);
         }
 
-        if (! $meetingOwner->calendar?->provider_id) {
+        if (! $meetingOwner->calendar?->oauth_token) {
             return response()->json([
                 'success' => false,
                 'message' => 'This booking group does not have a valid meeting owner calendar configured.',

--- a/app-modules/meeting-center/src/Services/BookingGroup/Bookers/RoundRobinBooker.php
+++ b/app-modules/meeting-center/src/Services/BookingGroup/Bookers/RoundRobinBooker.php
@@ -66,7 +66,7 @@ class RoundRobinBooker extends BookingGroupBooker
 
         $eligibleCount = User::query()
             ->whereIn('users.id', $bookingGroup->allMembers()->pluck('id'))
-            ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('provider_id'))
+            ->whereHas('calendar', fn (Builder $query) => $query->whereNotNull('oauth_token'))
             ->count();
 
         $triedCount = 0;

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -36,7 +36,6 @@
 
 namespace App\Exceptions;
 
-use AdvisingApp\MeetingCenter\Exceptions\CouldNotRefreshToken;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Psr\Log\LogLevel;
@@ -57,9 +56,7 @@ class Handler extends ExceptionHandler
      *
      * @var array<int, class-string<Throwable>>
      */
-    protected $dontReport = [
-        CouldNotRefreshToken::class,
-    ];
+    protected $dontReport = [];
 
     /**
      * A list of the inputs that are never flashed to the session on validation exceptions.


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2610

### Technical Description

Reports unhandled OAuth refresh exceptions to Sentry. Notifies the user and clears their OAuth token when the refresh fails. Uses OAuth token presence to determine calendar connection status, not calendar ID. Shows connection status of users and users inside teams when CRUDing the personal and group booking pages.

### Any deployment steps required?

No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
