### PR TITLE
[ADVAPP-2693]: Some users have reported errors trying to create new advising app Tenants after deleting one with the same domain

### DIFF
--- a/app/Http/Requests/Tenants/CreateTenantRequest.php
+++ b/app/Http/Requests/Tenants/CreateTenantRequest.php
@@ -48,7 +48,7 @@ class CreateTenantRequest extends FormRequest
     public function rules(): array
     {
         $rules = [
-            'domain' => ['required', 'string', 'max:255', Rule::unique(Tenant::class)],
+            'domain' => ['required', 'string', 'max:255', Rule::unique(Tenant::class)->whereNull('deleted_at')],
             'database' => ['required', 'string', 'max:255'],
             'limits' => ['required', 'array'],
             'limits.conversationalAiSeats' => ['required', 'integer', 'min:0'],


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2693

### Technical Description

> Solve the issue of creating new tenants with domain which are already deleted.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A.

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
