### PR TITLE
[ADVAPP-2621]: Personal booking page creates calendar events with no transparency, causing slot to remain visible after booking for a short time

### DIFF
--- a/app-modules/meeting-center/src/Http/Controllers/PersonalBookingPageWidgetController.php
+++ b/app-modules/meeting-center/src/Http/Controllers/PersonalBookingPageWidgetController.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\MeetingCenter\Http\Controllers;
 
 use AdvisingApp\MeetingCenter\Actions\GetAvailableAppointmentSlots;
+use AdvisingApp\MeetingCenter\Enums\EventTransparency;
 use AdvisingApp\MeetingCenter\Http\Requests\BookPersonalCalendarSlotRequest;
 use AdvisingApp\MeetingCenter\Models\CalendarEvent;
 use AdvisingApp\MeetingCenter\Models\PersonalBookingPage;
@@ -248,6 +249,7 @@ class PersonalBookingPageWidgetController extends Controller
                 'attendees' => [
                     $request->validated('email'),
                 ],
+                'transparency' => EventTransparency::Busy,
             ]);
 
             return response()->json([


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2621

### Technical Description

> Personal booking page created calendar events with no transparency, causing slot to remain visible after booking for a short time

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
