### PR TITLE
[ADVAPP-2626]: Update the naming used for chatbots to reflect the natural evolution of the features

### DIFF
--- a/app-modules/ai/resources/views/filament/resources/qna-advisors/pages/preview-qna-advisor.blade.php
+++ b/app-modules/ai/resources/views/filament/resources/qna-advisors/pages/preview-qna-advisor.blade.php
@@ -41,7 +41,7 @@
 <x-filament-panels::page>
     @if ($this->isFailed)
         <x-filament::empty-state icon="heroicon-o-x-circle">
-            <x-slot name="heading">QnA Advisor Failed to Learn</x-slot>
+            <x-slot name="heading">Customer Advisor Failed to Learn</x-slot>
 
             <x-slot name="description">
                 There was an issue while trying to learn from the materials you have uploaded/provided. Please
@@ -57,7 +57,7 @@
         </x-filament::empty-state>
     @elseif ($this->isProcessing)
         <x-filament::empty-state icon="heroicon-o-clock">
-            <x-slot name="heading">QnA Advisor is Learning</x-slot>
+            <x-slot name="heading">Customer Advisor is Learning</x-slot>
 
             <x-slot name="description">
                 This AI advisor is still learning from the materials you have uploaded/provided. Please check back in

--- a/app-modules/ai/src/Enums/AiModelApplicabilityFeature.php
+++ b/app-modules/ai/src/Enums/AiModelApplicabilityFeature.php
@@ -54,9 +54,9 @@ enum AiModelApplicabilityFeature: string implements HasLabel
     {
         return match ($this) {
             self::InstitutionalAdvisor => 'Institutional Advisor',
-            self::CustomAdvisors => 'Custom Advisors',
+            self::CustomAdvisors => 'Employee Advisors',
             self::ResearchAdvisor => 'Research Advisor',
-            self::QuestionAndAnswerAdvisor => 'QnA Advisor',
+            self::QuestionAndAnswerAdvisor => 'Customer Advisor',
             self::IntegratedAdvisor => 'Integrated Advisor',
         };
     }

--- a/app-modules/ai/src/Filament/Pages/ManageAiCustomAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiCustomAdvisorSettings.php
@@ -57,13 +57,15 @@ class ManageAiCustomAdvisorSettings extends SettingsPage
 {
     protected static string $settings = AiCustomAdvisorSettings::class;
 
-    protected static ?string $title = 'Custom Advisor';
+    protected static ?string $title = 'Employee Advisor';
 
     protected static ?string $cluster = GlobalArtificialIntelligence::class;
 
     protected static ?int $navigationSort = 15;
 
     protected ?bool $hasDatabaseTransactions = true;
+
+    protected static ?string $slug = 'manage-ai-employee-advisor-settings';
 
     public static function canAccess(): bool
     {
@@ -84,7 +86,7 @@ class ManageAiCustomAdvisorSettings extends SettingsPage
             ->components([
                 Toggle::make('allow_selection_of_model')
                     ->label('Allow selection of model?')
-                    ->helperText('If enabled, users can select a model when creating or editing custom advisors.')
+                    ->helperText('If enabled, users can select a model when creating or editing employee advisors.')
                     ->live(),
                 Select::make('preselected_model')
                     ->label('Select Model')
@@ -97,7 +99,7 @@ class ManageAiCustomAdvisorSettings extends SettingsPage
                         },
                     ]))
                     ->searchable()
-                    ->helperText('This model will be the model used for custom advisors.')
+                    ->helperText('This model will be the model used for employee advisors.')
                     ->required()
                     ->rule(Rule::enum(AiModel::class)->only(AiModelApplicabilityFeature::CustomAdvisors->getModels()))
                     ->visible(fn (Get $get): bool => ! $get('allow_selection_of_model')),

--- a/app-modules/ai/src/Filament/Pages/ManageAiQnaAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiQnaAdvisorSettings.php
@@ -52,11 +52,13 @@ class ManageAiQnaAdvisorSettings extends ManageAiCustomAdvisorSettings
 {
     protected static string $settings = AiQnaAdvisorSettings::class;
 
-    protected static ?string $title = 'QnA Advisor';
+    protected static ?string $title = 'Customer Advisor';
 
     protected static ?int $navigationSort = 40;
 
     protected static ?string $cluster = GlobalArtificialIntelligence::class;
+
+    protected static ?string $slug = 'manage-ai-customer-advisor-settings';
 
     public static function canAccess(): bool
     {
@@ -73,7 +75,7 @@ class ManageAiQnaAdvisorSettings extends ManageAiCustomAdvisorSettings
             ->components([
                 Toggle::make('allow_selection_of_model')
                     ->label('Allow selection of model?')
-                    ->helperText('If enabled, admin can select a model when creating or editing QnA advisors.')
+                    ->helperText('If enabled, admin can select a model when creating or editing Customer advisors.')
                     ->columnSpanFull()
                     ->live(),
                 Select::make('preselected_model')
@@ -87,7 +89,7 @@ class ManageAiQnaAdvisorSettings extends ManageAiCustomAdvisorSettings
                         },
                     ]))
                     ->searchable()
-                    ->helperText('This model will be the model used for QnA advisors.')
+                    ->helperText('This model will be the model used for Customer advisors.')
                     ->columnSpanFull()
                     ->required()
                     ->visible(fn (Get $get): bool => ! $get('allow_selection_of_model'))
@@ -109,7 +111,7 @@ class ManageAiQnaAdvisorSettings extends ManageAiCustomAdvisorSettings
                     ->columnSpanFull()
                     ->rows(10)
                     ->maxLength(65535)
-                    ->helperText('These restrictions will be applied to the QnA advisor. Use this field to specify any limitations or guidelines for the AI model.')
+                    ->helperText('These restrictions will be applied to the Customer advisor. Use this field to specify any limitations or guidelines for the AI model.')
                     ->required(),
             ]);
     }

--- a/app-modules/ai/src/Filament/Pages/ManageAiQnaAdvisorSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiQnaAdvisorSettings.php
@@ -75,7 +75,7 @@ class ManageAiQnaAdvisorSettings extends ManageAiCustomAdvisorSettings
             ->components([
                 Toggle::make('allow_selection_of_model')
                     ->label('Allow selection of model?')
-                    ->helperText('If enabled, admin can select a model when creating or editing Customer advisors.')
+                    ->helperText('If enabled, admin can select a model when creating or editing customer advisors.')
                     ->columnSpanFull()
                     ->live(),
                 Select::make('preselected_model')
@@ -89,7 +89,7 @@ class ManageAiQnaAdvisorSettings extends ManageAiCustomAdvisorSettings
                         },
                     ]))
                     ->searchable()
