### PR TITLE
[ADVAPP-2613] & [ADVAPP-2612] & [ADVAPP-2611]: Remove showdown js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
                 "prettier-plugin-blade": "^2.1.21",
                 "prettier-plugin-organize-imports": "^4.1.0",
                 "pusher-js": "^7.4.0",
-                "showdown": "^2.1.0",
                 "sortablejs": "^1.15.0",
                 "vue": "^3.3.4",
                 "vue-router": "^4.2.5",
@@ -4446,33 +4445,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/showdown": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
-            "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "commander": "^9.0.0"
-            },
-            "bin": {
-                "showdown": "bin/showdown.js"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://www.paypal.me/tiviesantos"
-            }
-        },
-        "node_modules/showdown/node_modules/commander": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/signature_pad": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
         "prettier-plugin-blade": "^2.1.21",
         "prettier-plugin-organize-imports": "^4.1.0",
         "pusher-js": "^7.4.0",
-        "showdown": "^2.1.0",
         "sortablejs": "^1.15.0",
         "vue": "^3.3.4",
         "vue-router": "^4.2.5",

--- a/portals/package-lock.json
+++ b/portals/package-lock.json
@@ -59,7 +59,6 @@
                 "prettier-plugin-blade": "^2.1.21",
                 "prettier-plugin-organize-imports": "^4.1.0",
                 "pusher-js": "^7.4.0",
-                "showdown": "^2.1.0",
                 "sortablejs": "^1.15.0",
                 "vue": "^3.3.4",
                 "vue-router": "^4.2.5",
@@ -4310,33 +4309,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/showdown": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
-            "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "commander": "^9.0.0"
-            },
-            "bin": {
-                "showdown": "bin/showdown.js"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://www.paypal.me/tiviesantos"
-            }
-        },
-        "node_modules/showdown/node_modules/commander": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/signature_pad": {

--- a/portals/package.json
+++ b/portals/package.json
@@ -62,7 +62,6 @@
         "prettier-plugin-blade": "^2.1.21",
         "prettier-plugin-organize-imports": "^4.1.0",
         "pusher-js": "^7.4.0",
-        "showdown": "^2.1.0",
         "sortablejs": "^1.15.0",
         "vue": "^3.3.4",
         "vue-router": "^4.2.5",

--- a/widgets/package-lock.json
+++ b/widgets/package-lock.json
@@ -59,7 +59,6 @@
                 "prettier-plugin-blade": "^2.1.21",
                 "prettier-plugin-organize-imports": "^4.1.0",
                 "pusher-js": "^7.4.0",
-                "showdown": "^2.1.0",
                 "sortablejs": "^1.15.0",
                 "vue": "^3.3.4",
                 "vue-router": "^4.2.5",
@@ -4460,33 +4459,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/showdown": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
-            "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "commander": "^9.0.0"
-            },
-            "bin": {
-                "showdown": "bin/showdown.js"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://www.paypal.me/tiviesantos"
-            }
-        },
-        "node_modules/showdown/node_modules/commander": {
-            "version": "9.5.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^12.20.0 || >=14"
             }
         },
         "node_modules/signature_pad": {

--- a/widgets/package.json
+++ b/widgets/package.json
@@ -76,7 +76,6 @@
         "prettier-plugin-blade": "^2.1.21",
         "prettier-plugin-organize-imports": "^4.1.0",
         "pusher-js": "^7.4.0",
-        "showdown": "^2.1.0",
         "sortablejs": "^1.15.0",
         "vue": "^3.3.4",
         "vue-router": "^4.2.5",


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2613
- https://canyongbs.atlassian.net/browse/ADVAPP-2612
- https://canyongbs.atlassian.net/browse/ADVAPP-2611

### Technical Description

Resolves reports of CVEs by removing `showdown` which is a package no longer used in the system.

Also, updates `devops` to keep it inline with `main`.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
