### PR TITLE
[ADVAPP-2521]: Improve SMS error handling for messages that are dispatched

### DIFF
--- a/app-modules/notification/src/DataTransferObjects/SmsChannelResultData.php
+++ b/app-modules/notification/src/DataTransferObjects/SmsChannelResultData.php
@@ -44,6 +44,7 @@ class SmsChannelResultData extends NotificationResultData
     public function __construct(
         public bool $success,
         public MessageInstance|ApiResource|null $message = null,
-        public ?string $error = null,
+          public ?string $error = null,
+          public ?string $errorCode = null,
     ) {}
 }

--- a/app-modules/notification/src/DataTransferObjects/SmsChannelResultData.php
+++ b/app-modules/notification/src/DataTransferObjects/SmsChannelResultData.php
@@ -44,7 +44,7 @@ class SmsChannelResultData extends NotificationResultData
     public function __construct(
         public bool $success,
         public MessageInstance|ApiResource|null $message = null,
-          public ?string $error = null,
-          public ?string $errorCode = null,
+        public ?string $error = null,
+        public ?string $errorCode = null,
     ) {}
 }

--- a/app-modules/notification/src/Notifications/Channels/SmsChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/SmsChannel.php
@@ -53,6 +53,7 @@ use AdvisingApp\Notification\Notifications\Contracts\OnDemandNotification;
 use AdvisingApp\Notification\Notifications\Messages\TwilioMessage;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\BouncedPhoneNumber;
+use AdvisingApp\StudentDataModel\Models\SmsOptOutPhoneNumber;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\User;
 use App\Settings\LicenseSettings;
@@ -60,8 +61,10 @@ use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Talkroute\MessageSegmentCalculator\SegmentCalculator;
+use Telnyx\Exception\ApiErrorException;
 use Telnyx\Message;
 use Telnyx\Telnyx;
 use Throwable;
@@ -209,10 +212,29 @@ class SmsChannel
 
                     $smsMessage->save();
                 } else {
+                    if ($result->errorCode === '40300') {
+                        SmsOptOutPhoneNumber::firstOrCreate([
+                            'number' => $recipientNumber,
+                        ]);
+
+                        Log::warning('SMS opt-out recorded at send time via Telnyx error 40300. Pre-send opt-out check did not catch this number.', [
+                            'recipient_number' => $recipientNumber,
+                            'sms_message_id' => $smsMessage->getKey(),
+                        ]);
+                    }
+
+                    if ($result->errorCode === '40310') {
+                        BouncedPhoneNumber::firstOrCreate(
+                            ['number' => $recipientNumber],
+                            ['external_error_code' => $result->errorCode]
+                        );
+                    }
+
                     $smsMessage->events()->create([
                         'type' => SmsMessageEventType::FailedDispatch,
                         'payload' => [
                             'error' => $result->error,
+                            'error_code' => $result->errorCode,
                         ],
                         'occurred_at' => now(),
                     ]);
@@ -294,6 +316,10 @@ class SmsChannel
             $result->message = $message;
         } catch (Throwable $exception) {
             $result->error = $exception->getMessage();
+
+            if ($exception instanceof ApiErrorException) {
+                $result->errorCode = $exception->getTelnyxCode();
+            }
         }
 
         return $result;

--- a/app-modules/notification/tests/Tenant/Notifications/Channels/SmsChannelSmsMessageTest.php
+++ b/app-modules/notification/tests/Tenant/Notifications/Channels/SmsChannelSmsMessageTest.php
@@ -36,14 +36,20 @@
 
 use AdvisingApp\IntegrationTwilio\Settings\TwilioSettings;
 use AdvisingApp\IntegrationTwilio\Tests\Fixtures\ClientMock;
+use AdvisingApp\Notification\DataTransferObjects\SmsChannelResultData;
 use AdvisingApp\Notification\Enums\SmsMessageEventType;
+use AdvisingApp\Notification\Enums\SmsMessagingProvider;
 use AdvisingApp\Notification\Exceptions\BouncedSmsException;
+use AdvisingApp\Notification\Exceptions\SmsOptOutException;
 use AdvisingApp\Notification\Models\SmsMessage;
+use AdvisingApp\Notification\Notifications\Channels\SmsChannel;
 use AdvisingApp\Notification\Tests\Fixtures\TestSmsNotification;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\BouncedPhoneNumber;