-                    ->helperText('This model will be the model used for Customer advisors.')
+                    ->helperText('This model will be the model used for customer advisors.')
                     ->columnSpanFull()
                     ->required()
                     ->visible(fn (Get $get): bool => ! $get('allow_selection_of_model'))
@@ -111,7 +111,7 @@ class ManageAiQnaAdvisorSettings extends ManageAiCustomAdvisorSettings
                     ->columnSpanFull()
                     ->rows(10)
                     ->maxLength(65535)
-                    ->helperText('These restrictions will be applied to the Customer advisor. Use this field to specify any limitations or guidelines for the AI model.')
+                    ->helperText('These restrictions will be applied to the customer advisor. Use this field to specify any limitations or guidelines for the AI model.')
                     ->required(),
             ]);
     }

--- a/app-modules/ai/src/Filament/Resources/AiAssistants/AiAssistantResource.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistants/AiAssistantResource.php
@@ -52,11 +52,13 @@ class AiAssistantResource extends Resource
 
     protected static string | UnitEnum | null $navigationGroup = 'Enterprise AI';
 
-    protected static ?string $navigationLabel = 'Custom Advisors';
+    protected static ?string $navigationLabel = 'Employee Advisors';
 
-    protected static ?string $modelLabel = 'Custom Advisor';
+    protected static ?string $modelLabel = 'Employee Advisor';
 
     protected static ?int $navigationSort = 30;
