### PR TITLE
[ADVAPP-2631]: Some users have reported that labels for mapped blocks do not appear when creating forms

### DIFF
--- a/app-modules/form/resources/views/blocks/previews/educatable-address.blade.php
+++ b/app-modules/form/resources/views/blocks/previews/educatable-address.blade.php
@@ -33,16 +33,32 @@
 --}}
 <x-form::blocks.field-wrapper :$label :$isRequired :description="$description ?? null">
     <div class="space-y-2">
-        <x-form::blocks.previews.field />
-        <x-form::blocks.previews.field />
-        <x-form::blocks.previews.field />
-        <div class="grid grid-cols-2 gap-2">
+        <x-form::blocks.field-wrapper label="Address Line 1">
             <x-form::blocks.previews.field />
+        </x-form::blocks.field-wrapper>
+
+        <x-form::blocks.field-wrapper label="Address Line 2">
             <x-form::blocks.previews.field />
-        </div>
-        <div class="grid grid-cols-2 gap-2">
+        </x-form::blocks.field-wrapper>
+
+        <x-form::blocks.field-wrapper label="Address Line 3">
             <x-form::blocks.previews.field />
+        </x-form::blocks.field-wrapper>
+
+        <x-form::blocks.field-wrapper label="City">
             <x-form::blocks.previews.field />
-        </div>
+        </x-form::blocks.field-wrapper>
+
+        <x-form::blocks.field-wrapper label="State">
+            <x-form::blocks.previews.field />
+        </x-form::blocks.field-wrapper>
+
+        <x-form::blocks.field-wrapper label="Postal Code">
+            <x-form::blocks.previews.field />
+        </x-form::blocks.field-wrapper>
+
+        <x-form::blocks.field-wrapper label="Country">
+            <x-form::blocks.previews.field />
+        </x-form::blocks.field-wrapper>
     </div>
 </x-form::blocks.field-wrapper>

--- a/app-modules/form/resources/views/components/blocks/field-wrapper.blade.php
+++ b/app-modules/form/resources/views/components/blocks/field-wrapper.blade.php
@@ -34,7 +34,7 @@
 <div {{ $attributes->class(['grid gap-y-2']) }}>
     <div class="text-sm font-medium leading-6">
         {{-- Deliberately poor formatting to ensure that the asterisk sticks to the final word in the label. --}}
-        {{ $label }}@if ($isRequired)<sup class="text-danger-600 dark:text-danger-400 font-medium">*</sup>
+        {{ $label }}@if ($isRequired ?? false)<sup class="text-danger-600 dark:text-danger-400 font-medium">*</sup>
         @endif
         @if (isset($description))
             <p class="text-muted-600 dark:text-muted-400 mt-1 text-xs font-normal">

--- a/app-modules/form/src/Filament/Blocks/EducatableAddressFormFieldBlock.php
+++ b/app-modules/form/src/Filament/Blocks/EducatableAddressFormFieldBlock.php
@@ -105,6 +105,13 @@ class EducatableAddressFormFieldBlock extends FormFieldBlock
             ...($helpText ? ['help' => $helpText] : []),
             'children' => [
                 [
+                    '$el' => 'p',
+                    'children' => $field->label,
+                    'attrs' => [
+                        'class' => 'formkit-label font-bold text-sm' . ($disabled ? ' opacity-50' : ''),
+                    ],
+                ],
+                [
                     '$formkit' => 'text',
                     'name' => 'line_1',
                     'label' => 'Address Line 1',


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2631

### Technical Description

Adds an additional label element to this field in the FormKit schema.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
