### PR TITLE
[ADVAPP-2623]: Enhance the ability to add details when emails are actioned

### DIFF
--- a/app-modules/engagement/database/factories/EngagementResponseActionedNoteFactory.php
+++ b/app-modules/engagement/database/factories/EngagementResponseActionedNoteFactory.php
@@ -37,12 +37,13 @@
 namespace AdvisingApp\Engagement\Database\Factories;
 
 use AdvisingApp\Engagement\Models\EngagementResponse;
+use AdvisingApp\Engagement\Models\EngagementResponseActionedNote;
 use AdvisingApp\Engagement\Models\Model;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends Factory<Model>
+ * @extends Factory<EngagementResponseActionedNote>
  */
 class EngagementResponseActionedNoteFactory extends Factory
 {

--- a/app-modules/engagement/database/factories/EngagementResponseActionedNoteFactory.php
+++ b/app-modules/engagement/database/factories/EngagementResponseActionedNoteFactory.php
@@ -38,7 +38,6 @@ namespace AdvisingApp\Engagement\Database\Factories;
 
 use AdvisingApp\Engagement\Models\EngagementResponse;
 use AdvisingApp\Engagement\Models\EngagementResponseActionedNote;
-use AdvisingApp\Engagement\Models\Model;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 

--- a/app-modules/engagement/database/factories/EngagementResponseActionedNoteFactory.php
+++ b/app-modules/engagement/database/factories/EngagementResponseActionedNoteFactory.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Engagement\Database\Factories;
 
 use AdvisingApp\Engagement\Models\EngagementResponse;

--- a/app-modules/engagement/database/factories/EngagementResponseActionedNoteFactory.php
+++ b/app-modules/engagement/database/factories/EngagementResponseActionedNoteFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AdvisingApp\Engagement\Database\Factories;
+
+use AdvisingApp\Engagement\Models\EngagementResponse;
+use AdvisingApp\Engagement\Models\Model;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Model>
+ */
+class EngagementResponseActionedNoteFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'created_by_id' => User::factory(),
+            'engagement_response_id' => EngagementResponse::factory(),
+            'note' => $this->faker->paragraph(),
+        ];
+    }
+}

--- a/app-modules/engagement/database/migrations/2026_05_04_105657_create_engagement_response_actioned_notes_table.php
+++ b/app-modules/engagement/database/migrations/2026_05_04_105657_create_engagement_response_actioned_notes_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;

--- a/app-modules/engagement/database/migrations/2026_05_04_105657_create_engagement_response_actioned_notes_table.php
+++ b/app-modules/engagement/database/migrations/2026_05_04_105657_create_engagement_response_actioned_notes_table.php
@@ -44,8 +44,8 @@ return new class () extends Migration {
         Schema::create('engagement_response_actioned_notes', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->foreignUuid('engagement_response_id')->constrained('engagement_responses')->onDelete('cascade');
-            $table->foreignUuid('created_by_id')->constrained('users')->nullOnDelete();
-            $table->foreignUuid('last_updated_by_id')->constrained('users')->nullOnDelete();
+            $table->foreignUuid('created_by_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignUuid('last_updated_by_id')->nullable()->constrained('users')->nullOnDelete();
             $table->text('note');
             $table->timestamps();
         });

--- a/app-modules/engagement/database/migrations/2026_05_04_105657_create_engagement_response_actioned_notes_table.php
+++ b/app-modules/engagement/database/migrations/2026_05_04_105657_create_engagement_response_actioned_notes_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('engagement_response_actioned_notes', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('engagement_response_id')->constrained('engagement_responses')->onDelete('cascade');
+            $table->foreignUuid('created_by_id')->constrained('users')->nullOnDelete();
+            $table->foreignUuid('last_updated_by_id')->constrained('users')->nullOnDelete();
+            $table->text('note');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('engagement_response_actioned_notes');
+    }
+};

--- a/app-modules/engagement/database/migrations/2026_05_04_172449_data_activate_engagement_response_mark_as_actioned_feature.php
+++ b/app-modules/engagement/database/migrations/2026_05_04_172449_data_activate_engagement_response_mark_as_actioned_feature.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Features\EngagementResponseMarkAsActionedFeature;
+use Illuminate\Database\Migrations\Migration;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        EngagementResponseMarkAsActionedFeature::activate();
+    }
+
+    public function down(): void
+    {
+        EngagementResponseMarkAsActionedFeature::deactivate();
+    }
+};

--- a/app-modules/engagement/database/migrations/2026_05_04_172449_data_activate_engagement_response_mark_as_actioned_feature.php
+++ b/app-modules/engagement/database/migrations/2026_05_04_172449_data_activate_engagement_response_mark_as_actioned_feature.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\EngagementResponseMarkAsActionedFeature;
 use Illuminate\Database\Migrations\Migration;
 

--- a/app-modules/engagement/resources/views/filament/pages/view-engagement-response.blade.php
+++ b/app-modules/engagement/resources/views/filament/pages/view-engagement-response.blade.php
@@ -59,11 +59,14 @@
                     Reply
                 </x-filament::button>
 
-                @if (EngagementResponseMarkAsActionedFeature::active() &&  $this->record->status === EngagementResponseStatus::New)
-                    
-                    <x-filament::button wire:click="mountAction('markAsActioned')">Mark as {{ $this->getInvertedStatus()->name }}</x-filament::button>
+                @if (EngagementResponseMarkAsActionedFeature::active() && $this->record->status === EngagementResponseStatus::New)
+                    <x-filament::button wire:click="mountAction('markAsActioned')">
+                        Mark as {{ $this->getInvertedStatus()->name }}
+                    </x-filament::button>
                 @else
-                <x-filament::button wire:click="changeStatus()">Mark as {{ $this->getInvertedStatus()->name }}</x-filament::button>
+                    <x-filament::button wire:click="changeStatus()">
+                        Mark as {{ $this->getInvertedStatus()->name }}
+                    </x-filament::button>
                 @endif
             </div>
 
@@ -91,9 +94,13 @@
                 </div>
 
                 @if (EngagementResponseMarkAsActionedFeature::active() && $this->record->status === EngagementResponseStatus::New)
-                <x-filament::button wire:click="mountAction('markAsActioned')">Mark as {{ $this->getInvertedStatus()->name }}</x-filament::button>
+                    <x-filament::button wire:click="mountAction('markAsActioned')">
+                        Mark as {{ $this->getInvertedStatus()->name }}
+                    </x-filament::button>
                 @else