+
+    protected static ?string $slug = 'employee-advisors';
 
     public static function getPages(): array
     {

--- a/app-modules/ai/src/Filament/Resources/AiAssistants/AiAssistantResource.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistants/AiAssistantResource.php
@@ -50,13 +50,13 @@ class AiAssistantResource extends Resource
 {
     protected static ?string $model = AiAssistant::class;
 
-    protected static string | UnitEnum | null $navigationGroup = 'Enterprise AI';
+    protected static string | UnitEnum | null $navigationGroup = 'Chatbots';
 
     protected static ?string $navigationLabel = 'Employee Advisors';
 
     protected static ?string $modelLabel = 'Employee Advisor';
 
-    protected static ?int $navigationSort = 30;
+    protected static ?int $navigationSort = 20;
 
     protected static ?string $slug = 'employee-advisors';
 

--- a/app-modules/ai/src/Filament/Resources/AiAssistants/Forms/AiAssistantForm.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistants/Forms/AiAssistantForm.php
@@ -71,7 +71,7 @@ class AiAssistantForm
                     ->columnSpanFull(),
                 Select::make('application')
                     ->options([
-                        AiAssistantApplication::PersonalAssistant->value => 'Custom Advisor',
+                        AiAssistantApplication::PersonalAssistant->value => 'Employee Advisor',
                     ])
                     ->dehydratedWhenHidden()
                     ->default(AiAssistantApplication::getDefault())

--- a/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/ListAiAssistants.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/ListAiAssistants.php
@@ -77,8 +77,8 @@ class ListAiAssistants extends ListRecords
             ->recordActions([
                 EditAction::make(),
             ])
-            ->emptyStateHeading('No AI Assistants')
-            ->emptyStateDescription('Add a new custom AI Assistant by clicking the "Create AI Assistant" button above.')
+            ->emptyStateHeading('No Employee Advisors')
+            ->emptyStateDescription('Add a new Employee Advisor by clicking the "New" button above.')
             ->modifyQueryUsing(fn (Builder $query) => $query->where('is_default', false));
     }
 

--- a/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/ManageAiAssistantAdditionalKnowledge.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/ManageAiAssistantAdditionalKnowledge.php
@@ -100,7 +100,7 @@ class ManageAiAssistantAdditionalKnowledge extends EditRecord
         return $schema
             ->components([
                 Section::make('Additional Knowledge')
-                    ->description('Add additional knowledge to this employee Advisor to improve its responses.')
+                    ->description('Add additional knowledge to this employee advisor to improve its responses.')
                     ->reactive()
                     ->columns([
                         'sm' => 1,
@@ -130,7 +130,7 @@ class ManageAiAssistantAdditionalKnowledge extends EditRecord
                             ->deleteAction(
                                 fn (Action $action) => $action->requiresConfirmation()
                                     ->modalHeading('Are you sure you want to delete this file?')
-                                    ->modalDescription('This file will be permanently removed from this employee Advisor, and cannot be restored.')
+                                    ->modalDescription('This file will be permanently removed from this employee advisor, and cannot be restored.')
                             ),
                         FileUpload::make('uploaded_files')
                             ->hiddenLabel()
@@ -145,7 +145,7 @@ class ManageAiAssistantAdditionalKnowledge extends EditRecord
                                     return 'You may upload a total of 25 files to this AI Assistant. Files must be less than ' . Number::fileSize(config('ai.file_size_limit_kb') * 1000) . '.';
                                 }
 
-                                return "You've reached the maximum file upload limit of 25 for this employee Advisor. Please delete a file if you wish to upload another.";
+                                return "You've reached the maximum file upload limit of 25 for this employee advisor. Please delete a file if you wish to upload another.";
                             })
                             ->maxSize(config('ai.file_size_limit_kb'))
                             ->columnSpan(function (Get $get) {

--- a/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/ManageAiAssistantAdditionalKnowledge.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/ManageAiAssistantAdditionalKnowledge.php
@@ -100,7 +100,7 @@ class ManageAiAssistantAdditionalKnowledge extends EditRecord
         return $schema
             ->components([
                 Section::make('Additional Knowledge')
-                    ->description('Add additional knowledge to this Custom Advisor to improve its responses.')
+                    ->description('Add additional knowledge to this Employee Advisor to improve its responses.')
                     ->reactive()
                     ->columns([
                         'sm' => 1,
@@ -130,7 +130,7 @@ class ManageAiAssistantAdditionalKnowledge extends EditRecord
                             ->deleteAction(
                                 fn (Action $action) => $action->requiresConfirmation()
                                     ->modalHeading('Are you sure you want to delete this file?')
-                                    ->modalDescription('This file will be permanently removed from this Custom Advisor, and cannot be restored.')
+                                    ->modalDescription('This file will be permanently removed from this Employee Advisor, and cannot be restored.')
                             ),
                         FileUpload::make('uploaded_files')
                             ->hiddenLabel()
@@ -145,7 +145,7 @@ class ManageAiAssistantAdditionalKnowledge extends EditRecord
                                     return 'You may upload a total of 25 files to this AI Assistant. Files must be less than ' . Number::fileSize(config('ai.file_size_limit_kb') * 1000) . '.';
                                 }
 
-                                return "You've reached the maximum file upload limit of 25 for this Custom Advisor. Please delete a file if you wish to upload another.";
+                                return "You've reached the maximum file upload limit of 25 for this Employee Advisor. Please delete a file if you wish to upload another.";
                             })
                             ->maxSize(config('ai.file_size_limit_kb'))
                             ->columnSpan(function (Get $get) {

--- a/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/ManageAiAssistantAdditionalKnowledge.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/ManageAiAssistantAdditionalKnowledge.php
@@ -100,7 +100,7 @@ class ManageAiAssistantAdditionalKnowledge extends EditRecord
         return $schema
             ->components([
                 Section::make('Additional Knowledge')
-                    ->description('Add additional knowledge to this Employee Advisor to improve its responses.')
+                    ->description('Add additional knowledge to this employee Advisor to improve its responses.')
                     ->reactive()
                     ->columns([
                         'sm' => 1,
@@ -130,7 +130,7 @@ class ManageAiAssistantAdditionalKnowledge extends EditRecord
                             ->deleteAction(
                                 fn (Action $action) => $action->requiresConfirmation()
                                     ->modalHeading('Are you sure you want to delete this file?')
-                                    ->modalDescription('This file will be permanently removed from this Employee Advisor, and cannot be restored.')
+                                    ->modalDescription('This file will be permanently removed from this employee Advisor, and cannot be restored.')
                             ),
                         FileUpload::make('uploaded_files')
                             ->hiddenLabel()
@@ -145,7 +145,7 @@ class ManageAiAssistantAdditionalKnowledge extends EditRecord
                                     return 'You may upload a total of 25 files to this AI Assistant. Files must be less than ' . Number::fileSize(config('ai.file_size_limit_kb') * 1000) . '.';
                                 }
 
-                                return "You've reached the maximum file upload limit of 25 for this Employee Advisor. Please delete a file if you wish to upload another.";
+                                return "You've reached the maximum file upload limit of 25 for this employee Advisor. Please delete a file if you wish to upload another.";
                             })
                             ->maxSize(config('ai.file_size_limit_kb'))
                             ->columnSpan(function (Get $get) {

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/EditQnaAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/EditQnaAdvisor.php
@@ -66,7 +66,7 @@ class EditQnaAdvisor extends EditRecord
 
     protected static ?string $navigationLabel = 'Edit';
 
-    protected static string | UnitEnum | null $navigationGroup = 'QnA Advisor';
+    protected static string | UnitEnum | null $navigationGroup = 'Customer Advisor';
 
     /**
      * @return array<int|string, string|null>
@@ -165,7 +165,7 @@ class EditQnaAdvisor extends EditRecord
                     $qnaAdvisor->save();
 
                     Notification::make()
-                        ->title('QnA Advisor archived')
+                        ->title('Customer Advisor archived')
                         ->success()
                         ->send();
                 })
@@ -178,7 +178,7 @@ class EditQnaAdvisor extends EditRecord
                     $qnaAdvisor->save();
 
                     Notification::make()
-                        ->title('QnA Advisor restored')
+                        ->title('Customer Advisor restored')
                         ->success()
                         ->send();
                 })

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/ManageCategories.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/ManageCategories.php
@@ -123,12 +123,12 @@ class ManageCategories extends ManageRelatedRecords
             ])
             ->headerActions([
                 CreateAction::make()
-                    ->modalHeading('Create QnA Advisor Category'),
+                    ->modalHeading('Create Customer Advisor Category'),
             ])
             ->recordActions([
                 EditAction::make(),
             ])
-            ->emptyStateHeading('No QnA Advisor Categories Found')
+            ->emptyStateHeading('No Customer Advisor Categories Found')
             ->emptyStateDescription('');
     }
 }

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/ManageQnaAdditionalKnowledge.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/ManageQnaAdditionalKnowledge.php
@@ -102,7 +102,7 @@ class ManageQnaAdditionalKnowledge extends EditRecord
         return $schema
             ->components([
                 Section::make('Additional Knowledge')
-                    ->description('Add additional knowledge to this QnA Advisor to improve its responses.')
+                    ->description('Add additional knowledge to this Customer Advisor to improve its responses.')
                     ->reactive()
                     ->columns([
                         'sm' => 1,
@@ -132,7 +132,7 @@ class ManageQnaAdditionalKnowledge extends EditRecord
                             ->deleteAction(
                                 fn (Action $action) => $action->requiresConfirmation()
                                     ->modalHeading('Are you sure you want to delete this file?')
-                                    ->modalDescription('This file will be permanently removed from this QnA Advisor, and cannot be restored.')
+                                    ->modalDescription('This file will be permanently removed from this Customer Advisor, and cannot be restored.')
                             ),
                         FileUpload::make('uploaded_files')
                             ->hiddenLabel()
@@ -144,10 +144,10 @@ class ManageQnaAdditionalKnowledge extends EditRecord
                             ->storeFiles(false)
                             ->helperText(function (QnaAdvisor $record): string {
                                 if ($record->files->count() < 25) {
-                                    return 'You may upload a total of 25 files to this QnA Advisor. Files must be less than ' . Number::fileSize(config('ai.file_size_limit_kb') * 1000) . '.';
+                                    return 'You may upload a total of 25 files to this Customer Advisor. Files must be less than ' . Number::fileSize(config('ai.file_size_limit_kb') * 1000) . '.';
                                 }
 
-                                return "You've reached the maximum file upload limit of 25 for this QnA Advisor. Please delete a file if you wish to upload another.";
+                                return "You've reached the maximum file upload limit of 25 for this Customer Advisor. Please delete a file if you wish to upload another.";
                             })
                             ->maxSize(config('ai.file_size_limit_kb'))
                             ->columnSpan(function (Get $get) {

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/ManageQnaQuestions.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/ManageQnaQuestions.php
@@ -144,7 +144,7 @@ class ManageQnaQuestions extends ManageRelatedRecords
             ])
             ->headerActions([
                 CreateAction::make()
-                    ->modalHeading('Create QnA Advisor Question'),
+                    ->modalHeading('Create Customer Advisor Question'),
             ])
             ->recordActions([
                 EditAction::make(),
@@ -155,7 +155,7 @@ class ManageQnaQuestions extends ManageRelatedRecords
                     DeleteBulkAction::make(),
                 ]),
             ])
-            ->emptyStateHeading('No QnA Advisor Questions Found')
+            ->emptyStateHeading('No Customer Advisor Questions Found')
             ->emptyStateDescription('');
     }
 }

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/QnaAdvisorEmbed.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/QnaAdvisorEmbed.php
@@ -91,7 +91,7 @@ class QnaAdvisorEmbed extends EditRecord
                             ->live(),
                         TagsInput::make('authorized_domains')
                             ->label('Authorized Domains')
-                            ->helperText('Only these domains will be allowed to embed this customer Advisor.')
+                            ->helperText('Only these domains will be allowed to embed this customer advisor.')
                             ->placeholder('example.com')
                             ->hidden(fn (Get $get) => ! $get('is_embed_enabled'))
                             ->disabled(fn (Get $get) => ! $get('is_embed_enabled'))
@@ -107,7 +107,7 @@ class QnaAdvisorEmbed extends EditRecord
                             ->hidden(fn (Get $get) => ! $get('is_embed_enabled')),
                         Toggle::make('is_generate_prospects_enabled')
                             ->label('Generate Prospects')
-                            ->helperText('If enabled, the customer Advisor will allow for the registration of an unrecognized prospect.')
+                            ->helperText('If enabled, the customer advisor will allow for the registration of an unrecognized prospect.')
                             ->hidden(fn (Get $get) => ! $get('is_embed_enabled') || ! $get('is_requires_authentication_enabled')),
                         Radio::make('default_theme')
                             ->label('Theme')

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/QnaAdvisorEmbed.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/QnaAdvisorEmbed.php
@@ -91,7 +91,7 @@ class QnaAdvisorEmbed extends EditRecord
                             ->live(),
                         TagsInput::make('authorized_domains')
                             ->label('Authorized Domains')
-                            ->helperText('Only these domains will be allowed to embed this QnA Advisor.')
+                            ->helperText('Only these domains will be allowed to embed this Customer Advisor.')
                             ->placeholder('example.com')
                             ->hidden(fn (Get $get) => ! $get('is_embed_enabled'))
                             ->disabled(fn (Get $get) => ! $get('is_embed_enabled'))
@@ -107,7 +107,7 @@ class QnaAdvisorEmbed extends EditRecord
                             ->hidden(fn (Get $get) => ! $get('is_embed_enabled')),
                         Toggle::make('is_generate_prospects_enabled')
                             ->label('Generate Prospects')
-                            ->helperText('If enabled, the QnA Advisor will allow for the registration of an unrecognized prospect.')
+                            ->helperText('If enabled, the Customer Advisor will allow for the registration of an unrecognized prospect.')
                             ->hidden(fn (Get $get) => ! $get('is_embed_enabled') || ! $get('is_requires_authentication_enabled')),
                         Radio::make('default_theme')
                             ->label('Theme')

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/QnaAdvisorEmbed.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/QnaAdvisorEmbed.php
@@ -91,7 +91,7 @@ class QnaAdvisorEmbed extends EditRecord
                             ->live(),
                         TagsInput::make('authorized_domains')
                             ->label('Authorized Domains')
-                            ->helperText('Only these domains will be allowed to embed this Customer Advisor.')
+                            ->helperText('Only these domains will be allowed to embed this customer Advisor.')
                             ->placeholder('example.com')
                             ->hidden(fn (Get $get) => ! $get('is_embed_enabled'))
                             ->disabled(fn (Get $get) => ! $get('is_embed_enabled'))
@@ -107,7 +107,7 @@ class QnaAdvisorEmbed extends EditRecord
                             ->hidden(fn (Get $get) => ! $get('is_embed_enabled')),
                         Toggle::make('is_generate_prospects_enabled')
                             ->label('Generate Prospects')
-                            ->helperText('If enabled, the Customer Advisor will allow for the registration of an unrecognized prospect.')
+                            ->helperText('If enabled, the customer Advisor will allow for the registration of an unrecognized prospect.')
                             ->hidden(fn (Get $get) => ! $get('is_embed_enabled') || ! $get('is_requires_authentication_enabled')),
                         Radio::make('default_theme')
                             ->label('Theme')

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/ViewQnaAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/Pages/ViewQnaAdvisor.php
@@ -59,7 +59,7 @@ class ViewQnaAdvisor extends ViewRecord
 
     protected static ?string $navigationLabel = 'View';
 
-    protected static string | UnitEnum | null $navigationGroup = 'QnA Advisor';
+    protected static string | UnitEnum | null $navigationGroup = 'Customer Advisor';
 
     public function infolist(Schema $schema): Schema
     {
@@ -145,7 +145,7 @@ class ViewQnaAdvisor extends ViewRecord
                     $record->save();
 
                     Notification::make()
-                        ->title('QnA Advisor archived')
+                        ->title('Customer Advisor archived')
                         ->success()
                         ->send();
                 })
@@ -158,7 +158,7 @@ class ViewQnaAdvisor extends ViewRecord
                     $record->save();
 
                     Notification::make()
-                        ->title('QnA Advisor restored')
+                        ->title('Customer Advisor restored')
                         ->success()
                         ->send();
                 })

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/QnaAdvisorResource.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/QnaAdvisorResource.php
@@ -60,7 +60,7 @@ class QnaAdvisorResource extends Resource
 
     protected static ?string $modelLabel = 'Customer Advisor';
 
-    protected static ?int $navigationSort = 40;
+    protected static ?int $navigationSort = 10;
 
     public static function getPages(): array
     {

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/QnaAdvisorResource.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/QnaAdvisorResource.php
@@ -62,6 +62,8 @@ class QnaAdvisorResource extends Resource
 
     protected static ?int $navigationSort = 10;
 
+    protected static ?string $slug = 'customer-advisors';
+
     public static function getPages(): array
     {
         return [

--- a/app-modules/ai/src/Filament/Resources/QnaAdvisors/QnaAdvisorResource.php
+++ b/app-modules/ai/src/Filament/Resources/QnaAdvisors/QnaAdvisorResource.php
@@ -58,7 +58,7 @@ class QnaAdvisorResource extends Resource
 
     protected static string | UnitEnum | null $navigationGroup = 'Chatbots';
 
-    protected static ?string $modelLabel = 'QnA Advisor';
+    protected static ?string $modelLabel = 'Customer Advisor';
 
     protected static ?int $navigationSort = 40;
 

--- a/app-modules/ai/src/Jobs/QnaAdvisors/CreateQnaAdvisorThreadInteraction.php
+++ b/app-modules/ai/src/Jobs/QnaAdvisors/CreateQnaAdvisorThreadInteraction.php
@@ -83,7 +83,7 @@ class CreateQnaAdvisorThreadInteraction implements ShouldQueue
             $interaction = $this->thread->author->interactions()->create([
                 'start_datetime' => $this->thread->messages()->oldest()->value('created_at'),
                 'end_datetime' => $this->thread->messages()->latest()->value('created_at'),
-                'subject' => "{$this->thread->advisor->name} (QnA Advisor) Chat Session",
+                'subject' => "{$this->thread->advisor->name} (Customer Advisor) Chat Session",
                 'description' => <<<"EOD"
                     **Summary:**
 

--- a/app-modules/ai/src/Policies/QnaAdvisorCategoryPolicy.php
+++ b/app-modules/ai/src/Policies/QnaAdvisorCategoryPolicy.php
@@ -58,7 +58,7 @@ class QnaAdvisorCategoryPolicy
     {
         return $authenticatable->canOrElse(
             abilities: 'qna_advisor.view-any',
-            denyResponse: 'You do not have permission to view QnA Advisor Categories.'
+            denyResponse: 'You do not have permission to view Customer Advisor Categories.'
         );
     }
 
@@ -66,7 +66,7 @@ class QnaAdvisorCategoryPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.view'],
-            denyResponse: 'You do not have permission to view this QnA Advisor Category.'
+            denyResponse: 'You do not have permission to view this Customer Advisor Category.'
         );
     }
 
@@ -74,7 +74,7 @@ class QnaAdvisorCategoryPolicy
     {
         return $authenticatable->canOrElse(
             abilities: 'qna_advisor.create',
-            denyResponse: 'You do not have permission to create QnA Advisor Categories.'
+            denyResponse: 'You do not have permission to create Customer Advisor Categories.'
         );
     }
 
@@ -82,7 +82,7 @@ class QnaAdvisorCategoryPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.update'],
-            denyResponse: 'You do not have permission to update this QnA Advisor Category.'
+            denyResponse: 'You do not have permission to update this Customer Advisor Category.'
         );
     }
 
@@ -90,7 +90,7 @@ class QnaAdvisorCategoryPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.delete'],
-            denyResponse: 'You do not have permission to delete this QnA Advisor Category.'
+            denyResponse: 'You do not have permission to delete this Customer Advisor Category.'
         );
     }
 
@@ -98,7 +98,7 @@ class QnaAdvisorCategoryPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.restore'],
-            denyResponse: 'You do not have permission to restore this QnA Advisor Category.'
+            denyResponse: 'You do not have permission to restore this Customer Advisor Category.'
         );
     }
 
@@ -106,7 +106,7 @@ class QnaAdvisorCategoryPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.force-delete'],
-            denyResponse: 'You do not have permission to force-delete this QnA Advisor Category.'
+            denyResponse: 'You do not have permission to force-delete this Customer Advisor Category.'
         );
     }
 }

--- a/app-modules/ai/src/Policies/QnaAdvisorPolicy.php
+++ b/app-modules/ai/src/Policies/QnaAdvisorPolicy.php
@@ -54,7 +54,7 @@ class QnaAdvisorPolicy
         }
 
         if (! Gate::check(Feature::QnAAdvisor->getGateName())) {
-            return Response::deny('QnA Advisors are not enabled.');
+            return Response::deny('Customer Advisors are not enabled.');
         }
 
         return null;
@@ -64,7 +64,7 @@ class QnaAdvisorPolicy
     {
         return $authenticatable->canOrElse(
             abilities: 'qna_advisor.view-any',
-            denyResponse: 'You do not have permission to view QnA Advisors.'
+            denyResponse: 'You do not have permission to view Customer Advisors.'
         );
     }
 
@@ -72,7 +72,7 @@ class QnaAdvisorPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.view'],
-            denyResponse: 'You do not have permission to view this QnA Advisor.'
+            denyResponse: 'You do not have permission to view this Customer Advisor.'
         );
     }
 
@@ -80,7 +80,7 @@ class QnaAdvisorPolicy
     {
         return $authenticatable->canOrElse(
             abilities: 'qna_advisor.create',
-            denyResponse: 'You do not have permission to create QnA Advisors.'
+            denyResponse: 'You do not have permission to create Customer Advisors.'
         );
     }
 
@@ -88,22 +88,22 @@ class QnaAdvisorPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.update'],
-            denyResponse: 'You do not have permission to update this QnA Advisor.'
+            denyResponse: 'You do not have permission to update this Customer Advisor.'
         );
     }
 
     public function delete(Authenticatable $authenticatable): Response
     {
-        return Response::deny('QnA Advisor cannot be deleted.');
+        return Response::deny('Customer Advisor cannot be deleted.');
     }
 
     public function restore(Authenticatable $authenticatable): Response
     {
-        return Response::deny('QnA Advisor cannot be restored.');
+        return Response::deny('Customer Advisor cannot be restored.');
     }
 
     public function forceDelete(Authenticatable $authenticatable): Response
     {
-        return Response::deny('QnA Advisor cannot be permanently deleted.');
+        return Response::deny('Customer Advisor cannot be permanently deleted.');
     }
 }

--- a/app-modules/ai/src/Policies/QnaAdvisorQuestionPolicy.php
+++ b/app-modules/ai/src/Policies/QnaAdvisorQuestionPolicy.php
@@ -58,7 +58,7 @@ class QnaAdvisorQuestionPolicy
     {
         return $authenticatable->canOrElse(
             abilities: 'qna_advisor.view-any',
-            denyResponse: 'You do not have permission to view QnA Advisor Questions.'
+            denyResponse: 'You do not have permission to view Customer Advisor Questions.'
         );
     }
 
@@ -66,7 +66,7 @@ class QnaAdvisorQuestionPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.view'],
-            denyResponse: 'You do not have permission to view this QnA Advisor Question.'
+            denyResponse: 'You do not have permission to view this Customer Advisor Question.'
         );
     }
 
@@ -74,7 +74,7 @@ class QnaAdvisorQuestionPolicy
     {
         return $authenticatable->canOrElse(
             abilities: 'qna_advisor.create',
-            denyResponse: 'You do not have permission to create QnA Advisor Questions.'
+            denyResponse: 'You do not have permission to create Customer Advisor Questions.'
         );
     }
 
@@ -82,7 +82,7 @@ class QnaAdvisorQuestionPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.update'],
-            denyResponse: 'You do not have permission to update this QnA Advisor Question.'
+            denyResponse: 'You do not have permission to update this Customer Advisor Question.'
         );
     }
 
@@ -90,7 +90,7 @@ class QnaAdvisorQuestionPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.delete'],
-            denyResponse: 'You do not have permission to delete this QnA Advisor Question.'
+            denyResponse: 'You do not have permission to delete this Customer Advisor Question.'
         );
     }
 
@@ -98,7 +98,7 @@ class QnaAdvisorQuestionPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.restore'],
-            denyResponse: 'You do not have permission to restore this QnA Advisor Question.'
+            denyResponse: 'You do not have permission to restore this Customer Advisor Question.'
         );
     }
 
@@ -106,7 +106,7 @@ class QnaAdvisorQuestionPolicy
     {
         return $authenticatable->canOrElse(
             abilities: ['qna_advisor.*.force-delete'],
-            denyResponse: 'You do not have permission to force-delete this QnA Advisor Question.'
+            denyResponse: 'You do not have permission to force-delete this Customer Advisor Question.'
         );
     }
 }

--- a/app-modules/integration-open-ai/src/Jobs/UploadQnaAdvisorFilesToVectorStore.php
+++ b/app-modules/integration-open-ai/src/Jobs/UploadQnaAdvisorFilesToVectorStore.php
@@ -80,7 +80,7 @@ class UploadQnaAdvisorFilesToVectorStore implements ShouldQueue, TenantAware, Sh
         ];
 
         if ($parsedFiles && (! $service->areFilesReady($parsedFiles, $this->advisor))) {
-            Log::info("The Qna Advisor [{$this->advisor->getKey()}] files and links are not ready for use yet.");
+            Log::info("The Customer Advisor [{$this->advisor->getKey()}] files and links are not ready for use yet.");
 
             ($this->attempts() < 15) && $this->release(now()->addMinute());
 
@@ -91,7 +91,7 @@ class UploadQnaAdvisorFilesToVectorStore implements ShouldQueue, TenantAware, Sh
             $this->advisor->files()->whereNull('parsing_results')->where('created_at', '<=', now()->subMinutes(15))->exists()
             || $this->advisor->links()->whereNull('parsing_results')->where('created_at', '<=', now()->subMinutes(15))->exists()
         ) {
-            Log::info("The Qna Advisor [{$this->advisor->getKey()}] has files or links that are not parsed yet.");
+            Log::info("The Customer Advisor [{$this->advisor->getKey()}] has files or links that are not parsed yet.");
 
             ($this->attempts() < 15) && $this->release(now()->addMinute());
         }

--- a/app-modules/report/src/Filament/Pages/CustomAdvisorReport.php
+++ b/app-modules/report/src/Filament/Pages/CustomAdvisorReport.php
@@ -55,13 +55,13 @@ class CustomAdvisorReport extends AiReport
 
     protected static string | UnitEnum | null $navigationGroup = 'Enterprise AI';
 
-    protected static ?string $title = 'Custom Advisor';
-
-    protected static string $routePath = 'custom-advisor-report';
+    protected static ?string $title = 'Employee Advisor';
+  
+    protected static string $routePath = 'employee-advisor-report';
 
     protected static ?int $navigationSort = 160;
 
-    protected string $cacheTag = 'custom-advisor-report';
+    protected string $cacheTag = 'employee-advisor-report';
 
     public static function canAccess(): bool
     {

--- a/app-modules/report/src/Filament/Pages/CustomAdvisorReport.php
+++ b/app-modules/report/src/Filament/Pages/CustomAdvisorReport.php
@@ -56,7 +56,7 @@ class CustomAdvisorReport extends AiReport
     protected static string | UnitEnum | null $navigationGroup = 'Enterprise AI';
 
     protected static ?string $title = 'Employee Advisor';
-  
+
     protected static string $routePath = 'employee-advisor-report';
 
     protected static ?int $navigationSort = 160;

--- a/app-modules/report/src/Filament/Pages/QnaAdvisorReport.php
+++ b/app-modules/report/src/Filament/Pages/QnaAdvisorReport.php
@@ -52,13 +52,13 @@ class QnaAdvisorReport extends AiReport
 
     protected static string | UnitEnum | null $navigationGroup = 'Enterprise AI';
 
-    protected static ?string $title = 'QnA Advisor';
+    protected static ?string $title = 'Customer Advisor';
 
-    protected static string $routePath = 'qna-advisor-report';
+    protected static string $routePath = 'customer-advisor-report';
 
     protected static ?int $navigationSort = 180;
 
-    protected string $cacheTag = 'qna-advisor-report';
+    protected string $cacheTag = 'customer-advisor-report';
 
     public static function canAccess(): bool
     {

--- a/app-modules/report/src/Filament/Widgets/CustomAdvisorStats.php
+++ b/app-modules/report/src/Filament/Widgets/CustomAdvisorStats.php
@@ -105,7 +105,7 @@ class CustomAdvisorStats extends StatsOverviewReportWidget
             );
 
         return [
-            Stat::make('Custom Advisors', Number::abbreviate(
+            Stat::make('Employee Advisors', Number::abbreviate(
                 $customAdvisorsCount,
                 maxPrecision: 2,
             )),

--- a/app-modules/report/src/Filament/Widgets/CustomAdvisorStats.php
+++ b/app-modules/report/src/Filament/Widgets/CustomAdvisorStats.php
@@ -63,7 +63,7 @@ class CustomAdvisorStats extends StatsOverviewReportWidget
                 )
                 ->count()
             : Cache::tags(["{{$this->cacheTag}}"])->remember(
-                'custom-advisor-advisors-count',
+                'employee-advisor-advisors-count',
                 now()->addHours(24),
                 fn (): int => AiAssistant::query()
                     ->where('is_default', false)
@@ -79,7 +79,7 @@ class CustomAdvisorStats extends StatsOverviewReportWidget
                 )
                 ->count()
             : Cache::tags(["{{$this->cacheTag}}"])->remember(
-                'custom-advisor-exchanges-count',
+                'employee-advisor-exchanges-count',
                 now()->addHours(24),
                 fn (): int => AiAssistantUse::query()
                     ->whereRelation('assistant', 'is_default', false)
@@ -96,7 +96,7 @@ class CustomAdvisorStats extends StatsOverviewReportWidget
                 ->distinct('user_id')
                 ->count('user_id')
             : Cache::tags(["{{$this->cacheTag}}"])->remember(
-                'custom-advisor-unique-users-count',
+                'employee-advisor-unique-users-count',
                 now()->addHours(24),
                 fn (): int => AiAssistantUse::query()
                     ->whereRelation('assistant', 'is_default', false)

--- a/app-modules/report/src/Filament/Widgets/CustomAdvisorTable.php
+++ b/app-modules/report/src/Filament/Widgets/CustomAdvisorTable.php
@@ -50,7 +50,7 @@ class CustomAdvisorTable extends BaseWidget
 
     public string $cacheTag;
 
-    protected static ?string $heading = 'Custom Advisors';
+    protected static ?string $heading = 'Employee Advisors';
 
     protected static ?string $pollingInterval = null;
 

--- a/app-modules/report/src/Filament/Widgets/QnaAdvisorReportStats.php
+++ b/app-modules/report/src/Filament/Widgets/QnaAdvisorReportStats.php
@@ -117,7 +117,7 @@ class QnaAdvisorReportStats extends StatsOverviewReportWidget
             );
 
         return [
-            Stat::make('QnA Advisors', Number::abbreviate($qnaAdvisors, maxPrecision: 2)),
+            Stat::make('Customer Advisors', Number::abbreviate($qnaAdvisors, maxPrecision: 2)),
             Stat::make('Students', Number::abbreviate($studentsCount, maxPrecision: 2)),
             Stat::make('Prospects', Number::abbreviate($prospectsCount, maxPrecision: 2)),
             Stat::make('Unauthenticated', Number::abbreviate($unauthenticatedCount, maxPrecision: 2)),

--- a/app-modules/report/src/Filament/Widgets/QnaAdvisorReportTable.php
+++ b/app-modules/report/src/Filament/Widgets/QnaAdvisorReportTable.php
@@ -59,7 +59,7 @@ class QnaAdvisorReportTable extends TableWidget
 
     protected int | string | array $columnSpan = 'full';
 
-    protected static ?string $heading = 'Most Recent QnA Advisor Chats';
+    protected static ?string $heading = 'Most Recent Customer Advisor Chats';
 
     #[Url]
     public string $activeTab = QnaAdvisorReportTableTab::Student->value;

--- a/app-modules/report/tests/Tenant/Filament/Widgets/CustomAdvisorLineChartTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/CustomAdvisorLineChartTest.php
@@ -73,7 +73,7 @@ it('returns correct monthly custom advisor exchanges data within the given date 
     ]);
 
     $widgetInstance = new CustomAdvisorLineChart();
-    $widgetInstance->cacheTag = 'report-custom-advisor';
+    $widgetInstance->cacheTag = 'report-employee-advisor';
     $widgetInstance->pageFilters = [
         'startDate' => $startDate->toDateString(),
         'endDate' => $endDate->toDateString(),
@@ -117,7 +117,7 @@ it('returns correct monthly custom advisor exchanges data without date filters',
     ]);
 
     $widgetInstance = new CustomAdvisorLineChart();
-    $widgetInstance->cacheTag = 'report-custom-advisor';
+    $widgetInstance->cacheTag = 'report-employee-advisor';
     $widgetInstance->pageFilters = [];
 
     $data = $widgetInstance->getData();
@@ -141,7 +141,7 @@ it('returns empty data when no custom advisor exchanges exist', function () {
     ]);
 
     $widgetInstance = new CustomAdvisorLineChart();
-    $widgetInstance->cacheTag = 'report-custom-advisor';
+    $widgetInstance->cacheTag = 'report-employee-advisor';
     $widgetInstance->pageFilters = [];
 
     $data = $widgetInstance->getData();

--- a/app-modules/report/tests/Tenant/Filament/Widgets/CustomAdvisorStatsTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/CustomAdvisorStatsTest.php
@@ -109,7 +109,7 @@ it('returns correct total custom advisor stats within the given date range', fun
     ]);
 
     $widget = new CustomAdvisorStats();
-    $widget->cacheTag = 'report-custom-advisor';
+    $widget->cacheTag = 'report-employee-advisor';
     $widget->pageFilters = [
         'startDate' => $startDate->toDateString(),
         'endDate' => $endDate->toDateString(),
@@ -160,7 +160,7 @@ it('returns correct total custom advisor stats without date filters', function (
     }
 
     $widget = new CustomAdvisorStats();
-    $widget->cacheTag = 'report-custom-advisor';
+    $widget->cacheTag = 'report-employee-advisor';
     $widget->pageFilters = [];
 
     $stats = $widget->getStats();
@@ -185,7 +185,7 @@ it('returns zero stats when no custom advisors exist', function () {
     ]);
 
     $widget = new CustomAdvisorStats();
-    $widget->cacheTag = 'report-custom-advisor';
+    $widget->cacheTag = 'report-employee-advisor';
     $widget->pageFilters = [];
 
     $stats = $widget->getStats();

--- a/app-modules/report/tests/Tenant/Filament/Widgets/CustomAdvisorStatsTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/CustomAdvisorStatsTest.php
@@ -118,7 +118,7 @@ it('returns correct total custom advisor stats within the given date range', fun
     $stats = $widget->getStats();
 
     expect($stats)->toHaveCount(3)
-        ->and($stats[0]->getLabel())->toBe('Custom Advisors')
+        ->and($stats[0]->getLabel())->toBe('Employee Advisors')
         ->and($stats[0]->getValue())->toEqual($count * 2) // Only custom advisors within date range
         ->and($stats[1]->getLabel())->toBe('Exchanges')
         ->and($stats[1]->getValue())->toEqual(($count * 2) + 1) // Custom advisor uses within date range
@@ -166,7 +166,7 @@ it('returns correct total custom advisor stats without date filters', function (
     $stats = $widget->getStats();
 
     expect($stats)->toHaveCount(3)
-        ->and($stats[0]->getLabel())->toBe('Custom Advisors')
+        ->and($stats[0]->getLabel())->toBe('Employee Advisors')
         ->and($stats[0]->getValue())->toEqual($count + 1) // All custom advisors
         ->and($stats[1]->getLabel())->toBe('Exchanges')
         ->and($stats[1]->getValue())->toEqual($count + 2) // All custom advisor uses
@@ -191,7 +191,7 @@ it('returns zero stats when no custom advisors exist', function () {
     $stats = $widget->getStats();
 
     expect($stats)->toHaveCount(3)
-        ->and($stats[0]->getLabel())->toBe('Custom Advisors')
+        ->and($stats[0]->getLabel())->toBe('Employee Advisors')
         ->and($stats[0]->getValue())->toEqual('0')
         ->and($stats[1]->getLabel())->toBe('Exchanges')
         ->and($stats[1]->getValue())->toEqual('0')

--- a/app-modules/report/tests/Tenant/Filament/Widgets/QnaAdvisorReportLineChartTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/QnaAdvisorReportLineChartTest.php
@@ -63,7 +63,7 @@ it('returns correct QnaAdvisorMessage counts grouped by month within the given d
         ])->create();
 
         $widgetInstance = new QnaAdvisorReportLineChart();
-        $widgetInstance->cacheTag = 'qna-advisor-report-cache';
+        $widgetInstance->cacheTag = 'customer-advisor-report-cache';
         $widgetInstance->pageFilters = [
             'startDate' => $startDate->toDateString(),
             'endDate' => $endDate->toDateString(),

--- a/app-modules/report/tests/Tenant/Filament/Widgets/QnaAdvisorReportStatsTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/QnaAdvisorReportStatsTest.php
@@ -85,7 +85,7 @@ it('returns correct total QnaAdvisor stats of QnaAdvisors, students, prospects a
         ->create();
 
     $widget = new QnaAdvisorReportStats();
-    $widget->cacheTag = 'qna-advisor-report-cache';
+    $widget->cacheTag = 'customer-advisor-report-cache';
     $widget->pageFilters = [
         'startDate' => $startDate->toDateString(),
         'endDate' => $endDate->toDateString(),

--- a/app-modules/report/tests/Tenant/Filament/Widgets/QnaAdvisorReportTableTest.php
+++ b/app-modules/report/tests/Tenant/Filament/Widgets/QnaAdvisorReportTableTest.php
@@ -72,7 +72,7 @@ it('displays only QnaAdvisorThreads added within the selected date range based o
 
     // for student tab
     $component = livewire(QnaAdvisorReportTable::class, [
-        'cacheTag' => 'qna-advisor-thread-report-cache',
+        'cacheTag' => 'customer-advisor-thread-report-cache',
         'pageFilters' => $filters,
         'activeTab' => QnaAdvisorReportTableTab::Student->value,
     ]);
@@ -85,7 +85,7 @@ it('displays only QnaAdvisorThreads added within the selected date range based o
 
     // for prospect tab
     $component = livewire(QnaAdvisorReportTable::class, [
-        'cacheTag' => 'qna-advisor-thread-report-cache',
+        'cacheTag' => 'customer-advisor-thread-report-cache',
         'pageFilters' => $filters,
         'activeTab' => QnaAdvisorReportTableTab::Prospect->value,
     ]);
@@ -98,7 +98,7 @@ it('displays only QnaAdvisorThreads added within the selected date range based o
 
     // for unauthorized tab
     $component = livewire(QnaAdvisorReportTable::class, [
-        'cacheTag' => 'qna-advisor-thread-report-cache',
+        'cacheTag' => 'customer-advisor-thread-report-cache',
         'pageFilters' => $filters,
         'activeTab' => QnaAdvisorReportTableTab::Unauthenticated->value,
     ]);

--- a/app/Filament/Pages/ManageLicenseSettings.php
+++ b/app/Filament/Pages/ManageLicenseSettings.php
@@ -109,7 +109,7 @@ class ManageLicenseSettings extends SettingsPage
                                 ->required()
                                 ->disabled(fn (Get $get): bool => ! $get('data.addons.customAiAssistants')),
                             TextInput::make('data.limits.qnaAdvisorsCount')
-                                ->label('Customer Advisors')
+                                ->label('QnA Advisors')
                                 ->numeric()
                                 ->minValue(0)
                                 ->required()
@@ -175,7 +175,7 @@ class ManageLicenseSettings extends SettingsPage
                             Toggle::make('data.addons.researchAdvisor')
                                 ->label('Research Advisors'),
                             Toggle::make('data.addons.qnaAdvisor')
-                                ->label('Customer Advisors')
+                                ->label('QnA Advisors')
                                 ->live(),
                             Toggle::make('data.addons.dataAdvisor')
                                 ->label('Data Advisors')

--- a/app/Filament/Pages/ManageLicenseSettings.php
+++ b/app/Filament/Pages/ManageLicenseSettings.php
@@ -109,7 +109,7 @@ class ManageLicenseSettings extends SettingsPage
                                 ->required()
                                 ->disabled(fn (Get $get): bool => ! $get('data.addons.customAiAssistants')),
                             TextInput::make('data.limits.qnaAdvisorsCount')
-                                ->label('QnA Advisors')
+                                ->label('Customer Advisors')
                                 ->numeric()
                                 ->minValue(0)
                                 ->required()
@@ -175,7 +175,7 @@ class ManageLicenseSettings extends SettingsPage
                             Toggle::make('data.addons.researchAdvisor')
                                 ->label('Research Advisors'),
                             Toggle::make('data.addons.qnaAdvisor')
-                                ->label('QnA Advisors')
+                                ->label('Customer Advisors')
                                 ->live(),
                             Toggle::make('data.addons.dataAdvisor')
                                 ->label('Data Advisors')


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2626

### Technical Description

> Updated all instances of "QnA Advisor" to "Customer Advisor" across the application.
> Renamed "Custom Advisors" to "Employee Advisors" across the application and change it position under chatbots navigation.

### Any deployment steps required?

> No

### Are any Feature Flags and/or Data Migrations that can eventually be removed Added?

> No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
