### PR TITLE
[Chore]: Fix zizmor setup

### DIFF
--- a/.github/workflows/update_yearly_copyright.yml
+++ b/.github/workflows/update_yearly_copyright.yml
@@ -5,6 +5,8 @@ on:
     schedule: # Run every year on January 1st
         - cron: '0 0 1 1 *' # UTC time
 
+permissions: {}
+
 concurrency:
     group: ${{ github.workflow }}
     cancel-in-progress: true
@@ -21,7 +23,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   token: ${{ secrets.PAT }} # zizmor: ignore[secrets-outside-env]
-                  persist-credentials: true
+                  persist-credentials: true # zizmor: ignore[artipacked] -- credentials needed for git push
 
             - name: Set up Ruby
               uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0

--- a/.github/workflows/update_yearly_copyright.yml
+++ b/.github/workflows/update_yearly_copyright.yml
@@ -5,8 +5,6 @@ on:
     schedule: # Run every year on January 1st
         - cron: '0 0 1 1 *' # UTC time
 
-permissions: {}
-
 concurrency:
     group: ${{ github.workflow }}
     cancel-in-progress: true

--- a/.github/workflows/update_yearly_copyright.yml
+++ b/.github/workflows/update_yearly_copyright.yml
@@ -23,7 +23,7 @@ jobs:
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   token: ${{ secrets.PAT }} # zizmor: ignore[secrets-outside-env]
-                  persist-credentials: true # zizmor: ignore[artipacked] -- credentials needed for git push
+                  persist-credentials: true
 
             - name: Set up Ruby
               uses: ruby/setup-ruby@97ecb7b512899eb71ab1bf2310a624c6f1589ac6 # v1.308.0

--- a/.github/workflows/zizmor-monitoring.yml
+++ b/.github/workflows/zizmor-monitoring.yml
@@ -1,0 +1,35 @@
+name: Zizmor Monitoring
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - '.github/workflows/**'
+            - '.github/dependabot.yml'
+    schedule:
+        - cron: '0 11 * * 1' # Mondays at 11:00 UTC
+
+permissions: {}
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: false
+
+jobs:
+    zizmor:
+        name: Zizmor (monitoring)
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            actions: read
+            security-events: write
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  persist-credentials: false
+
+            - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: true
+                  persona: auditor
+                  min-severity: informational

--- a/.github/workflows/zizmor-monitoring.yml
+++ b/.github/workflows/zizmor-monitoring.yml
@@ -21,8 +21,8 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
-            actions: read
-            security-events: write
+            actions: read # needed by upload-sarif to read workflow run metadata on private repos
+            security-events: write # required to upload SARIF results to GitHub code scanning
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,15 +1,7 @@
 name: zizmor
 
 on:
-    push:
-        branches: [main]
-        paths:
-            - '.github/workflows/**'
-            - '.github/dependabot.yml'
     pull_request:
-        paths:
-            - '.github/workflows/**'
-            - '.github/dependabot.yml'
     merge_group:
         types: [checks_requested]
 
@@ -25,12 +17,22 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
-            security-events: write # required to upload SARIF to code scanning
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
                   persist-credentials: false
-            - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+
+            - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+              id: changes
               with:
-                  advanced-security: true
+                  filters: |
+                      workflows:
+                          - '.github/workflows/**'
+                          - '.github/dependabot.yml'
+
+            - if: steps.changes.outputs.workflows == 'true'
+              uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+              with:
+                  advanced-security: false
                   persona: auditor
+                  min-severity: informational


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Fixes the `zizmor` setup to block on any findings in a PR directly. And create a separate task to scan `main` on merge into it and every Monday and report those findings as a SARIF to Code Scanning.

This is so we get blocks on PRs WHEN the files updated are workflows. But then we get regular scans to report new findings as `zizmor` updates / adds more.

The reasoning behind the `auditor` persona and reporting ALL findings (min being `informational`) is that I believe all findings should be addressed. Either by directly making the change, or intentionally ignoring it.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