-                <x-filament::button wire:click="changeStatus()">Mark as {{ $this->getInvertedStatus()->name }}</x-filament::button>
+                    <x-filament::button wire:click="changeStatus()">
+                        Mark as {{ $this->getInvertedStatus()->name }}
+                    </x-filament::button>
                 @endif
             </div>
         </div>

--- a/app-modules/engagement/resources/views/filament/pages/view-engagement-response.blade.php
+++ b/app-modules/engagement/resources/views/filament/pages/view-engagement-response.blade.php
@@ -35,6 +35,8 @@
 @use(AdvisingApp\Prospect\Models\Prospect)
 @use(AdvisingApp\StudentDataModel\Models\Student)
 @use(AdvisingApp\Engagement\Enums\EngagementResponseType)
+@use(AdvisingApp\Engagement\Enums\EngagementResponseStatus)
+@use(App\Features\EngagementResponseMarkAsActionedFeature)
 
 <x-filament-panels::page>
     <div>
@@ -57,9 +59,12 @@
                     Reply
                 </x-filament::button>
 
-                <x-filament::button wire:click="changeStatus()">
-                    Mark as {{ $this->getInvertedStatus()->name }}
-                </x-filament::button>
+                @if (EngagementResponseMarkAsActionedFeature::active() &&  $this->record->status === EngagementResponseStatus::New)
+                    
+                    <x-filament::button wire:click="mountAction('markAsActioned')">Mark as {{ $this->getInvertedStatus()->name }}</x-filament::button>
+                @else
+                <x-filament::button wire:click="changeStatus()">Mark as {{ $this->getInvertedStatus()->name }}</x-filament::button>
+                @endif
             </div>
 
             <form class="grid gap-6" x-show="isReplying" wire:submit.prevent="reply">
@@ -84,9 +89,12 @@
                         : 'The email address this message was sent from does not match any known student or prospect record. You may only reply to messages that have an associated prospect or student record.'"
                     />
                 </div>
-                <x-filament::button wire:click="changeStatus()">
-                    Mark as {{ $this->getInvertedStatus()->name }}
-                </x-filament::button>
+
+                @if (EngagementResponseMarkAsActionedFeature::active() && $this->record->status === EngagementResponseStatus::New)
+                <x-filament::button wire:click="mountAction('markAsActioned')">Mark as {{ $this->getInvertedStatus()->name }}</x-filament::button>
+                @else
+                <x-filament::button wire:click="changeStatus()">Mark as {{ $this->getInvertedStatus()->name }}</x-filament::button>
+                @endif
             </div>
         </div>
     @endif

--- a/app-modules/engagement/src/Filament/Actions/BulkChangeStatusAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkChangeStatusAction.php
@@ -40,7 +40,10 @@ use AdvisingApp\Engagement\Enums\EngagementResponseStatus;
 use AdvisingApp\Engagement\Models\EngagementResponse;
 use Filament\Actions\BulkAction;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Schemas\Components\Utilities\Get;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class BulkChangeStatusAction
@@ -56,14 +59,29 @@ class BulkChangeStatusAction
                 Select::make('status')
                     ->label('Which status should be applied?')
                     ->required()
-                    ->options(EngagementResponseStatus::class)
-                    ->required(),
+                    ->live()
+                    ->options(EngagementResponseStatus::class),
+                Textarea::make('note')
+                    ->label('Note')
+                    ->helperText('Please describe the steps you have taken.')
+                    ->rows(4)
+                    ->visible(fn (Get $get): bool => $get('status') === EngagementResponseStatus::Actioned)
+                    ->required(fn (Get $get): bool => $get('status') === EngagementResponseStatus::Actioned),
             ])
             ->action(function (Collection $records, array $data): void {
-                $records->each(function (EngagementResponse $record) use ($data) {
-                    $record->status = $data['status'];
+                $isActioned = $data['status'] === EngagementResponseStatus::Actioned;
 
-                    $record->save();
+                DB::transaction(static function () use ($records, $data, $isActioned): void {
+                    $records->each(static function (EngagementResponse $record) use ($data, $isActioned): void {
+                        if ($isActioned) {
+                            $record->actionedNotes()->create([
+                                'note' => $data['note'],
+                            ]);
+                            $record->update(['status' => EngagementResponseStatus::Actioned]);
+                        } else {
+                            $record->update(['status' => EngagementResponseStatus::New]);
+                        }
+                    });
                 });
             });
     }

--- a/app-modules/engagement/src/Filament/Actions/BulkChangeStatusAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkChangeStatusAction.php
@@ -67,7 +67,7 @@ class BulkChangeStatusAction
                     ->helperText('Please describe the steps you have taken.')
                     ->rows(4)
                     ->visible(fn (Get $get): bool => EngagementResponseMarkAsActionedFeature::active() && $get('status') === EngagementResponseStatus::Actioned)
-                    ->required(fn (Get $get): bool => $get('status') === EngagementResponseStatus::Actioned),
+                    ->required(fn (Get $get): bool => EngagementResponseMarkAsActionedFeature::active() && $get('status') === EngagementResponseStatus::Actioned),
             ])
             ->action(function (Collection $records, array $data): void {
                 $isActioned = $data['status'] === EngagementResponseStatus::Actioned;

--- a/app-modules/engagement/src/Filament/Actions/BulkChangeStatusAction.php
+++ b/app-modules/engagement/src/Filament/Actions/BulkChangeStatusAction.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Engagement\Filament\Actions;
 
 use AdvisingApp\Engagement\Enums\EngagementResponseStatus;
 use AdvisingApp\Engagement\Models\EngagementResponse;
+use App\Features\EngagementResponseMarkAsActionedFeature;
 use Filament\Actions\BulkAction;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
@@ -59,13 +60,13 @@ class BulkChangeStatusAction
                 Select::make('status')
                     ->label('Which status should be applied?')
                     ->required()
-                    ->live()
+                    ->live(condition: EngagementResponseMarkAsActionedFeature::active())
                     ->options(EngagementResponseStatus::class),
                 Textarea::make('note')
                     ->label('Note')
                     ->helperText('Please describe the steps you have taken.')
                     ->rows(4)
-                    ->visible(fn (Get $get): bool => $get('status') === EngagementResponseStatus::Actioned)
+                    ->visible(fn (Get $get): bool => EngagementResponseMarkAsActionedFeature::active() && $get('status') === EngagementResponseStatus::Actioned)
                     ->required(fn (Get $get): bool => $get('status') === EngagementResponseStatus::Actioned),
             ])
             ->action(function (Collection $records, array $data): void {
@@ -73,13 +74,18 @@ class BulkChangeStatusAction
 
                 DB::transaction(static function () use ($records, $data, $isActioned): void {
                     $records->each(static function (EngagementResponse $record) use ($data, $isActioned): void {
-                        if ($isActioned) {
-                            $record->actionedNotes()->create([
-                                'note' => $data['note'],
-                            ]);
-                            $record->update(['status' => EngagementResponseStatus::Actioned]);
+                        if (EngagementResponseMarkAsActionedFeature::active()) {
+                            if ($isActioned) {
+                                $record->actionedNotes()->create([
+                                    'note' => $data['note'],
+                                ]);
+                                $record->update(['status' => EngagementResponseStatus::Actioned]);
+                            } else {
+                                $record->update(['status' => EngagementResponseStatus::New]);
+                            }
                         } else {
-                            $record->update(['status' => EngagementResponseStatus::New]);
+                            $record->status = $data['status'];
+                            $record->save();
                         }
                     });
                 });

--- a/app-modules/engagement/src/Filament/Actions/EngagementResponseMarkAsActionedAction.php
+++ b/app-modules/engagement/src/Filament/Actions/EngagementResponseMarkAsActionedAction.php
@@ -48,7 +48,6 @@ use Filament\Forms\Components\Textarea;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 class EngagementResponseMarkAsActionedAction extends Action
 {
@@ -58,16 +57,7 @@ class EngagementResponseMarkAsActionedAction extends Action
 
         $this
             ->label('Mark as Actioned')
-            ->modalHeading(function (?Model $record): string {
-                $engagementResponse = $this->getEngagementResponse($record);
-                $type = match ($engagementResponse?->type) {
-                    EngagementResponseType::Email => 'Email',
-                    EngagementResponseType::Sms => 'Text',
-                    default => null,
-                };
-
-                return 'Mark ' . $type . ' as Actioned';
-            })
+            ->modalHeading(fn (?Model $record): string => 'Mark ' . $this->resolveHeadingTypeLabel($record) . ' as Actioned')
             ->modalDescription(function (?Model $record): string {
                 return 'When you action ' . $this->resolveTypeLabel($record) . ', you are indicating that you have taken all necessary steps to respond to this ' . $this->resolveSenderLabel($record) . '. Please describe below what steps you have taken.';
             })
@@ -101,7 +91,7 @@ class EngagementResponseMarkAsActionedAction extends Action
                 });
 
                 Notification::make()
-                    ->title(Str::ucfirst($this->resolveTypeLabel($record)) . ' marked as actioned')
+                    ->title($this->resolveHeadingTypeLabel($record) . ' marked as actioned')
                     ->success()
                     ->send();
             });
