### PR TITLE
[ADVAPP-2629]: Some users have reported that when attempting to create a workflow step in forms or admissions with an email an error is reported

### DIFF
--- a/app-modules/workflow/src/Filament/Resources/Workflows/RelationManagers/WorkflowStepsRelationManager.php
+++ b/app-modules/workflow/src/Filament/Resources/Workflows/RelationManagers/WorkflowStepsRelationManager.php
@@ -237,6 +237,7 @@ class WorkflowStepsRelationManager extends RelationManager
             ]),
             'workflow_engagement_email_details' => WorkflowEngagementEmailDetails::create([
                 'channel' => $transformedData['channel'],
+                'email_type' => $transformedData['email_type'],
                 'subject' => $transformedData['subject'] ?? ['type' => 'doc', 'content' => []],
                 'body' => $transformedData['body'] ?? ['type' => 'doc', 'content' => []],
             ]),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2629

### Technical Description

> Pass `email_type` when creating workflow engagement email details so the value selected on the form is persisted

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
