### PR TITLE
[Chore]: Add zizmor scanning of GitHub Actions

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: zizmor
+
+on:
+    push:
+        paths:
+            - '.github/workflows/**'
+            - '.github/dependabot.yml'
+    pull_request:
+        paths:
+            - '.github/workflows/**'
+            - '.github/dependabot.yml'
+    workflow_dispatch:
+
+permissions: {}
+
+jobs:
+    zizmor:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            security-events: write # required to upload SARIF to code scanning
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+            - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: true


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Adds a `zizmor` scan of our GitHub Actions with reporting of the SARIF file for our code scanning setup.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