@@ -143,5 +133,19 @@ class EngagementResponseMarkAsActionedAction extends Action
             $record instanceof Timeline && $record->timelineable instanceof EngagementResponse => $record->timelineable,
             default => null,
         };
+    }
+
+    public function getHeadingTypeLabel(?EngagementResponse $engagementResponse): ?string
+    {
+        return match ($engagementResponse?->type) {
+            EngagementResponseType::Email => 'Email',
+            EngagementResponseType::Sms => 'Text',
+            default => null,
+        };
+    }
+
+    public function resolveHeadingTypeLabel(?Model $record): ?string
+    {
+        return $this->getHeadingTypeLabel($this->getEngagementResponse($record));
     }
 }

--- a/app-modules/engagement/src/Filament/Actions/EngagementResponseMarkAsActionedAction.php
+++ b/app-modules/engagement/src/Filament/Actions/EngagementResponseMarkAsActionedAction.php
@@ -59,14 +59,17 @@ class EngagementResponseMarkAsActionedAction extends Action
         $this
             ->label('Mark as Actioned')
             ->modalHeading(function (?Model $record): string {
-                $engagementResponse = $this->resolveEngagementResponse($record);
+                $engagementResponse = $this->getEngagementResponse($record);
+                $type = match ($engagementResponse?->type) {
+                    EngagementResponseType::Email => 'Email',
+                    EngagementResponseType::Sms => 'Text',
+                    default => null,
+                };
 
-                return 'Mark ' . $this->resolveTypeLabel($engagementResponse) . ' as Actioned';
+                return 'Mark ' . $type . ' as Actioned';
             })
             ->modalDescription(function (?Model $record): string {
-                $engagementResponse = $this->resolveEngagementResponse($record);
-
-                return 'When you action ' . $this->resolveTypeLabel($engagementResponse) . ', you are indicating that you have taken all necessary steps to respond to this ' . $this->resolveSenderLabel($engagementResponse) . '. Please describe below what steps you have taken.';
+                return 'When you action ' . $this->resolveTypeLabel($record) . ', you are indicating that you have taken all necessary steps to respond to this ' . $this->resolveSenderLabel($record) . '. Please describe below what steps you have taken.';
             })
             ->schema([
                 Textarea::make('note')
@@ -98,7 +101,7 @@ class EngagementResponseMarkAsActionedAction extends Action
                 });
 
                 Notification::make()
-                    ->title(Str::ucfirst($this->resolveTypeLabel($engagementResponse)) . ' marked as actioned')
+                    ->title(Str::ucfirst($this->resolveTypeLabel($record)) . ' marked as actioned')
                     ->success()
                     ->send();
             });
@@ -115,14 +118,7 @@ class EngagementResponseMarkAsActionedAction extends Action
 
     public function resolveTypeLabel(?Model $record): ?string
     {
-        $engagementResponse = match (true) {
-            $record instanceof EngagementResponse => $record,
-            $record instanceof HolisticEngagement && $record->record instanceof EngagementResponse => $record->record,
-            $record instanceof Timeline && $record->timelineable instanceof EngagementResponse => $record->timelineable,
-            default => null,
-        };
-
-        return $this->getTypeLabel($engagementResponse);
+        return $this->getTypeLabel($this->getEngagementResponse($record));
     }
 
     public function getSenderLabel(?EngagementResponse $engagementResponse): ?string
@@ -136,28 +132,16 @@ class EngagementResponseMarkAsActionedAction extends Action
 
     public function resolveSenderLabel(?Model $record): ?string
     {
-        $engagementResponse = match (true) {
-            $record instanceof EngagementResponse => $record,
-            $record instanceof HolisticEngagement && $record->record instanceof EngagementResponse => $record->record,
-            $record instanceof Timeline && $record->timelineable instanceof EngagementResponse => $record->timelineable,
-            default => null,
-        };
-
-        return $this->getSenderLabel($engagementResponse);
+        return $this->getSenderLabel($this->getEngagementResponse($record));
     }
 
     public function getEngagementResponse(?Model $record): ?EngagementResponse