+use AdvisingApp\StudentDataModel\Models\SmsOptOutPhoneNumber;
 
 use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
 
 use Twilio\Rest\Api\V2010;
 use Twilio\Rest\Api\V2010\Account\MessageInstance;
@@ -127,4 +133,204 @@ it('will not send an SMS if recipient phone number has previously bounced', func
     }
 });
 
+it('creates an SmsOptOutPhoneNumber and records a FailedDispatch event when Telnyx returns error 40300, without rethrowing', function () {
+    $notifiable = Prospect::factory()->create();
+
+    $phoneNumber = $notifiable->phoneNumbers()->create([
+        'number' => '+13125000002',
+        'can_receive_sms' => true,
+    ]);
+
+    $notifiable->primaryPhoneNumber()->associate($phoneNumber)->save();
+
+    $settings = app()->make(TwilioSettings::class);
+    $settings->provider = SmsMessagingProvider::Telnyx;
+    $settings->telnyx_api_key = 'test_api_key';
+    $settings->save();
+
+    $failureResult = SmsChannelResultData::from(['success' => false]);
+    $failureResult->error = 'Forbidden - User has opted out of SMS';
+    $failureResult->errorCode = '40300';
+
+    $channel = mock(SmsChannel::class)
+        ->shouldAllowMockingProtectedMethods()
+        ->makePartial();
+    $channel->shouldReceive('sendViaTelnyx')->andReturn($failureResult);
+
+    app()->instance(SmsChannel::class, $channel);
+
+    $notifiable->notify(new TestSmsNotification());
+
+    assertDatabaseHas(SmsOptOutPhoneNumber::class, [
+        'number' => '+13125000002',
+    ]);
+
+    $event = SmsMessage::first()->events()->first();
+    expect($event->type)->toBe(SmsMessageEventType::FailedDispatch)
+        ->and($event->payload['error_code'])->toBe('40300');
+});
+
+it('creates a BouncedPhoneNumber and records a FailedDispatch event when Telnyx returns error 40310, without rethrowing', function () {
+    $notifiable = Prospect::factory()->create();
+
+    $phoneNumber = $notifiable->phoneNumbers()->create([
+        'number' => '+13125000003',
+        'can_receive_sms' => true,
+    ]);
+
+    $notifiable->primaryPhoneNumber()->associate($phoneNumber)->save();
+
+    $settings = app()->make(TwilioSettings::class);
+    $settings->provider = SmsMessagingProvider::Telnyx;
+    $settings->telnyx_api_key = 'test_api_key';
+    $settings->save();
+
+    $failureResult = SmsChannelResultData::from(['success' => false]);
+    $failureResult->error = 'Not routable - destination is a landline or non-routable number';
+    $failureResult->errorCode = '40310';
+
+    $channel = mock(SmsChannel::class)
+        ->shouldAllowMockingProtectedMethods()
+        ->makePartial();
+    $channel->shouldReceive('sendViaTelnyx')->andReturn($failureResult);
+
+    app()->instance(SmsChannel::class, $channel);
+
+    $notifiable->notify(new TestSmsNotification());
+
+    assertDatabaseHas(BouncedPhoneNumber::class, [
+        'number' => '+13125000003',
+        'external_error_code' => '40310',
+    ]);
+
+    assertDatabaseMissing(SmsOptOutPhoneNumber::class, [
+        'number' => '+13125000003',
+    ]);
+
+    $event = SmsMessage::first()->events()->first();
+    expect($event->type)->toBe(SmsMessageEventType::FailedDispatch)
+        ->and($event->payload['error_code'])->toBe('40310');
+});
+
+it('records a FailedDispatch event without creating opt-out or bounce records for other Telnyx error codes', function (string $errorCode) {
+    $notifiable = Prospect::factory()->create();
+
+    $phoneNumber = $notifiable->phoneNumbers()->create([
+        'number' => '+13125000004',
+        'can_receive_sms' => true,
+    ]);
+
+    $notifiable->primaryPhoneNumber()->associate($phoneNumber)->save();
+
+    $settings = app()->make(TwilioSettings::class);
+    $settings->provider = SmsMessagingProvider::Telnyx;
+    $settings->telnyx_api_key = 'test_api_key';
+    $settings->save();
+
+    $failureResult = SmsChannelResultData::from(['success' => false]);
+    $failureResult->error = 'Telnyx send failed';
+    $failureResult->errorCode = $errorCode;
+
+    $channel = mock(SmsChannel::class)
+        ->shouldAllowMockingProtectedMethods()
+        ->makePartial();
+    $channel->shouldReceive('sendViaTelnyx')->andReturn($failureResult);
+
+    app()->instance(SmsChannel::class, $channel);
+
+    $notifiable->notify(new TestSmsNotification());
+
+    assertDatabaseMissing(SmsOptOutPhoneNumber::class, ['number' => '+13125000004']);
+    assertDatabaseMissing(BouncedPhoneNumber::class, ['number' => '+13125000004']);
+
+    $event = SmsMessage::first()->events()->first();
+    expect($event->type)->toBe(SmsMessageEventType::FailedDispatch)
+        ->and($event->payload['error_code'])->toBe($errorCode);
+})->with([
+    '40301',
+    '40302',
+    '40304',
+    '40306',
+    '40307',
+    '40308',
+    '40309',
+    '40311',
+    '40313',
+    '40315',
+    '40316',
+    '40318',
+    '40319',
+    '40320',
+    '40321',
+    '40322',
+    '40325',
+    '40328',
+    '40329',
+    '40330',
+    '40331',
+    '40333',
+]);
+
+it('short-circuits with BouncedSmsException before the API call when the number is already bounced', function () {
+    $notifiable = Prospect::factory()->create();
+
+    $phoneNumber = $notifiable->phoneNumbers()->create([
+        'number' => '+13125000010',
+        'can_receive_sms' => true,
+    ]);
+
+    $notifiable->primaryPhoneNumber()->associate($phoneNumber)->save();
+
+    BouncedPhoneNumber::factory()->create([
+        'number' => '+13125000010',
+        'external_error_code' => '40001',
+    ]);
+
+    // sendViaTelnyx must never be called — if it were, the mock would fail the test
+    $channel = mock(SmsChannel::class)
+        ->shouldAllowMockingProtectedMethods()
+        ->makePartial();
+    $channel->shouldNotReceive('sendViaTelnyx');
+    $channel->shouldNotReceive('sendViaTwilio');
+
+    app()->instance(SmsChannel::class, $channel);
+
+    expect(fn () => $notifiable->notify(new TestSmsNotification()))
+        ->toThrow(BouncedSmsException::class);
+
+    $event = SmsMessage::first()->events()->first();
+    expect($event->type)->toBe(SmsMessageEventType::FailedDispatch)
+        ->and($event->payload['error'])->toBe('Recipient phone number has previously bounced.');
+});
+
+it('short-circuits with SmsOptOutException before the API call when the number is already opted out', function () {
+    $notifiable = Prospect::factory()->create();
+
+    $phoneNumber = $notifiable->phoneNumbers()->create([
+        'number' => '+13125000011',
+        'can_receive_sms' => true,
+    ]);
+
+    $notifiable->primaryPhoneNumber()->associate($phoneNumber)->save();
+
+    SmsOptOutPhoneNumber::factory()->create([
+        'number' => '+13125000011',
+    ]);
+
+    // sendViaTelnyx must never be called — if it were, the mock would fail the test
+    $channel = mock(SmsChannel::class)
+        ->shouldAllowMockingProtectedMethods()
+        ->makePartial();
+    $channel->shouldNotReceive('sendViaTelnyx');
+    $channel->shouldNotReceive('sendViaTwilio');
+
+    app()->instance(SmsChannel::class, $channel);
+
+    expect(fn () => $notifiable->notify(new TestSmsNotification()))
+        ->toThrow(SmsOptOutException::class);
+
+    $event = SmsMessage::first()->events()->first();
+    expect($event->type)->toBe(SmsMessageEventType::FailedDispatch)
+        ->and($event->payload['error'])->toBe('Recipient phone number has opted out of SMS messages.');
+});
 // TODO Add more tests for SMS Demo mode etc.


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2521

### Technical Description

> Handle SMS for different error codes.
> If dispatched messages gives error code 40300 then create SMSoptOut record for that number
> If dispatched messages gives error code 40310 then create BouncedPhoneNumber record for that number.
> If dispatched messages gives error code  40305 , 40312 or 40314 then report in sentry.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
