### PR TITLE
[ADVAPP-2645]: Introduce a component for public profiles that gates display of certain related features

### DIFF
--- a/.cleanup-tasks/2026_06_04_public_profiles.md
+++ b/.cleanup-tasks/2026_06_04_public_profiles.md
@@ -1,0 +1,13 @@
+---
+title: Public Profiles
+created: 2026-06-04
+---
+
+## Feature Flags
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+Create Tenant Request: The publicProfiles addon should be made required, line 81
+Sync Tenant Request: The publicProfiles addon should be made required, line 77

--- a/app/DataTransferObjects/LicenseManagement/LicenseAddonsData.php
+++ b/app/DataTransferObjects/LicenseManagement/LicenseAddonsData.php
@@ -62,5 +62,6 @@ class LicenseAddonsData extends Data
         public bool $dataAdvisor = false,
         public bool $projectManagement = false,
         public bool $earlyAlert = false,
+        public bool $publicProfiles = false,
     ) {}
 }

--- a/app/Enums/Feature.php
+++ b/app/Enums/Feature.php
@@ -77,6 +77,8 @@ enum Feature: string
 
     case EarlyAlert = 'early-alert';
 
+    case PublicProfiles = 'public-profiles';
+
     public function generateGate(): void
     {
         // If features are added that are not based on a License Addon we will need to update this

--- a/app/Filament/Pages/ManageLicenseSettings.php
+++ b/app/Filament/Pages/ManageLicenseSettings.php
@@ -211,6 +211,8 @@ class ManageLicenseSettings extends SettingsPage
                                 ->label('Project Management'),
                             Toggle::make('data.addons.earlyAlert')
                                 ->label('Early Alert'),
+                            Toggle::make('data.addons.publicProfiles')
+                                ->label('Public Profiles'),
                         ]
                     ),
             ])

--- a/app/Filament/Pages/ProfileInformation.php
+++ b/app/Filament/Pages/ProfileInformation.php
@@ -37,6 +37,7 @@
 namespace App\Filament\Pages;
 
 use AdvisingApp\Authorization\Enums\LicenseType;
+use App\Enums\Feature;
 use App\Models\User;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Checkbox;
@@ -50,6 +51,7 @@ use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules\Password;
 use Ysfkaya\FilamentPhoneInput\Forms\PhoneInput;
@@ -74,7 +76,8 @@ class ProfileInformation extends ProfilePage
         return $schema
             ->components([
                 Section::make('Public Profile')
-                    ->visible($hasCrmLicense)
+                    ->key('public-profile')
+                    ->visible($hasCrmLicense && Gate::check(Feature::PublicProfiles->getGateName()))
                     ->schema([
                         Toggle::make('has_enabled_public_profile')
                             ->label('Enable public profile')

--- a/app/Http/Requests/Tenants/CreateTenantRequest.php
+++ b/app/Http/Requests/Tenants/CreateTenantRequest.php
@@ -78,6 +78,7 @@ class CreateTenantRequest extends FormRequest
             'addons.dataAdvisor' => ['required', 'boolean'],
             'addons.projectManagement' => ['required', 'boolean'],
             'addons.earlyAlert' => ['required', 'boolean'],
+            'addons.publicProfiles' => ['nullable', 'boolean'], // TODO: During Public Profiles feature cleanup, make this required
             'subscription' => ['required', 'array'],
             'subscription.clientName' => ['required', 'string'],
             'subscription.partnerName' => ['required', 'string'],

--- a/app/Http/Requests/Tenants/SyncTenantRequest.php
+++ b/app/Http/Requests/Tenants/SyncTenantRequest.php
@@ -74,6 +74,7 @@ class SyncTenantRequest extends FormRequest
             'addons.dataAdvisor' => ['required', 'boolean'],
             'addons.projectManagement' => ['required', 'boolean'],
             'addons.earlyAlert' => ['required', 'boolean'],
+            'addons.publicProfiles' => ['nullable', 'boolean'], // TODO: During Public Profiles feature cleanup, make this required
             'smartPrompts' => ['nullable', 'array'],
             'smartPrompts.*.title' => ['required', 'string'],
             'smartPrompts.*.description' => ['nullable', 'string'],

--- a/docs/how-tos/introducing-a-new-feature-addon.md
+++ b/docs/how-tos/introducing-a-new-feature-addon.md
@@ -40,6 +40,7 @@ This guide covers gating features behind addon toggles tied to the account subsc
             ];
         }
     ```
+
     Additionally, a cleanup task should be created to make this new field required in the future, in both files. Allowing it to be nullable prevents issues if the app is updated before the external API.
 
 4. Add Feature Toggle to License Settings

--- a/docs/how-tos/introducing-a-new-feature-addon.md
+++ b/docs/how-tos/introducing-a-new-feature-addon.md
@@ -36,10 +36,11 @@ This guide covers gating features behind addon toggles tied to the account subsc
         {
             return [
                 // ...
-                'addons.exampleFeature' => ['required', 'boolean'],
+                'addons.exampleFeature' => ['nullable', 'boolean'],
             ];
         }
     ```
+    Additionally, a cleanup task should be created to make this new field required in the future, in both files. Allowing it to be nullable prevents issues if the app is updated before the external API.
 
 4. Add Feature Toggle to License Settings
 
@@ -149,13 +150,4 @@ This guide covers gating features behind addon toggles tied to the account subsc
 
         get(ListExamples::getUrl())->assertSuccessful();
     });
-    ```
-
-    `tests/TestCase.php`: Both the `createTenant` function and the `refreshTenantTestingEnvironment` will need to be updated:
-
-    ```php
-    new LicenseAddonsData(
-            // ...
-            exampleFeature: true,
-        )
     ```

--- a/tests/Tenant/Feature/Filament/Pages/ProfileInformationTest.php
+++ b/tests/Tenant/Feature/Filament/Pages/ProfileInformationTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Authorization\Enums\LicenseType;
 use App\Filament\Pages\ProfileInformation;
 use App\Models\User;

--- a/tests/Tenant/Feature/Filament/Pages/ProfileInformationTest.php
+++ b/tests/Tenant/Feature/Filament/Pages/ProfileInformationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use AdvisingApp\Authorization\Enums\LicenseType;
+use App\Filament\Pages\ProfileInformation;
+use App\Models\User;
+use App\Settings\LicenseSettings;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+it('is gated by proper access control', function () {
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->publicProfiles = false;
+    $settings->save();
+
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    actingAs($user);
+
+    livewire(ProfileInformation::class)
+        ->assertSchemaComponentHidden('public-profile');
+
+    $settings->data->addons->publicProfiles = true;
+    $settings->save();
+
+    livewire(ProfileInformation::class)
+        ->assertSchemaComponentVisible('public-profile');
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2645

### Technical Description

Gate public profile by external feature. Update documentation to make update order of this and feature sources not matter.

### Any deployment steps required?

No

### Cleanup Tasks

.cleanup-tasks/2026_06_04_public_profiles.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