-    {
+    {Emai
         return match (true) {
             $record instanceof EngagementResponse => $record,
             $record instanceof HolisticEngagement && $record->record instanceof EngagementResponse => $record->record,
             $record instanceof Timeline && $record->timelineable instanceof EngagementResponse => $record->timelineable,
             default => null,
         };
-    }
-
-    public function resolveEngagementResponse(?Model $record): ?EngagementResponse
-    {
-        return $this->getEngagementResponse($record);
     }
 }

--- a/app-modules/engagement/src/Filament/Actions/EngagementResponseMarkAsActionedAction.php
+++ b/app-modules/engagement/src/Filament/Actions/EngagementResponseMarkAsActionedAction.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Engagement\Filament\Actions;
+
+use AdvisingApp\Engagement\Enums\EngagementResponseStatus;
+use AdvisingApp\Engagement\Enums\EngagementResponseType;
+use AdvisingApp\Engagement\Models\EngagementResponse;
+use AdvisingApp\Engagement\Models\HolisticEngagement;
+use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Models\Student;
+use AdvisingApp\Timeline\Models\Timeline;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Textarea;
+use Filament\Notifications\Notification;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class EngagementResponseMarkAsActionedAction extends Action
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this
+            ->label('Mark as Actioned')
+            ->modalHeading(function (?Model $record): string {
+                $engagementResponse = $this->resolveEngagementResponse($record);
+
+                return 'Mark ' . $this->resolveTypeLabel($engagementResponse) . ' as Actioned';
+            })
+            ->modalDescription(function (?Model $record): string {
+                $engagementResponse = $this->resolveEngagementResponse($record);
+
+                return 'When you action ' . $this->resolveTypeLabel($engagementResponse) . ', you are indicating that you have taken all necessary steps to respond to this ' . $this->resolveSenderLabel($engagementResponse) . '. Please describe below what steps you have taken.';
+            })
+            ->schema([
+                Textarea::make('note')
+                    ->label('Note')
+                    ->required(),
+            ])
+            ->modalSubmitActionLabel('Mark as Actioned')
+            ->modalFooterActions(fn (): array => array_filter([
+                $this->getModalCancelAction(),
+                $this->getModalSubmitAction(),
+            ]))
+            ->action(function (array $data, ?Model $record) {
+                $engagementResponse = $this->getEngagementResponse($record);
+
+                if ($engagementResponse === null) {
+                    Notification::make()
+                        ->title('Something went wrong!')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
+                DB::transaction(function () use ($data, $engagementResponse): void {
+                    $engagementResponse->actionedNotes()->create([
+                        'note' => $data['note'],
+                    ]);
+                    $engagementResponse->update(['status' => EngagementResponseStatus::Actioned]);
+                });
+
+                Notification::make()
+                    ->title(Str::ucfirst($this->resolveTypeLabel($engagementResponse)) . ' marked as actioned')
+                    ->success()
+                    ->send();
+            });
+    }
+
+    public function getTypeLabel(?EngagementResponse $engagementResponse): ?string
+    {
+        return match ($engagementResponse?->type) {
+            EngagementResponseType::Email => 'an email',
+            EngagementResponseType::Sms => 'a text',
+            default => null,
+        };
+    }
+
+    public function resolveTypeLabel(?Model $record): ?string
+    {
+        $engagementResponse = match (true) {
+            $record instanceof EngagementResponse => $record,
+            $record instanceof HolisticEngagement && $record->record instanceof EngagementResponse => $record->record,
+            $record instanceof Timeline && $record->timelineable instanceof EngagementResponse => $record->timelineable,
+            default => null,
+        };
+
+        return $this->getTypeLabel($engagementResponse);
+    }
+
+    public function getSenderLabel(?EngagementResponse $engagementResponse): ?string
+    {
+        return match (true) {
+            $engagementResponse?->sender instanceof Student => 'student',
+            $engagementResponse?->sender instanceof Prospect => 'prospect',
+            default => null,
+        };
+    }
+
+    public function resolveSenderLabel(?Model $record): ?string
+    {
+        $engagementResponse = match (true) {
+            $record instanceof EngagementResponse => $record,
+            $record instanceof HolisticEngagement && $record->record instanceof EngagementResponse => $record->record,
+            $record instanceof Timeline && $record->timelineable instanceof EngagementResponse => $record->timelineable,
+            default => null,
+        };
+
+        return $this->getSenderLabel($engagementResponse);
+    }
+
+    public function getEngagementResponse(?Model $record): ?EngagementResponse
+    {
+        return match (true) {
+            $record instanceof EngagementResponse => $record,
+            $record instanceof HolisticEngagement && $record->record instanceof EngagementResponse => $record->record,
+            $record instanceof Timeline && $record->timelineable instanceof EngagementResponse => $record->timelineable,
+            default => null,
+        };
+    }
+
+    public function resolveEngagementResponse(?Model $record): ?EngagementResponse
+    {
+        return $this->getEngagementResponse($record);
+    }
+}

--- a/app-modules/engagement/src/Filament/Actions/EngagementResponseMarkAsActionedAction.php
+++ b/app-modules/engagement/src/Filament/Actions/EngagementResponseMarkAsActionedAction.php
@@ -136,7 +136,7 @@ class EngagementResponseMarkAsActionedAction extends Action
     }
 
     public function getEngagementResponse(?Model $record): ?EngagementResponse
