### PR TITLE
[ADVAPP-2702]: Some users have reported "Signed in as..." always present in Advising App forms

### DIFF
--- a/widgets/application/src/App.vue
+++ b/widgets/application/src/App.vue
@@ -525,7 +525,7 @@
             </div>
 
             <div v-if="applicationSubmissionUrl" class="space-y-6">
-                <p v-if="!(props.preview === 'true' || props.preview === true)" class="text-sm">
+                <p v-if="authentication.email" class="text-sm">
                     Signed in as <strong>{{ authentication.email }}</strong>
                 </p>
 

--- a/widgets/form/src/App.vue
+++ b/widgets/form/src/App.vue
@@ -569,7 +569,7 @@
             </div>
 
             <div v-if="formSubmissionUrl" class="space-y-6">
-                <p v-if="formIsAuthenticated || !(props.preview === 'true' || props.preview === true)" class="text-sm">
+                <p v-if="formIsAuthenticated" class="text-sm">
                     Signed in as <strong>{{ authentication.email }}</strong>
                 </p>
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2702

### Technical Description

> Fixed a bug where the "Signed in as…" message was incorrectly displayed at the top of unauthenticated forms and applications.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
