### PR TITLE
[ADVAPP-2609]: Some administrators report inconsistent results when attempting to get a passwordless login code

### DIFF
--- a/app-modules/engagement/src/Notifications/EngagementNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementNotification.php
@@ -108,6 +108,7 @@ class EngagementNotification extends Notification implements ShouldQueue, HasBef
 
         return MailMessage::make()
             ->to($this->engagement->recipient_route)
+            ->hideFooter()
             ->when(
                 app(EngagementSettings::class)->are_dynamic_engagements_enabled && $this->engagement->user,
                 fn (MailMessage $message) => $message->from(name: $this->engagement->user->name),

--- a/app-modules/notification/src/Notifications/Messages/MailMessage.php
+++ b/app-modules/notification/src/Notifications/Messages/MailMessage.php
@@ -62,10 +62,14 @@ class MailMessage extends BaseMailMessage
 
     public function content(string $content): static
     {
-        $this->viewData = [
-            $this->viewData,
-            'content' => $content,
-        ];
+        $this->viewData['content'] = $content;
+
+        return $this;
+    }
+
+    public function hideFooter(bool $hide = true): static
+    {
+        $this->viewData['hideFooter'] = $hide;
 
         return $this;
     }
@@ -81,10 +85,7 @@ class MailMessage extends BaseMailMessage
             $this->from(name: $setting->from_name);
         }
 
-        $this->viewData = [
-            $this->viewData,
-            'settings' => $setting,
-        ];
+        $this->viewData['settings'] = $setting;
 
         return $this;
     }

--- a/resources/views/vendor/mail/html/layout.blade.php
+++ b/resources/views/vendor/mail/html/layout.blade.php
@@ -31,7 +31,7 @@
     
     </COPYRIGHT>
 --}}
-@props(['settings' => null, 'unsubscribeUrl' => null])
+@props(['settings' => null, 'unsubscribeUrl' => null, 'hideFooter' => false])
     <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
@@ -104,6 +104,7 @@
 
             </table>
             {{-- Footer --}}
+            @unless($hideFooter)
             <tr>
                 <td>
                 <table class="footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
@@ -115,6 +116,7 @@
                 </table>
                 </td>
             </tr>
+            @endunless
             {{-- Unsubscribe Link --}}
             @if (! empty($unsubscribeUrl))
             <p style="text-align: center; margin-top: 20px; font-size: 12px; color: #999999;">

--- a/resources/views/vendor/mail/html/layout.blade.php
+++ b/resources/views/vendor/mail/html/layout.blade.php
@@ -42,6 +42,12 @@
     <meta name="color-scheme" content="light">
     <meta name="supported-color-schemes" content="light">
     <style>
+        body,
+        .panel-content,
+        .panel-content p {
+            color: #000000;
+        }
+
         @media only screen and (max-width: 600px) {
             .inner-body {
                 width: 100% !important;
@@ -96,8 +102,19 @@
                     </td>
                 </tr>
 
-                {{ $footer ?? '' }}
             </table>
+            {{-- Footer --}}
+            <tr>
+                <td>
+                <table class="footer" align="center" width="570" cellpadding="0" cellspacing="0" role="presentation">
+                <tr>
+                <td class="content-cell" align="center">
+                    This email was sent using Advising App®. <br /> <br /> © 2016-{{ date('Y') }} Canyon GBS Inc. All Rights Reserved. Canyon GBS® and Advising App® are trademarks of Canyon GBS Inc.
+                </td>
+                </tr>
+                </table>
+                </td>
+            </tr>
             {{-- Unsubscribe Link --}}
             @if (! empty($unsubscribeUrl))
             <p style="text-align: center; margin-top: 20px; font-size: 12px; color: #999999;">

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -50,8 +50,4 @@
         </x-slot:subcopy>
     @endisset
 
-    {{-- Footer --}}
-    <x-slot:footer>
-        <x-mail::footer></x-mail::footer>
-    </x-slot:footer>
 </x-mail::layout>

--- a/resources/views/vendor/mail/html/message.blade.php
+++ b/resources/views/vendor/mail/html/message.blade.php
@@ -32,7 +32,7 @@
     </COPYRIGHT>
 --}}
 @props(['settings' => null, 'unsubscribeUrl' => null])
-<x-mail::layout :settings="$settings" :unsubscribeUrl="$unsubscribeUrl">
+<x-mail::layout :settings="$settings" :unsubscribeUrl="$unsubscribeUrl" :hideFooter="$hideFooter ?? false">
     {{-- Header --}}
     <x-slot:header>
         <x-mail::header :url="config('app.url')" :settings="$settings"></x-mail::header>

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -44,7 +44,6 @@ body *:not(html):not(style):not(br):not(tr):not(code) {
 body {
     -webkit-text-size-adjust: none;
     background-color: #ffffff;
-    color: #718096;
     height: 100%;
     line-height: 1.4;
     margin: 0;

--- a/resources/views/vendor/mail/html/themes/default.css
+++ b/resources/views/vendor/mail/html/themes/default.css
@@ -69,65 +69,46 @@ a img {
 
 /* Typography */
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-    color: #3d4852;
+h1 {
+    font-size: 18px;
+    font-weight: bold;
+    margin-top: 0;
     text-align: left;
-    margin-top: 1rem;
-    margin-bottom: 1rem;
 }
 
-h1 { 
-    font-size: 1.875rem; 
-    line-height: 2.25rem; 
+h2 {
+    font-size: 16px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: left;
 }
 
-h2 { 
-    font-size: 1.5rem; 
-    line-height: 2rem; 
+h3 {
+    font-size: 14px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: left;
 }
 
-h3 { 
-    font-size: 1.25rem; 
-    line-height: 1.75rem;
+h4 {
+    font-size: 14px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: left;
 }
 
-h4 { 
-    font-size: 1.125rem; 
-    line-height: 1.75rem;
+h5 {
+    font-size: 13px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: left;
 }
 
-h5 { 
-    font-size: 1rem; 
-    line-height: 1.5rem;
-}
-
-h6 { 
-    font-size: 0.875rem; 
-    line-height: 1.25rem;
-}
-
-/* Font weight */
-h1,
-h2
-{
-    font-weight: 700;
-}
-
-h3,
-h4
-{
-    font-weight: 600;
-}
-
-h5,
-h6
-{
-    font-weight: 500;
+h6 {
+    font-size: 12px;
+    font-weight: bold;
+    margin-top: 0;
+    text-align: left;
 }
 
 p {

--- a/resources/views/vendor/notifications/email.blade.php
+++ b/resources/views/vendor/notifications/email.blade.php
@@ -32,7 +32,7 @@
     </COPYRIGHT>
 --}}
 @if (isset($content))
-<x-mail::layout :settings="$settings ?? null" :unsubscribeUrl="$unsubscribeUrl ?? null">
+<x-mail::layout :settings="$settings ?? null" :unsubscribeUrl="$unsubscribeUrl ?? null" :hideFooter="$hideFooter ?? false">
 {{ str($content)->sanitizeHtml()->toHtmlString() }}
 </x-mail::layout>
 @else


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2609

### Technical Description

Advising App emails have low-contrast gray text, oversized headings, no footer, and stripped color-scheme meta tags — all contributing to poor readability and deliverability compared to Aiding App.

Changes
- Body text color: #718096 (gray) → #000000 (black)
- Headings: 30px → 18px (matching Aiding App)
- Added default footer with Advising App® trademark/copyright
- Style block preserved through CSS inliner (fixes color-scheme meta tag stripping)

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