-    {Emai
+    {
         return match (true) {
             $record instanceof EngagementResponse => $record,
             $record instanceof HolisticEngagement && $record->record instanceof EngagementResponse => $record->record,

--- a/app-modules/engagement/src/Filament/Pages/Inbox.php
+++ b/app-modules/engagement/src/Filament/Pages/Inbox.php
@@ -49,6 +49,7 @@ use AdvisingApp\Prospect\Filament\Resources\Prospects\ProspectResource;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Filament\Resources\Students\StudentResource;
 use AdvisingApp\StudentDataModel\Models\Student;
+use App\Features\EngagementResponseMarkAsActionedFeature;
 use App\Filament\Clusters\UnifiedInbox;
 use App\Models\User;
 use Filament\Actions\BulkActionGroup;
@@ -105,7 +106,8 @@ class Inbox extends Page implements HasTable
                     ->toggleable(isToggledHiddenByDefault: true)
                     ->badge(),
                 TextColumn::make('status')
-                    ->badge(),
+                    ->badge()
+                    ->tooltip(fn (EngagementResponse $record): ?string => EngagementResponseMarkAsActionedFeature::active() && $record->status === EngagementResponseStatus::Actioned ? $record->latestActionedNote?->getActionedNoteTooltip() : null),
                 TextColumn::make('sender_type')
                     ->label('Relation')
                     ->formatStateUsing(fn (EngagementResponse $record) => ucwords($record->sender_type))

--- a/app-modules/engagement/src/Filament/Pages/Inbox.php
+++ b/app-modules/engagement/src/Filament/Pages/Inbox.php
@@ -97,7 +97,7 @@ class Inbox extends Page implements HasTable
     {
         return $table
             ->query(
-                EngagementResponse::query()
+                EngagementResponse::query()->with('latestActionedNote')
             )
             ->columns([
                 TextColumn::make('direction')

--- a/app-modules/engagement/src/Filament/Pages/ViewEngagementResponse.php
+++ b/app-modules/engagement/src/Filament/Pages/ViewEngagementResponse.php
@@ -42,6 +42,7 @@ use AdvisingApp\Engagement\DataTransferObjects\EngagementCreationData;
 use AdvisingApp\Engagement\Enums\EngagementResponseStatus;
 use AdvisingApp\Engagement\Enums\EngagementResponseType;
 use AdvisingApp\Engagement\Filament\Actions\DraftWithAiAction;
+use AdvisingApp\Engagement\Filament\Actions\EngagementResponseMarkAsActionedAction;
 use AdvisingApp\Engagement\Filament\Actions\SendEngagementAction;
 use AdvisingApp\Engagement\Filament\Forms\Components\EngagementSmsBodyInput;
 use AdvisingApp\Engagement\Models\Engagement;
@@ -55,6 +56,7 @@ use AdvisingApp\StudentDataModel\Models\StudentEmailAddress;
 use AdvisingApp\StudentDataModel\Models\StudentPhoneNumber;
 use App\Filament\Clusters\UnifiedInbox;
 use App\Models\User;
+use Filament\Actions\Action;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\RichEditor\ToolbarButtonGroup;
@@ -304,6 +306,12 @@ class ViewEngagementResponse extends Page
     {
         $this->record->status = $this->getInvertedStatus();
         $this->record->save();
+    }
+
+    public function markAsActionedAction(): Action
+    {
+        return EngagementResponseMarkAsActionedAction::make('markAsActioned')
+            ->record($this->record);
     }
 
     protected function generateEmailReplyBody(string $content = '<p></p>'): string

--- a/app-modules/engagement/src/Models/EngagementResponse.php
+++ b/app-modules/engagement/src/Models/EngagementResponse.php
@@ -51,6 +51,8 @@ use App\Models\BaseModel;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -163,5 +165,21 @@ class EngagementResponse extends BaseModel implements Auditable, ProvidesATimeli
             EngagementResponseType::Email => NotificationChannel::Email,
             EngagementResponseType::Sms => NotificationChannel::Sms,
         };
+    }
+
+    /**
+    * @return HasMany<EngagementResponseActionedNote, $this>
+    */
+    public function actionedNotes(): HasMany
+    {
+        return $this->hasMany(EngagementResponseActionedNote::class);
+    }
+
+    /**
+     * @return HasOne<EngagementResponseActionedNote, $this>
+     */
+    public function latestActionedNote(): HasOne
+    {
+        return $this->actionedNotes()->one()->latestOfMany();
     }
 }

--- a/app-modules/engagement/src/Models/EngagementResponseActionedNote.php
+++ b/app-modules/engagement/src/Models/EngagementResponseActionedNote.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace AdvisingApp\Engagement\Models;
+
+use AdvisingApp\Engagement\Database\Factories\EngagementResponseActionedNoteFactory;
+use CanyonGBS\Common\Models\Concerns\HasUserSaveTracking;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Workbench\App\Models\User;
+
+class EngagementResponseActionedNote extends Model
+{
+    /** @use HasFactory<EngagementResponseActionedNoteFactory> */
+    use HasFactory;
+
+    use HasUuids;
+    use HasUserSaveTracking;
+
+    protected $fillable = [
+        'engagement_response_id',
+        'created_by_id',
+        'note',
+    ];
+
+    /**
+     * Get the engagement response associated with the actioned note.
+     *
+     * @return BelongsTo<EngagementResponse, $this>
+     */
+    public function engagementResponse(): BelongsTo
+    {
+        return $this->belongsTo(EngagementResponse::class, 'engagement_response_id');
+    }
+
+    public function getActionedNoteTooltip(): string
+    {
+        /** @var User|null $user */
+        $user = $this->createdBy;
+        $date = $this->created_at?->format('m-d-Y - g:i A');
+        $name = $user->name ?? 'Unknown User';
+
+        return "{$date} - {$name} marked this message as actioned with the following note: {$this->note}";
+    }
+}

--- a/app-modules/engagement/src/Models/EngagementResponseActionedNote.php
+++ b/app-modules/engagement/src/Models/EngagementResponseActionedNote.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\Engagement\Models;
 
 use AdvisingApp\Engagement\Database\Factories\EngagementResponseActionedNoteFactory;

--- a/app-modules/engagement/src/Models/EngagementResponseActionedNote.php
+++ b/app-modules/engagement/src/Models/EngagementResponseActionedNote.php
@@ -37,13 +37,16 @@
 namespace AdvisingApp\Engagement\Models;
 
 use AdvisingApp\Engagement\Database\Factories\EngagementResponseActionedNoteFactory;
+use App\Models\User;
 use CanyonGBS\Common\Models\Concerns\HasUserSaveTracking;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Workbench\App\Models\User;
 
+/**
+ * @mixin IdeHelperEngagementResponseActionedNote
+ */
 class EngagementResponseActionedNote extends Model
 {
     /** @use HasFactory<EngagementResponseActionedNoteFactory> */

--- a/app-modules/engagement/tests/Tenant/Filament/Actions/EngagementResponseMarkAsActionedActionTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Actions/EngagementResponseMarkAsActionedActionTest.php
@@ -64,7 +64,7 @@ it('can send a success notification after marking an email as actioned', functio
 
     livewire(ViewEngagementResponse::class, ['record' => $record])
         ->callAction('markAsActioned', data: ['note' => 'Resolved via email.'])
-        ->assertNotified('An email marked as actioned');
+        ->assertNotified('Email marked as actioned');
 });
 
 it('can send a success notification after marking a text message as actioned', function () {
@@ -73,7 +73,7 @@ it('can send a success notification after marking a text message as actioned', f
 
     livewire(ViewEngagementResponse::class, ['record' => $record])
         ->callAction('markAsActioned', data: ['note' => 'Resolved via text.'])
-        ->assertNotified('A text marked as actioned');
+        ->assertNotified('Text marked as actioned');
 });
 
 it('can require the note field to be filled', function () {

--- a/app-modules/engagement/tests/Tenant/Filament/Actions/EngagementResponseMarkAsActionedActionTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Actions/EngagementResponseMarkAsActionedActionTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Engagement\Enums\EngagementResponseStatus;
+use AdvisingApp\Engagement\Filament\Actions\EngagementResponseMarkAsActionedAction;
+use AdvisingApp\Engagement\Filament\Pages\ViewEngagementResponse;
+use AdvisingApp\Engagement\Models\EngagementResponse;
+use AdvisingApp\Engagement\Models\HolisticEngagement;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('can mark an engagement response as actioned and create an actioned note', function () {
+    asSuperAdmin();
+    $record = EngagementResponse::factory()->email()->create(['status' => EngagementResponseStatus::New]);
+
+    livewire(ViewEngagementResponse::class, ['record' => $record])
+        ->callAction('markAsActioned', data: ['note' => 'This is a test call.'])
+        ->assertHasNoActionErrors();
+
+    $record->refresh();
+
+    expect($record->status)->toBe(EngagementResponseStatus::Actioned)
+        ->and($record->actionedNotes()->count())->toBe(1)
+        ->and($record->actionedNotes()->first()->note)->toBe('This is a test call.');
+});
+
+it('can send a success notification after marking an email as actioned', function () {
+    asSuperAdmin();
+    $record = EngagementResponse::factory()->email()->create(['status' => EngagementResponseStatus::New]);
+
+    livewire(ViewEngagementResponse::class, ['record' => $record])
+        ->callAction('markAsActioned', data: ['note' => 'Resolved via email.'])
+        ->assertNotified('An email marked as actioned');
+});
+
+it('can send a success notification after marking a text message as actioned', function () {
+    asSuperAdmin();
+    $record = EngagementResponse::factory()->sms()->create(['status' => EngagementResponseStatus::New]);
+
+    livewire(ViewEngagementResponse::class, ['record' => $record])
+        ->callAction('markAsActioned', data: ['note' => 'Resolved via text.'])
+        ->assertNotified('A text marked as actioned');
+});
+
+it('can require the note field to be filled', function () {
+    asSuperAdmin();
+    $record = EngagementResponse::factory()->email()->create(['status' => EngagementResponseStatus::New]);
+
+    livewire(ViewEngagementResponse::class, ['record' => $record])
+        ->callAction('markAsActioned', data: ['note' => ''])
+        ->assertHasActionErrors(['note' => 'required']);
+
+    $record->refresh();
+
+    expect($record->status)->toBe(EngagementResponseStatus::New)
+        ->and($record->actionedNotes()->count())->toBe(0);
+});
+
+it('can not change status when note validation fails', function () {
+    asSuperAdmin();
+    $record = EngagementResponse::factory()->email()->create(['status' => EngagementResponseStatus::New]);
+
+    livewire(ViewEngagementResponse::class, ['record' => $record])
+        ->callAction('markAsActioned', data: [])
+        ->assertHasActionErrors(['note' => 'required']);
+
+    $record->refresh();
+
+    expect($record->status)->toBe(EngagementResponseStatus::New);
+});
+
+it('resolves the underlying engagement response from a holistic engagement record', function () {
+    asSuperAdmin();
+    $engagementResponse = EngagementResponse::factory()->email()->create(['status' => EngagementResponseStatus::New]);
+
+    $holisticEngagement = HolisticEngagement::where('record_id', $engagementResponse->getKey())
+        ->where('record_type', 'engagement_response')
+        ->firstOrFail();
+
+    expect($holisticEngagement->record)->toBeInstanceOf(EngagementResponse::class);
+
+    $action = EngagementResponseMarkAsActionedAction::make('markAsActioned');
+
+    $resolved = $action->getEngagementResponse($holisticEngagement);
+
+    expect($resolved)
+        ->toBeInstanceOf(EngagementResponse::class)
+        ->and($resolved->getKey())->toBe($engagementResponse->getKey());
+});

--- a/app-modules/student-data-model/resources/views/components/filament/resources/educatables/view-educatable/engagement-modal-header.blade.php
+++ b/app-modules/student-data-model/resources/views/components/filament/resources/educatables/view-educatable/engagement-modal-header.blade.php
@@ -43,9 +43,15 @@
     View {{ $timelineable->getDeliveryMethod()->getLabel() }}
 </h1>
 @if ($status)
-    <span class="mt-2 flex w-auto text-gray-400 dark:text-gray-500">
-        <x-filament::badge>
+    @if ($tooltip ?? null)
+        <span x-data x-tooltip="{{ json_encode($tooltip) }}" class="mt-2 flex w-auto text-gray-400 dark:text-gray-500">
+            <x-filament::badge>
+                {{ $status }}
+            </x-filament::badge>
+        </span>
+    @else
+        <x-filament::badge class="mt-2 flex w-auto text-gray-400 dark:text-gray-500">
             {{ $status }}
         </x-filament::badge>
-    </span>
+    @endif
 @endif

--- a/app-modules/student-data-model/resources/views/components/filament/resources/educatables/view-educatable/engagement-modal-header.blade.php
+++ b/app-modules/student-data-model/resources/views/components/filament/resources/educatables/view-educatable/engagement-modal-header.blade.php
@@ -43,15 +43,30 @@
     View {{ $timelineable->getDeliveryMethod()->getLabel() }}
 </h1>
 @if ($status)
-    @if ($tooltip ?? null)
+    {{--
+        @if ($tooltip ?? null)
         <span x-data x-tooltip="{{ json_encode($tooltip) }}" class="mt-2 flex w-auto text-gray-400 dark:text-gray-500">
-            <x-filament::badge>
-                {{ $status }}
-            </x-filament::badge>
+        <x-filament::badge>
+        {{ $status }}
+        </x-filament::badge>
         </span>
-    @else
-        <x-filament::badge class="mt-2 flex w-auto text-gray-400 dark:text-gray-500">
+        @else
+        <span class="mt-2 flex w-auto text-gray-400 dark:text-gray-500">
+        <x-filament::badge>
+        {{ $status }}
+        </x-filament::badge>
+        </span>
+        @endif
+    --}}
+    <span
+        @if (! empty($tooltip))
+            x-data
+            x-tooltip="@json($tooltip)"
+        @endif
+        class="mt-2 flex w-auto text-gray-400 dark:text-gray-500"
+    >
+        <x-filament::badge>
             {{ $status }}
         </x-filament::badge>
-    @endif
+    </span>
 @endif

--- a/app-modules/student-data-model/resources/views/components/filament/resources/educatables/view-educatable/engagement-modal-header.blade.php
+++ b/app-modules/student-data-model/resources/views/components/filament/resources/educatables/view-educatable/engagement-modal-header.blade.php
@@ -43,17 +43,17 @@
     View {{ $timelineable->getDeliveryMethod()->getLabel() }}
 </h1>
 @if ($status)
-    <span
-        @if (! empty($tooltip))
-            x-data="{
-                tooltip: @json($tooltip),
-            }"
-            x-tooltip="tooltip"
-        @endif
-        class="mt-2 flex w-auto text-gray-400 dark:text-gray-500"
-    >
-        <x-filament::badge>
-            {{ $status }}
-        </x-filament::badge>
-    </span>
+    @if ($tooltip ?? null)
+        <span x-data x-tooltip="{{ json_encode($tooltip) }}" class="mt-2 flex w-auto text-gray-400 dark:text-gray-500">
+            <x-filament::badge>
+                {{ $status }}
+            </x-filament::badge>
+        </span>
+    @else
+        <span class="mt-2 flex w-auto text-gray-400 dark:text-gray-500">
+            <x-filament::badge>
+                {{ $status }}
+            </x-filament::badge>
+        </span>
+    @endif
 @endif

--- a/app-modules/student-data-model/resources/views/components/filament/resources/educatables/view-educatable/engagement-modal-header.blade.php
+++ b/app-modules/student-data-model/resources/views/components/filament/resources/educatables/view-educatable/engagement-modal-header.blade.php
@@ -43,25 +43,12 @@
     View {{ $timelineable->getDeliveryMethod()->getLabel() }}
 </h1>
 @if ($status)
-    {{--
-        @if ($tooltip ?? null)
-        <span x-data x-tooltip="{{ json_encode($tooltip) }}" class="mt-2 flex w-auto text-gray-400 dark:text-gray-500">
-        <x-filament::badge>
-        {{ $status }}
-        </x-filament::badge>
-        </span>
-        @else
-        <span class="mt-2 flex w-auto text-gray-400 dark:text-gray-500">
-        <x-filament::badge>
-        {{ $status }}
-        </x-filament::badge>
-        </span>
-        @endif
-    --}}
     <span
         @if (! empty($tooltip))
-            x-data
-            x-tooltip="@json($tooltip)"
+            x-data="{
+                tooltip: @json($tooltip),
+            }"
+            x-tooltip="tooltip"
         @endif
         class="mt-2 flex w-auto text-gray-400 dark:text-gray-500"
     >

--- a/app-modules/student-data-model/src/Filament/Resources/Students/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/Students/RelationManagers/EngagementsRelationManager.php
@@ -275,6 +275,7 @@ class EngagementsRelationManager extends RelationManager
             ])
             ->recordActions([
                 ViewAction::make()
+                    ->slideOver()
                     ->modalHeading(function (Timeline $record): Htmlable {
                         $status = match ($record->timelineable::class) {
                             EngagementResponse::class => $record->timelineable->status->getLabel(),
@@ -283,7 +284,7 @@ class EngagementsRelationManager extends RelationManager
 
                         $tooltip = null;
 
-                        if ($record->timelineable instanceof EngagementResponse && $record->timelineable->status === EngagementResponseStatus::Actioned) {
+                        if (EngagementResponseMarkAsActionedFeature::active() && $record->timelineable instanceof EngagementResponse && $record->timelineable->status === EngagementResponseStatus::Actioned) {
                             $tooltip = $record->timelineable->latestActionedNote?->getActionedNoteTooltip();
                         }
 

--- a/app-modules/student-data-model/src/Filament/Resources/Students/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/Students/RelationManagers/EngagementsRelationManager.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\StudentDataModel\Filament\Resources\Students\RelationManag
 use AdvisingApp\Engagement\Enums\EngagementDisplayStatus;
 use AdvisingApp\Engagement\Enums\EngagementResponseStatus;
 use AdvisingApp\Engagement\Enums\EngagementResponseType;
+use AdvisingApp\Engagement\Filament\Actions\EngagementResponseMarkAsActionedAction;
 use AdvisingApp\Engagement\Filament\Actions\RelationManagerSendEngagementAction;
 use AdvisingApp\Engagement\Models\Contracts\HasDeliveryMethod;
 use AdvisingApp\Engagement\Models\Engagement;
@@ -47,6 +48,7 @@ use AdvisingApp\Notification\Enums\NotificationChannel;
 use AdvisingApp\Notification\Models\EmailMessageEvent;
 use AdvisingApp\Notification\Models\SmsMessageEvent;
 use AdvisingApp\Timeline\Models\Timeline;
+use App\Features\EngagementResponseMarkAsActionedFeature;
 use App\Infolists\Components\EngagementBody;
 use Exception;
 use Filament\Actions\Action;
@@ -222,7 +224,8 @@ class EngagementsRelationManager extends RelationManager
                         Engagement::class => EngagementDisplayStatus::getStatus($record->timelineable),
                         default => 'N/A',
                     })
-                    ->badge(),
+                    ->badge()
+                    ->tooltip(fn (Timeline $record): ?string => EngagementResponseMarkAsActionedFeature::active() && $record->timelineable::class === EngagementResponse::class && $record->timelineable->status === EngagementResponseStatus::Actioned ? $record->timelineable->latestActionedNote?->getActionedNoteTooltip() : null),
                 TextColumn::make('subject')
                     ->label('Preview')
                     ->description(
@@ -247,11 +250,11 @@ class EngagementsRelationManager extends RelationManager
                     )
                     ->state(fn (Timeline $record) => match ($record->timelineable::class) {
                         Engagement::class => $record->timelineable->channel === NotificationChannel::Sms
-                                ? Str::limit($record->timelineable->getBodyText(), 50)
-                                : Str::limit((string) $record->timelineable->getSubject(), 50),
+                            ? Str::limit($record->timelineable->getBodyText(), 50)
+                            : Str::limit((string) $record->timelineable->getSubject(), 50),
                         EngagementResponse::class => $record->timelineable->type === EngagementResponseType::Sms
-                                ? Str::limit(html_entity_decode(strip_tags($record->timelineable->getBody()), ENT_QUOTES | ENT_HTML5, 'UTF-8'), 50)
-                                : Str::limit(html_entity_decode(strip_tags($record->timelineable->subject), ENT_QUOTES | ENT_HTML5, 'UTF-8'), 50),
+                            ? Str::limit(html_entity_decode(strip_tags($record->timelineable->getBody()), ENT_QUOTES | ENT_HTML5, 'UTF-8'), 50)
+                            : Str::limit(html_entity_decode(strip_tags($record->timelineable->subject), ENT_QUOTES | ENT_HTML5, 'UTF-8'), 50),
 
                         default => '',
                     }),
@@ -278,37 +281,64 @@ class EngagementsRelationManager extends RelationManager
                             default => ''
                         };
 
-                        return new HtmlString(view('student-data-model::components.filament.resources.educatables.view-educatable.engagement-modal-header', ['record' => $record, 'status' => $status]));
+                        $tooltip = null;
+
+                        if ($record->timelineable instanceof EngagementResponse && $record->timelineable->status === EngagementResponseStatus::Actioned) {
+                            $tooltip = $record->timelineable->latestActionedNote?->getActionedNoteTooltip();
+                        }
+
+                        return new HtmlString(view('student-data-model::components.filament.resources.educatables.view-educatable.engagement-modal-header', ['record' => $record, 'status' => $status, 'tooltip' => $tooltip]));
                     })
                     ->extraModalFooterActions([
-                        Action::make('updateStatus')
-                            ->label(
-                                function (Timeline $record) {
-                                    /** @var EngagementResponse $timelineable */
-                                    $timelineable = $record->timelineable;
+                        ...[
+                            EngagementResponseMarkAsActionedFeature::active() ?
+                                EngagementResponseMarkAsActionedAction::make('markAsActioned')
+                                    ->color('gray')
+                                    ->visible(fn (Timeline $record): bool => $record->timelineable instanceof EngagementResponse && $record->timelineable->status === EngagementResponseStatus::New) :
+                                Action::make('markAsActioned')
+                                    ->label(
+                                        function (Timeline $record) {
+                                            /** @var EngagementResponse $timelineable */
+                                            $timelineable = $record->timelineable;
 
-                                    return $timelineable->status === EngagementResponseStatus::New ? 'Mark as Actioned' : 'Mark as New';
-                                }
-                            )
+                                            return $timelineable->status === EngagementResponseStatus::New ? 'Mark as Actioned' : 'Mark as New';
+                                        }
+                                    )
+                                    ->color('gray')
+                                    ->action(
+                                        function (Timeline $record) {
+                                            /** @var EngagementResponse $timelineable */
+                                            $timelineable = $record->timelineable;
+
+                                            if ($timelineable->status === EngagementResponseStatus::New) {
+                                                $timelineable->update(['status' => EngagementResponseStatus::Actioned]);
+                                            } else {
+                                                $timelineable->update(['status' => EngagementResponseStatus::New]);
+                                            }
+
+                                            Notification::make()
+                                                ->success()
+                                                ->title('Status updated!')
+                                                ->send();
+                                        }
+                                    )
+                                    ->visible(fn (Timeline $record): bool => ! EngagementResponseMarkAsActionedFeature::active() && $record->timelineable instanceof EngagementResponse && $record->timelineable->status === EngagementResponseStatus::New),
+                        ],
+                        Action::make('markAsNew')
+                            ->label('Mark as New')
                             ->color('gray')
-                            ->action(
-                                function (Timeline $record) {
-                                    /** @var EngagementResponse $timelineable */
-                                    $timelineable = $record->timelineable;
+                            ->action(function (Timeline $record) {
+                                /** @var EngagementResponse $engagementResponse */
+                                $engagementResponse = $record->timelineable;
 
-                                    if ($timelineable->status === EngagementResponseStatus::New) {
-                                        $timelineable->update(['status' => EngagementResponseStatus::Actioned]);
-                                    } else {
-                                        $timelineable->update(['status' => EngagementResponseStatus::New]);
-                                    }
+                                $engagementResponse->update(['status' => EngagementResponseStatus::New]);
 
-                                    Notification::make()
-                                        ->success()
-                                        ->title('Status updated!')
-                                        ->send();
-                                }
-                            )
-                            ->visible(fn (Timeline $record): bool => $record->timelineable instanceof EngagementResponse),
+                                Notification::make()
+                                    ->success()
+                                    ->title('Status updated!')
+                                    ->send();
+                            })
+                            ->visible(fn (Timeline $record): bool => $record->timelineable instanceof EngagementResponse && $record->timelineable->status === EngagementResponseStatus::Actioned),
                     ]),
             ])
             ->filters([

--- a/app-modules/student-data-model/src/Filament/Resources/Students/RelationManagers/EngagementsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/Students/RelationManagers/EngagementsRelationManager.php
@@ -198,10 +198,13 @@ class EngagementsRelationManager extends RelationManager
                         ...($canAccessEngagementResponses ? [EngagementResponse::class] : []),
                     ])
                     ->with([
-                        'timelineable' => function ($morphQuery) use ($canAccessEngagements) {
+                        'timelineable' => function ($morphQuery) use ($canAccessEngagements, $canAccessEngagementResponses) {
                             $morphQuery->when(
                                 $canAccessEngagements && $morphQuery->getModel() instanceof Engagement,
                                 fn (Builder $query) => $query->with(['latestEmailMessage.events', 'latestSmsMessage.events'])
+                            )->when(
+                                $canAccessEngagementResponses && $morphQuery->getModel() instanceof EngagementResponse,
+                                fn (Builder $query) => $query->with('latestActionedNote')
                             );
                         },
                     ])

--- a/app/Features/EngagementResponseMarkAsActionedFeature.php
+++ b/app/Features/EngagementResponseMarkAsActionedFeature.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/app/Features/EngagementResponseMarkAsActionedFeature.php
+++ b/app/Features/EngagementResponseMarkAsActionedFeature.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class EngagementResponseMarkAsActionedFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2623
 
### Technical Description

> Enhance the ability to add details when email/sms status changes to actioned.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> Yes, `EngagementResponseMarkAsActionedFeature`

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
