### PR TITLE
[ADVAPP-2627]: Some users have reported a "Create" button available on the group calendar page that shouldn't be there and throws an error when used

### DIFF
--- a/app-modules/meeting-center/src/Filament/Widgets/CalendarEventWidget.php
+++ b/app-modules/meeting-center/src/Filament/Widgets/CalendarEventWidget.php
@@ -71,4 +71,9 @@ class CalendarEventWidget extends FullCalendarWidget
     {
         $this->refreshRecords();
     }
+
+    protected function headerActions(): array
+    {
+        return [];
+    }
 }

--- a/app-modules/meeting-center/src/Filament/Widgets/CalendarEventWidget.php
+++ b/app-modules/meeting-center/src/Filament/Widgets/CalendarEventWidget.php
@@ -72,6 +72,9 @@ class CalendarEventWidget extends FullCalendarWidget
         $this->refreshRecords();
     }
 
+    /**
+     * @return array<int, mixed>
+     */
     protected function headerActions(): array
     {
         return [];

--- a/app-modules/meeting-center/src/Filament/Widgets/CalendarWidget.php
+++ b/app-modules/meeting-center/src/Filament/Widgets/CalendarWidget.php
@@ -58,4 +58,12 @@ class CalendarWidget extends FullCalendarWidget
                 ->extendedProps(['shouldOpenInNewTab' => true]))
             ->toArray();
     }
+
+    /**
+     * @return array<int, mixed>
+     */
+    protected function headerActions(): array
+    {
+        return [];
+    }
 }

--- a/app-modules/meeting-center/src/Filament/Widgets/GroupAppointmentCalendarWidget.php
+++ b/app-modules/meeting-center/src/Filament/Widgets/GroupAppointmentCalendarWidget.php
@@ -112,6 +112,9 @@ class GroupAppointmentCalendarWidget extends FullCalendarWidget
         $this->refreshRecords();
     }
 
+    /**
+     * @return array<int, mixed>
+     */
     protected function headerActions(): array
     {
         return [];

--- a/app-modules/meeting-center/src/Filament/Widgets/GroupAppointmentCalendarWidget.php
+++ b/app-modules/meeting-center/src/Filament/Widgets/GroupAppointmentCalendarWidget.php
@@ -111,4 +111,9 @@ class GroupAppointmentCalendarWidget extends FullCalendarWidget
         $this->hidePast = $hidePast;
         $this->refreshRecords();
     }
+
+    protected function headerActions(): array
+    {
+        return [];
+    }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2627

### Technical Description

> Some users have reported a "Create" button available on the group calendar page that shouldn't be there and throws an error when used

### Any deployment steps required?

> No

### Cleanup Tasks

> No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
