### PR TITLE
[ADVAPP-2695]: Some users have reported a failure for inline attachments to display in the user interface

### DIFF
--- a/app-modules/engagement/src/Models/EngagementResponse.php
+++ b/app-modules/engagement/src/Models/EngagementResponse.php
@@ -136,6 +136,8 @@ class EngagementResponse extends BaseModel implements Auditable, ProvidesATimeli
             $cid = $inlineAttachment->getCustomProperty('cid');
 
             if (is_string($cid)) {
+                assert(is_string($content));
+                
                 $content = Str::replace(
                     "\"cid:{$cid}\"",
                     '"' . $inlineAttachmentTemporaryUrl . '"',

--- a/app-modules/engagement/src/Models/EngagementResponse.php
+++ b/app-modules/engagement/src/Models/EngagementResponse.php
@@ -137,7 +137,7 @@ class EngagementResponse extends BaseModel implements Auditable, ProvidesATimeli
 
             if (is_string($cid)) {
                 assert(is_string($content));
-                
+
                 $content = Str::replace(
                     "\"cid:{$cid}\"",
                     '"' . $inlineAttachmentTemporaryUrl . '"',

--- a/app-modules/engagement/src/Models/EngagementResponse.php
+++ b/app-modules/engagement/src/Models/EngagementResponse.php
@@ -135,21 +135,26 @@ class EngagementResponse extends BaseModel implements Auditable, ProvidesATimeli
 
             $cid = $inlineAttachment->getCustomProperty('cid');
 
-            if (! is_string($cid)) {
-                continue;
+            if (is_string($cid)) {
+                $content = Str::replace(
+                    "\"cid:{$cid}\"",
+                    '"' . $inlineAttachmentTemporaryUrl . '"',
+                    $content,
+                );
+
+                // In case single quotes are used in the HTML
+                $content = Str::replace(
+                    "'cid:{$cid}'",
+                    '\'' . $inlineAttachmentTemporaryUrl . '\'',
+                    $content,
+                );
             }
 
-            $content = Str::replace(
-                "\"cid:{$cid}\"",
-                '"' . $inlineAttachmentTemporaryUrl . '"',
+            $content = preg_replace(
+                '/src\s*=\s*["\']data:image[^\s>]+/i',
+                'src="' . $inlineAttachmentTemporaryUrl . '"',
                 $content,
-            );
-
-            // In case single quotes are used in the HTML
-            $content = Str::replace(
-                "'cid:{$cid}'",
-                '\'' . $inlineAttachmentTemporaryUrl . '\'',
-                $content,
+                1
             );
         }
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2695

### Technical Description

Display non CID inline images in inbound communications

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
