### PR TITLE
[ADVAPP-2712]: Introduce the ability for submitters to see their past form or admissions application submission when form authentication is active

### DIFF
--- a/.cleanup-tasks/2026_06_15_past_submissions_feature.md
+++ b/.cleanup-tasks/2026_06_15_past_submissions_feature.md
@@ -1,0 +1,12 @@
+---
+title: Past Submissions Feature
+created: 2026-06-15
+---
+
+## Feature Flags
+
+- App\Features\PastSubmissionsFeature
+
+## Temporary Migrations
+
+## Additional Cleanup

--- a/app-modules/application/database/migrations/2026_06_15_101820_add_allow_view_past_submissions_to_applications_table.php
+++ b/app-modules/application/database/migrations/2026_06_15_101820_add_allow_view_past_submissions_to_applications_table.php
@@ -1,11 +1,44 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('applications', function (Blueprint $table) {

--- a/app-modules/application/database/migrations/2026_06_15_101820_add_allow_view_past_submissions_to_applications_table.php
+++ b/app-modules/application/database/migrations/2026_06_15_101820_add_allow_view_past_submissions_to_applications_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->boolean('allow_view_past_submissions')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('applications', function (Blueprint $table) {
+            $table->dropColumn('allow_view_past_submissions');
+        });
+    }
+};

--- a/app-modules/application/routes/widgets.php
+++ b/app-modules/application/routes/widgets.php
@@ -74,6 +74,12 @@ Route::middleware([
                 Route::post('register', [ApplicationWidgetController::class, 'registerProspect'])
                     ->middleware(['signed'])
                     ->name('register-prospect');
+                Route::get('submissions/past-submissions', [ApplicationWidgetController::class, 'getPastSubmissions'])
+                    ->middleware(['signed'])
+                    ->name('get-past-submissions');
+                Route::get('submissions/{submission}', [ApplicationWidgetController::class, 'getSubmission'])
+                    ->middleware(['signed'])
+                    ->name('get-submission');
 
                 // Handle preflight CORS requests for all routes in this group
                 // MUST remain the last route in this group

--- a/app-modules/application/routes/widgets.php
+++ b/app-modules/application/routes/widgets.php
@@ -75,7 +75,7 @@ Route::middleware([
                     ->middleware(['signed'])
                     ->name('register-prospect');
                 Route::get('submissions/past-submissions', [ApplicationWidgetController::class, 'getPastSubmissions'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:page,per_page'])
                     ->name('get-past-submissions');
                 Route::get('submissions/{submission}', [ApplicationWidgetController::class, 'getSubmission'])
                     ->middleware(['signed'])

--- a/app-modules/application/src/Filament/Resources/Applications/Pages/Concerns/HasSharedFormConfiguration.php
+++ b/app-modules/application/src/Filament/Resources/Applications/Pages/Concerns/HasSharedFormConfiguration.php
@@ -45,6 +45,7 @@ use AdvisingApp\Form\Filament\Blocks\FormFieldBlockRegistry;
 use AdvisingApp\Form\Rules\IsDomain;
 use App\Enums\FontWeight;
 use App\Features\FormVersioningFeature;
+use App\Features\PastSubmissionsFeature;
 use CanyonGBS\Common\Filament\Forms\Components\ColorSelect;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\RichEditor;
@@ -90,8 +91,8 @@ trait HasSharedFormConfiguration
                         ->label('Allowed Domains')
                         ->helperText('Only these domains will be allowed to embed this form.')
                         ->placeholder('example.com')
-                        ->hidden(fn (Get $get) => ! $get('embed_enabled'))
-                        ->disabled(fn (Get $get) => ! $get('embed_enabled'))
+                        ->hidden(fn(Get $get) => ! $get('embed_enabled'))
+                        ->disabled(fn(Get $get) => ! $get('embed_enabled'))
                         ->nestedRecursiveRules(
                             [
                                 'string',
@@ -107,8 +108,12 @@ trait HasSharedFormConfiguration
             Toggle::make('should_generate_prospects')
                 ->label('Generate Prospects')
                 ->helperText('If enabled, a request to submit by an unknown prospect will result in a new prospect being created.')
-                ->disabled(fn () => ! auth()->user()?->hasLicense(LicenseType::RecruitmentCrm))
-                ->hintIcon(fn () => ! auth()->user()?->hasLicense(LicenseType::RecruitmentCrm) ? 'heroicon-m-lock-closed' : null),
+                ->disabled(fn() => ! auth()->user()?->hasLicense(LicenseType::RecruitmentCrm))
+                ->hintIcon(fn() => ! auth()->user()?->hasLicense(LicenseType::RecruitmentCrm) ? 'heroicon-m-lock-closed' : null),
+            Toggle::make('allow_view_past_submissions')
+                ->label('Allow viewing past submissions')
+                ->visible(fn(): bool => PastSubmissionsFeature::active())
+                ->helperText('If enabled, students and prospects can view their past submissions on this form.'),
             Section::make('Fields')
                 ->schema([
                     $this->fieldBuilder(),

--- a/app-modules/application/src/Filament/Resources/Applications/Pages/Concerns/HasSharedFormConfiguration.php
+++ b/app-modules/application/src/Filament/Resources/Applications/Pages/Concerns/HasSharedFormConfiguration.php
@@ -91,8 +91,8 @@ trait HasSharedFormConfiguration
                         ->label('Allowed Domains')
                         ->helperText('Only these domains will be allowed to embed this form.')
                         ->placeholder('example.com')
-                        ->hidden(fn(Get $get) => ! $get('embed_enabled'))
-                        ->disabled(fn(Get $get) => ! $get('embed_enabled'))
+                        ->hidden(fn (Get $get) => ! $get('embed_enabled'))
+                        ->disabled(fn (Get $get) => ! $get('embed_enabled'))
                         ->nestedRecursiveRules(
                             [
                                 'string',
@@ -108,11 +108,11 @@ trait HasSharedFormConfiguration
             Toggle::make('should_generate_prospects')
                 ->label('Generate Prospects')
                 ->helperText('If enabled, a request to submit by an unknown prospect will result in a new prospect being created.')
-                ->disabled(fn() => ! auth()->user()?->hasLicense(LicenseType::RecruitmentCrm))
-                ->hintIcon(fn() => ! auth()->user()?->hasLicense(LicenseType::RecruitmentCrm) ? 'heroicon-m-lock-closed' : null),
+                ->disabled(fn () => ! auth()->user()?->hasLicense(LicenseType::RecruitmentCrm))
+                ->hintIcon(fn () => ! auth()->user()?->hasLicense(LicenseType::RecruitmentCrm) ? 'heroicon-m-lock-closed' : null),
             Toggle::make('allow_view_past_submissions')
                 ->label('Allow viewing past submissions')
-                ->visible(fn(): bool => PastSubmissionsFeature::active())
+                ->visible(fn (): bool => PastSubmissionsFeature::active())
                 ->helperText('If enabled, students and prospects can view their past submissions on this form.'),
             Section::make('Fields')
                 ->schema([

--- a/app-modules/application/src/Filament/Resources/Applications/Pages/ListApplications.php
+++ b/app-modules/application/src/Filament/Resources/Applications/Pages/ListApplications.php
@@ -39,6 +39,8 @@ namespace AdvisingApp\Application\Filament\Resources\Applications\Pages;
 use AdvisingApp\Application\Actions\DuplicateApplication;
 use AdvisingApp\Application\Filament\Resources\Applications\ApplicationResource;
 use AdvisingApp\Application\Models\Application;
+use AdvisingApp\Application\Models\ApplicationSubmission;
+use App\Features\FormVersioningFeature;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
@@ -51,6 +53,7 @@ use Filament\Resources\Pages\ListRecords;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 class ListApplications extends ListRecords
@@ -62,13 +65,26 @@ class ListApplications extends ListRecords
     public function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(function (Builder $query) {
+                $submissionsCountQuery = FormVersioningFeature::active()
+                    ? ApplicationSubmission::query()
+                        ->join('applications as version_applications', 'application_submissions.application_id', '=', 'version_applications.id')
+                        ->whereColumn('version_applications.root_id', 'applications.root_id')
+                        ->selectRaw('count(*)')
+                    : ApplicationSubmission::query()
+                        ->whereColumn('application_id', 'applications.id')
+                        ->selectRaw('count(*)');
+
+                $query->addSelect([
+                    'submissions_count' => $submissionsCountQuery,
+                ]);
+            })
             ->columns([
                 IdColumn::make(),
                 TextColumn::make('name')
                     ->description(fn (Application $record) => $record->title),
                 TextColumn::make('submissions_count')
-                    ->label('Submissions')
-                    ->counts('submissions'),
+                    ->label('Submissions'),
                 TextColumn::make('created_at')
                     ->label('Created')
                     ->date()

--- a/app-modules/application/src/Filament/Resources/Applications/Pages/ViewApplication.php
+++ b/app-modules/application/src/Filament/Resources/Applications/Pages/ViewApplication.php
@@ -40,6 +40,7 @@ use AdvisingApp\Application\Filament\Resources\Applications\ApplicationResource;
 use AdvisingApp\Application\Models\Application;
 use AdvisingApp\Form\Actions\GenerateSubmissibleEmbedCode;
 use AdvisingApp\Form\Filament\Blocks\FormFieldBlockRegistry;
+use App\Features\PastSubmissionsFeature;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Repeater;
@@ -86,6 +87,10 @@ class ViewApplication extends ViewRecord
                             ->boolean(),
                         IconEntry::make('is_wizard')
                             ->label('Multi-step form')
+                            ->boolean(),
+                        IconEntry::make('allow_view_past_submissions')
+                            ->label('Allow View Past Submissions')
+                            ->visible(fn (): bool => PastSubmissionsFeature::active())
                             ->boolean(),
                     ]),
                 Section::make('Fields')

--- a/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
+++ b/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
@@ -474,7 +474,7 @@ class ApplicationWidgetController extends Controller
         $pastSubmissions = $application->submissions()
             ->whereMorphedTo('author', $author)
             ->orderByDesc('created_at')
-            ->paginate($request->query('per_page', 10));
+            ->paginate(min((int) $request->query('per_page', 10), 50));
 
         $items = $pastSubmissions->map(fn (ApplicationSubmission $submission) => [
             'id' => $submission->getKey(),
@@ -501,6 +501,7 @@ class ApplicationWidgetController extends Controller
     }
 
     public function getSubmission(
+        Request $request,
         GenerateSubmissionViewData $generateSubmissionViewData,
         GenerateFormKitSchema $generateSchema,
         Application $application,
@@ -510,7 +511,7 @@ class ApplicationWidgetController extends Controller
             abort(Response::HTTP_FORBIDDEN);
         }
 
-        $authentication = request()->query('authentication');
+        $authentication = $request->query('authentication');
 
         if (filled($authentication)) {
             $authentication = ApplicationAuthentication::findOrFail($authentication);

--- a/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
+++ b/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
@@ -240,7 +240,15 @@ class ApplicationWidgetController extends Controller
         $pastSubmissionsUrl = null;
 
         if (PastSubmissionsFeature::active() && $application->allow_view_past_submissions && $author) {
-            $pastSubmissionsCount = $application->submissions()
+            $pastSubmissionsCount = ApplicationSubmission::query()
+                ->when(
+                    FormVersioningFeature::active(),
+                    fn ($query) => $query->whereHas(
+                        'submissible',
+                        fn ($query) => $query->withoutGlobalScopes()->where('root_id', $application->root_id),
+                    ),
+                    fn ($query) => $query->where('application_id', $application->getKey()),
+                )
                 ->whereMorphedTo('author', $author)
                 ->count();
 
@@ -471,7 +479,15 @@ class ApplicationWidgetController extends Controller
             ]);
         }
 
-        $pastSubmissions = $application->submissions()
+        $pastSubmissions = ApplicationSubmission::query()
+            ->when(
+                FormVersioningFeature::active(),
+                fn ($query) => $query->whereHas(
+                    'submissible',
+                    fn ($query) => $query->withoutGlobalScopes()->where('root_id', $application->root_id),
+                ),
+                fn ($query) => $query->where('application_id', $application->getKey()),
+            )
             ->whereMorphedTo('author', $author)
             ->orderByDesc('created_at')
             ->paginate(min((int) $request->query('per_page', 10), 50));
@@ -521,7 +537,12 @@ class ApplicationWidgetController extends Controller
             abort(Response::HTTP_UNAUTHORIZED);
         }
 
-        abort_unless($submission->application_id === $application->getKey(), Response::HTTP_NOT_FOUND);
+        abort_unless(
+            FormVersioningFeature::active()
+                ? $submission->submissible()->withoutGlobalScopes()->value('root_id') === $application->root_id
+                : $submission->application_id === $application->getKey(),
+            Response::HTTP_NOT_FOUND,
+        );
 
         $author = $authentication->author;
 

--- a/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
+++ b/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
@@ -132,13 +132,13 @@ class ApplicationWidgetController extends Controller
                 ),
                 'primary_color' => collect(Color::all()[$application->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $application->rounding,
                 'title_font_weight' => $application->title_font_weight,
                 'title_color' => collect(Color::all()[$application->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ],
         );
@@ -154,13 +154,13 @@ class ApplicationWidgetController extends Controller
                 'schema' => $generateSchema($application),
                 'primary_color' => collect(Color::all()[$application->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $application->rounding,
                 'title_font_weight' => $application->title_font_weight,
                 'title_color' => collect(Color::all()[$application->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ],
         );
@@ -491,7 +491,7 @@ class ApplicationWidgetController extends Controller
             ->orderByDesc('created_at')
             ->paginate($request->query('per_page', 10));
 
-        $items = $pastSubmissions->map(fn (ApplicationSubmission $submission) => [
+        $items = $pastSubmissions->map(fn(ApplicationSubmission $submission) => [
             'id' => $submission->getKey(),
             'submitted_at' => $submission->created_at->toIso8601String(),
             'view_url' => URL::signedRoute(
@@ -517,6 +517,7 @@ class ApplicationWidgetController extends Controller
 
     public function getSubmission(
         GenerateSubmissionViewData $generateSubmissionViewData,
+        GenerateFormKitSchema $generateSchema,
         Application $application,
         ApplicationSubmission $submission,
     ): JsonResponse {
@@ -545,7 +546,7 @@ class ApplicationWidgetController extends Controller
         );
 
         return response()->json(
-            $generateSubmissionViewData($submission),
+            $generateSubmissionViewData($submission, $generateSchema),
         );
     }
 }

--- a/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
+++ b/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
@@ -125,7 +125,7 @@ class ApplicationWidgetController extends Controller
             [
                 'name' => $application->title,
                 'description' => $application->description,
-                'allow_view_past_submissions' => $application->allow_view_past_submissions,
+                'allow_view_past_submissions' => PastSubmissionsFeature::active() && $application->allow_view_past_submissions,
                 'authentication_url' => URL::signedRoute(
                     name: 'widgets.applications.api.request-authentication',
                     parameters: ['application' => $application],

--- a/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
+++ b/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
@@ -42,6 +42,7 @@ use AdvisingApp\Application\Models\ApplicationAuthentication;
 use AdvisingApp\Application\Models\ApplicationSubmission;
 use AdvisingApp\Form\Actions\GenerateFormKitSchema;
 use AdvisingApp\Form\Actions\GenerateSubmissibleValidation;
+use AdvisingApp\Form\Actions\GenerateSubmissionViewData;
 use AdvisingApp\Form\Actions\ProcessSubmissionField;
 use AdvisingApp\Form\Actions\ResolveSubmissionAuthorFromEmail;
 use AdvisingApp\Form\Http\Requests\RegisterProspectRequestForApplication;
@@ -52,6 +53,7 @@ use AdvisingApp\Prospect\Models\ProspectSource;
 use AdvisingApp\Prospect\Models\ProspectStatus;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Features\FormVersioningFeature;
+use App\Features\PastSubmissionsFeature;
 use App\Features\PhoneNumberLookupFeature;
 use App\Http\Controllers\Controller;
 use Closure;
@@ -123,19 +125,20 @@ class ApplicationWidgetController extends Controller
             [
                 'name' => $application->title,
                 'description' => $application->description,
+                'allow_view_past_submissions' => $application->allow_view_past_submissions,
                 'authentication_url' => URL::signedRoute(
                     name: 'widgets.applications.api.request-authentication',
                     parameters: ['application' => $application],
                 ),
                 'primary_color' => collect(Color::all()[$application->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $application->rounding,
                 'title_font_weight' => $application->title_font_weight,
                 'title_color' => collect(Color::all()[$application->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ],
         );
@@ -151,13 +154,13 @@ class ApplicationWidgetController extends Controller
                 'schema' => $generateSchema($application),
                 'primary_color' => collect(Color::all()[$application->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $application->rounding,
                 'title_font_weight' => $application->title_font_weight,
                 'title_color' => collect(Color::all()[$application->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ],
         );
@@ -233,6 +236,25 @@ class ApplicationWidgetController extends Controller
 
         assert($author instanceof Prospect || $author instanceof Student || $author === null);
 
+        $pastSubmissionsCount = 0;
+        $pastSubmissionsUrl = null;
+
+        if (PastSubmissionsFeature::active() && $application->allow_view_past_submissions && $author) {
+            $pastSubmissionsCount = $application->submissions()
+                ->whereMorphedTo('author', $author)
+                ->count();
+
+            if ($pastSubmissionsCount > 0) {
+                $pastSubmissionsUrl = URL::signedRoute(
+                    name: 'widgets.applications.api.get-past-submissions',
+                    parameters: [
+                        'application' => $application,
+                        'authentication' => $authentication,
+                    ],
+                );
+            }
+        }
+
         return response()->json([
             'submission_url' => URL::signedRoute(
                 name: 'widgets.applications.api.submit',
@@ -242,6 +264,9 @@ class ApplicationWidgetController extends Controller
                 ],
             ),
             'schema' => $generateSchema->withAuthor($author)($application),
+            'allow_view_past_submissions' => PastSubmissionsFeature::active() &&  $application->allow_view_past_submissions,
+            'past_submissions_count' => $pastSubmissionsCount,
+            'past_submissions_url' => $pastSubmissionsUrl,
         ]);
     }
 
@@ -432,5 +457,97 @@ class ApplicationWidgetController extends Controller
         return Application::query()->where('root_id', $application->root_id)
             ->whereNull('archived_at')
             ->first() ?? $application;
+    }
+
+    public function getPastSubmissions(
+        Request $request,
+        Application $application,
+    ): JsonResponse {
+
+        if (! PastSubmissionsFeature::active()) {
+            abort(Response::HTTP_FORBIDDEN);
+        }
+        $authentication = $request->query('authentication');
+
+        if (filled($authentication)) {
+            $authentication = ApplicationAuthentication::findOrFail($authentication);
+        }
+
+        if (! $authentication || $authentication->isExpired()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        $author = $authentication->author;
+
+        assert($author instanceof Prospect || $author instanceof Student || $author === null);
+
+        if (! $application->allow_view_past_submissions || ! $author) {
+            return response()->json([
+                'past_submissions' => [],
+            ]);
+        }
+
+        $pastSubmissions = $application->submissions()
+            ->whereMorphedTo('author', $author)
+            ->orderByDesc('created_at')
+            ->paginate($request->query('per_page', 10));
+
+        $items = $pastSubmissions->map(fn(ApplicationSubmission $submission) => [
+            'id' => $submission->getKey(),
+            'submitted_at' => $submission->created_at->toIso8601String(),
+            'view_url' => URL::signedRoute(
+                name: 'widgets.applications.api.get-submission',
+                parameters: [
+                    'application' => $application,
+                    'submission' => $submission,
+                    'authentication' => $authentication,
+                ],
+            ),
+        ])->all();
+
+        return response()->json([
+            'past_submissions' => $items,
+            'meta' => [
+                'current_page' => $pastSubmissions->currentPage(),
+                'last_page' => $pastSubmissions->lastPage(),
+                'per_page' => $pastSubmissions->perPage(),
+                'total' => $pastSubmissions->total(),
+            ],
+        ]);
+    }
+
+    public function getSubmission(
+        GenerateSubmissionViewData $generateSubmissionViewData,
+        Application $application,
+        ApplicationSubmission $submission,
+    ): JsonResponse {
+
+        if (! PastSubmissionsFeature::active()) {
+            abort(Response::HTTP_FORBIDDEN);
+        }
+
+        $authentication = request()->query('authentication');
+
+        if (filled($authentication)) {
+            $authentication = ApplicationAuthentication::findOrFail($authentication);
+        }
+
+        if (! $authentication || $authentication->isExpired()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        abort_unless($submission->application_id === $application->getKey(), Response::HTTP_NOT_FOUND);
+
+        $author = $authentication->author;
+
+        abort_unless(
+            $submission->author_type === $author?->getMorphClass()
+                && $submission->author_id === $author?->getKey(),
+            Response::HTTP_FORBIDDEN,
+        );
+
+        return response()->json(
+            $generateSubmissionViewData($submission),
+        );
     }
 }

--- a/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
+++ b/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
@@ -132,13 +132,13 @@ class ApplicationWidgetController extends Controller
                 ),
                 'primary_color' => collect(Color::all()[$application->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $application->rounding,
                 'title_font_weight' => $application->title_font_weight,
                 'title_color' => collect(Color::all()[$application->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ],
         );
@@ -154,13 +154,13 @@ class ApplicationWidgetController extends Controller
                 'schema' => $generateSchema($application),
                 'primary_color' => collect(Color::all()[$application->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $application->rounding,
                 'title_font_weight' => $application->title_font_weight,
                 'title_color' => collect(Color::all()[$application->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ],
         );
@@ -491,7 +491,7 @@ class ApplicationWidgetController extends Controller
             ->orderByDesc('created_at')
             ->paginate($request->query('per_page', 10));
 
-        $items = $pastSubmissions->map(fn(ApplicationSubmission $submission) => [
+        $items = $pastSubmissions->map(fn (ApplicationSubmission $submission) => [
             'id' => $submission->getKey(),
             'submitted_at' => $submission->created_at->toIso8601String(),
             'view_url' => URL::signedRoute(

--- a/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
+++ b/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
@@ -444,21 +444,6 @@ class ApplicationWidgetController extends Controller
         ]);
     }
 
-    private function resolveToLatestVersion(Application $application): Application
-    {
-        if (! FormVersioningFeature::active()) {
-            return $application;
-        }
-
-        if (! $application->isArchived()) {
-            return $application;
-        }
-
-        return Application::query()->where('root_id', $application->root_id)
-            ->whereNull('archived_at')
-            ->first() ?? $application;
-    }
-
     public function getPastSubmissions(
         Request $request,
         Application $application,
@@ -548,5 +533,20 @@ class ApplicationWidgetController extends Controller
         return response()->json(
             $generateSubmissionViewData($submission, $generateSchema),
         );
+    }
+
+    private function resolveToLatestVersion(Application $application): Application
+    {
+        if (! FormVersioningFeature::active()) {
+            return $application;
+        }
+
+        if (! $application->isArchived()) {
+            return $application;
+        }
+
+        return Application::query()->where('root_id', $application->root_id)
+            ->whereNull('archived_at')
+            ->first() ?? $application;
     }
 }

--- a/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
+++ b/app-modules/application/src/Http/Controllers/ApplicationWidgetController.php
@@ -132,13 +132,13 @@ class ApplicationWidgetController extends Controller
                 ),
                 'primary_color' => collect(Color::all()[$application->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $application->rounding,
                 'title_font_weight' => $application->title_font_weight,
                 'title_color' => collect(Color::all()[$application->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ],
         );
@@ -154,13 +154,13 @@ class ApplicationWidgetController extends Controller
                 'schema' => $generateSchema($application),
                 'primary_color' => collect(Color::all()[$application->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $application->rounding,
                 'title_font_weight' => $application->title_font_weight,
                 'title_color' => collect(Color::all()[$application->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ],
         );
@@ -264,7 +264,7 @@ class ApplicationWidgetController extends Controller
                 ],
             ),
             'schema' => $generateSchema->withAuthor($author)($application),
-            'allow_view_past_submissions' => PastSubmissionsFeature::active() &&  $application->allow_view_past_submissions,
+            'allow_view_past_submissions' => PastSubmissionsFeature::active() && $application->allow_view_past_submissions,
             'past_submissions_count' => $pastSubmissionsCount,
             'past_submissions_url' => $pastSubmissionsUrl,
         ]);
@@ -463,7 +463,6 @@ class ApplicationWidgetController extends Controller
         Request $request,
         Application $application,
     ): JsonResponse {
-
         if (! PastSubmissionsFeature::active()) {
             abort(Response::HTTP_FORBIDDEN);
         }
@@ -492,7 +491,7 @@ class ApplicationWidgetController extends Controller
             ->orderByDesc('created_at')
             ->paginate($request->query('per_page', 10));
 
-        $items = $pastSubmissions->map(fn(ApplicationSubmission $submission) => [
+        $items = $pastSubmissions->map(fn (ApplicationSubmission $submission) => [
             'id' => $submission->getKey(),
             'submitted_at' => $submission->created_at->toIso8601String(),
             'view_url' => URL::signedRoute(
@@ -521,7 +520,6 @@ class ApplicationWidgetController extends Controller
         Application $application,
         ApplicationSubmission $submission,
     ): JsonResponse {
-
         if (! PastSubmissionsFeature::active()) {
             abort(Response::HTTP_FORBIDDEN);
         }

--- a/app-modules/application/src/Models/Application.php
+++ b/app-modules/application/src/Models/Application.php
@@ -90,7 +90,7 @@ class Application extends Submissible implements HasMedia, HasRichContent
         'notify_via_app',
         'notify_via_email',
         'root_id',
-        'allow_view_past_submissions'
+        'allow_view_past_submissions',
     ];
 
     protected $casts = [

--- a/app-modules/application/src/Models/Application.php
+++ b/app-modules/application/src/Models/Application.php
@@ -90,6 +90,7 @@ class Application extends Submissible implements HasMedia, HasRichContent
         'notify_via_app',
         'notify_via_email',
         'root_id',
+        'allow_view_past_submissions'
     ];
 
     protected $casts = [
@@ -104,6 +105,7 @@ class Application extends Submissible implements HasMedia, HasRichContent
         'notify_to_subscribers' => 'boolean',
         'notify_via_app' => 'boolean',
         'notify_via_email' => 'boolean',
+        'allow_view_past_submissions' => 'boolean'
     ];
 
     public function setUpRichContent(): void

--- a/app-modules/application/src/Models/Application.php
+++ b/app-modules/application/src/Models/Application.php
@@ -105,7 +105,7 @@ class Application extends Submissible implements HasMedia, HasRichContent
         'notify_to_subscribers' => 'boolean',
         'notify_via_app' => 'boolean',
         'notify_via_email' => 'boolean',
-        'allow_view_past_submissions' => 'boolean'
+        'allow_view_past_submissions' => 'boolean',
     ];
 
     public function setUpRichContent(): void

--- a/app-modules/application/tests/Tenant/Application/ListApplicationsTest.php
+++ b/app-modules/application/tests/Tenant/Application/ListApplicationsTest.php
@@ -34,12 +34,18 @@
 </COPYRIGHT>
 */
 
+use AdvisingApp\Application\Database\Seeders\ApplicationSubmissionStateSeeder;
 use AdvisingApp\Application\Filament\Resources\Applications\ApplicationResource;
+use AdvisingApp\Application\Filament\Resources\Applications\Pages\ListApplications;
+use AdvisingApp\Application\Models\Application;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use App\Models\User;
 use App\Settings\LicenseSettings;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\seed;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
 
 // TODO: Write ListApplications tests
 //test('The correct details are displayed on the ListApplications page', function () {});
@@ -88,4 +94,54 @@ test('ListApplications is gated with proper feature access control', function ()
         ->get(
             ApplicationResource::getUrl('index')
         )->assertSuccessful();
+});
+
+test('submissions count displays the correct count for an application', function () {
+    seed(ApplicationSubmissionStateSeeder::class);
+
+    asSuperAdmin();
+
+    $application = Application::factory()->create();
+
+    $expectedCount = $application->submissions()->count();
+
+    expect($expectedCount)->toBeGreaterThan(0);
+
+    livewire(ListApplications::class)
+        ->assertTableColumnStateSet('submissions_count', $expectedCount, $application);
+});
+
+test('submissions count includes submissions across all versions', function () {
+    seed(ApplicationSubmissionStateSeeder::class);
+
+    asSuperAdmin();
+
+    $application = Application::factory()->create();
+
+    $existingCount = $application->submissions()->count();
+
+    $archivedVersion = Application::factory()->create([
+        'root_id' => $application->root_id,
+        'archived_at' => now(),
+    ]);
+
+    $archivedCount = $archivedVersion->submissions()->count();
+
+    livewire(ListApplications::class)
+        ->assertTableColumnStateSet('submissions_count', $existingCount + $archivedCount, $application);
+});
+
+test('submissions count does not include submissions from unrelated applications', function () {
+    seed(ApplicationSubmissionStateSeeder::class);
+
+    asSuperAdmin();
+
+    $application = Application::factory()->create();
+
+    $expectedCount = $application->submissions()->count();
+
+    $unrelatedApplication = Application::factory()->create();
+
+    livewire(ListApplications::class)
+        ->assertTableColumnStateSet('submissions_count', $expectedCount, $application);
 });

--- a/app-modules/application/tests/Tenant/ApplicationPastSubmissionsApiTest.php
+++ b/app-modules/application/tests/Tenant/ApplicationPastSubmissionsApiTest.php
@@ -1,0 +1,469 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Application\Database\Seeders\ApplicationSubmissionStateSeeder;
+use AdvisingApp\Application\Models\Application;
+use AdvisingApp\Application\Models\ApplicationAuthentication;
+use AdvisingApp\Application\Models\ApplicationSubmission;
+use AdvisingApp\Form\Http\Middleware\EnsureSubmissibleIsEmbeddableAndAuthorized;
+use AdvisingApp\Prospect\Models\Prospect;
+use App\Settings\LicenseSettings;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\URL;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\seed;
+use function Pest\Laravel\withoutMiddleware;
+
+beforeEach(function () {
+    withoutMiddleware([EnsureSubmissibleIsEmbeddableAndAuthorized::class]);
+
+    seed(ApplicationSubmissionStateSeeder::class);
+
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->onlineAdmissions = true;
+    $settings->save();
+});
+
+test('view endpoint returns allow_view_past_submissions true when toggle is on', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $response = get(route('widgets.applications.api.entry', ['application' => $application]))
+        ->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeTrue();
+});
+
+test('view endpoint returns allow_view_past_submissions false when toggle is off', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => false,
+    ]);
+
+    $response = get(route('widgets.applications.api.entry', ['application' => $application]))
+        ->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeFalse();
+});
+
+test('authenticate returns past_submissions_count and url when toggle is on and submissions exist', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $code = 123456;
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make($code),
+    ]);
+
+    ApplicationSubmission::factory()->count(3)->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+    ]);
+
+    $response = post(URL::signedRoute(
+        name: 'widgets.applications.api.authenticate',
+        parameters: [
+            'application' => $application,
+            'authentication' => $authentication,
+            'code' => $code,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeTrue();
+    expect($response->json('past_submissions_count'))->toBe(3);
+    expect($response->json('past_submissions_url'))->not->toBeNull();
+    expect($response->json('schema'))->toBeArray();
+    expect($response->json('submission_url'))->not->toBeNull();
+});
+
+test('authenticate returns zero past_submissions_count when toggle is on but no submissions exist', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $code = 123456;
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make($code),
+    ]);
+
+    $response = post(URL::signedRoute(
+        name: 'widgets.applications.api.authenticate',
+        parameters: [
+            'application' => $application,
+            'authentication' => $authentication,
+            'code' => $code,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeTrue();
+    expect($response->json('past_submissions_count'))->toBe(0);
+    expect($response->json('past_submissions_url'))->toBeNull();
+});
+
+test('authenticate returns zero past_submissions_count when toggle is off', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => false,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $code = 123456;
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make($code),
+    ]);
+
+    ApplicationSubmission::factory()->count(2)->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+    ]);
+
+    $response = post(URL::signedRoute(
+        name: 'widgets.applications.api.authenticate',
+        parameters: [
+            'application' => $application,
+            'authentication' => $authentication,
+            'code' => $code,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeFalse();
+    expect($response->json('past_submissions_count'))->toBe(0);
+    expect($response->json('past_submissions_url'))->toBeNull();
+});
+
+test('getPastSubmissions returns paginated past submissions', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make('123456'),
+    ]);
+
+    ApplicationSubmission::factory()->count(3)->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+    ]);
+
+    $response = get(URL::signedRoute(
+        name: 'widgets.applications.api.get-past-submissions',
+        parameters: [
+            'application' => $application,
+            'authentication' => $authentication,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('past_submissions'))->toHaveCount(3);
+    expect($response->json('meta.total'))->toBe(3);
+    expect($response->json('meta.current_page'))->toBe(1);
+
+    $firstSubmission = $response->json('past_submissions.0');
+    expect($firstSubmission)->toHaveKeys(['id', 'submitted_at', 'view_url']);
+});
+
+test('getPastSubmissions returns empty when toggle is off', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => false,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make('123456'),
+    ]);
+
+    ApplicationSubmission::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+    ]);
+
+    $response = get(URL::signedRoute(
+        name: 'widgets.applications.api.get-past-submissions',
+        parameters: [
+            'application' => $application,
+            'authentication' => $authentication,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('past_submissions'))->toBeEmpty();
+});
+
+test('getPastSubmissions does not return submissions from other authors', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+    $otherProspect = Prospect::factory()->create();
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make('123456'),
+    ]);
+
+    // Submissions from the authenticated author
+    ApplicationSubmission::factory()->count(2)->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+    ]);
+
+    // Submissions from a different author
+    ApplicationSubmission::factory()->count(3)->create([
+        'application_id' => $application->id,
+        'author_type' => $otherProspect->getMorphClass(),
+        'author_id' => $otherProspect->getKey(),
+    ]);
+
+    $response = get(URL::signedRoute(
+        name: 'widgets.applications.api.get-past-submissions',
+        parameters: [
+            'application' => $application,
+            'authentication' => $authentication,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('past_submissions'))->toHaveCount(2);
+    expect($response->json('meta.total'))->toBe(2);
+});
+
+test('getPastSubmissions returns 401 with expired authentication', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make('123456'),
+    ]);
+
+    ApplicationAuthentication::withoutTimestamps(
+        fn() =>
+        ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+    );
+    $authentication->refresh();
+
+    get(URL::signedRoute(
+        name: 'widgets.applications.api.get-past-submissions',
+        parameters: [
+            'application' => $application,
+            'authentication' => $authentication,
+        ],
+    ))->assertUnauthorized();
+});
+
+test('getPastSubmissions returns 401 without authentication parameter', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+
+    get(URL::signedRoute(
+        name: 'widgets.applications.api.get-past-submissions',
+        parameters: [
+            'application' => $application,
+        ],
+    ))->assertUnauthorized();
+});
+
+test('getSubmission returns submission detail data', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make('123456'),
+    ]);
+
+    $submission = ApplicationSubmission::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+    ]);
+
+    $response = get(URL::signedRoute(
+        name: 'widgets.applications.api.get-submission',
+        parameters: [
+            'application' => $application,
+            'submission' => $submission,
+            'authentication' => $authentication,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('id'))->toBe($submission->getKey());
+    expect($response->json('submitted_at'))->not->toBeNull();
+    expect($response->json('is_wizard'))->toBeFalse();
+    expect($response->json('fields'))->toBeArray();
+});
+
+test('getSubmission returns 401 with expired authentication', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make('123456'),
+    ]);
+
+    ApplicationAuthentication::withoutTimestamps(
+        fn() =>
+        ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+    );
+    $authentication->refresh();
+
+    $submission = ApplicationSubmission::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+    ]);
+
+    get(URL::signedRoute(
+        name: 'widgets.applications.api.get-submission',
+        parameters: [
+            'application' => $application,
+            'submission' => $submission,
+            'authentication' => $authentication,
+        ],
+    ))->assertUnauthorized();
+});
+
+test('getSubmission returns 403 when author does not match', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+    $otherProspect = Prospect::factory()->create();
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make('123456'),
+    ]);
+
+    $submission = ApplicationSubmission::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $otherProspect->getMorphClass(),
+        'author_id' => $otherProspect->getKey(),
+    ]);
+
+    get(URL::signedRoute(
+        name: 'widgets.applications.api.get-submission',
+        parameters: [
+            'application' => $application,
+            'submission' => $submission,
+            'authentication' => $authentication,
+        ],
+    ))->assertForbidden();
+});
+
+test('getSubmission returns 404 when submission does not belong to application', function () {
+    $application = Application::factory()->create([
+        'allow_view_past_submissions' => true,
+    ]);
+    $otherApplication = Application::factory()->create();
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = ApplicationAuthentication::factory()->create([
+        'application_id' => $application->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'code' => Hash::make('123456'),
+    ]);
+
+    $submission = ApplicationSubmission::factory()->create([
+        'application_id' => $otherApplication->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+    ]);
+
+    get(URL::signedRoute(
+        name: 'widgets.applications.api.get-submission',
+        parameters: [
+            'application' => $application,
+            'submission' => $submission,
+            'authentication' => $authentication,
+        ],
+    ))->assertNotFound();
+});

--- a/app-modules/application/tests/Tenant/ApplicationPastSubmissionsApiTest.php
+++ b/app-modules/application/tests/Tenant/ApplicationPastSubmissionsApiTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of
@@ -308,8 +308,7 @@ test('getPastSubmissions returns 401 with expired authentication', function () {
     ]);
 
     ApplicationAuthentication::withoutTimestamps(
-        fn() =>
-        ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn () => ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 
@@ -385,8 +384,7 @@ test('getSubmission returns 401 with expired authentication', function () {
     ]);
 
     ApplicationAuthentication::withoutTimestamps(
-        fn() =>
-        ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn () => ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 

--- a/app-modules/application/tests/Tenant/ApplicationPastSubmissionsApiTest.php
+++ b/app-modules/application/tests/Tenant/ApplicationPastSubmissionsApiTest.php
@@ -308,7 +308,7 @@ test('getPastSubmissions returns 401 with expired authentication', function () {
     ]);
 
     ApplicationAuthentication::withoutTimestamps(
-        fn() => ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn () => ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 
@@ -383,7 +383,7 @@ test('getSubmission returns 401 with expired authentication', function () {
     ]);
 
     ApplicationAuthentication::withoutTimestamps(
-        fn() => ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn () => ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 

--- a/app-modules/application/tests/Tenant/ApplicationPastSubmissionsApiTest.php
+++ b/app-modules/application/tests/Tenant/ApplicationPastSubmissionsApiTest.php
@@ -88,7 +88,7 @@ test('authenticate returns past_submissions_count and url when toggle is on and 
 
     $prospect = Prospect::factory()->create();
 
-    $code = 123456;
+    $code = '123456';
 
     $authentication = ApplicationAuthentication::factory()->create([
         'application_id' => $application->id,
@@ -126,7 +126,7 @@ test('authenticate returns zero past_submissions_count when toggle is on but no 
 
     $prospect = Prospect::factory()->create();
 
-    $code = 123456;
+    $code = '123456';
 
     $authentication = ApplicationAuthentication::factory()->create([
         'application_id' => $application->id,
@@ -156,7 +156,7 @@ test('authenticate returns zero past_submissions_count when toggle is off', func
 
     $prospect = Prospect::factory()->create();
 
-    $code = 123456;
+    $code = '123456';
 
     $authentication = ApplicationAuthentication::factory()->create([
         'application_id' => $application->id,

--- a/app-modules/application/tests/Tenant/ApplicationPastSubmissionsApiTest.php
+++ b/app-modules/application/tests/Tenant/ApplicationPastSubmissionsApiTest.php
@@ -308,7 +308,7 @@ test('getPastSubmissions returns 401 with expired authentication', function () {
     ]);
 
     ApplicationAuthentication::withoutTimestamps(
-        fn () => ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn() => ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 
@@ -365,8 +365,7 @@ test('getSubmission returns submission detail data', function () {
 
     expect($response->json('id'))->toBe($submission->getKey());
     expect($response->json('submitted_at'))->not->toBeNull();
-    expect($response->json('is_wizard'))->toBeFalse();
-    expect($response->json('fields'))->toBeArray();
+    expect($response->json('schema'))->toBeArray();
 });
 
 test('getSubmission returns 401 with expired authentication', function () {
@@ -384,7 +383,7 @@ test('getSubmission returns 401 with expired authentication', function () {
     ]);
 
     ApplicationAuthentication::withoutTimestamps(
-        fn () => ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn() => ApplicationAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 

--- a/app-modules/form/database/migrations/2026_06_15_101745_add_allow_view_past_submissions_to_forms_table.php
+++ b/app-modules/form/database/migrations/2026_06_15_101745_add_allow_view_past_submissions_to_forms_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->boolean('allow_view_past_submissions')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('forms', function (Blueprint $table) {
+            $table->dropColumn('allow_view_past_submissions');
+        });
+    }
+};

--- a/app-modules/form/database/migrations/2026_06_15_101745_add_allow_view_past_submissions_to_forms_table.php
+++ b/app-modules/form/database/migrations/2026_06_15_101745_add_allow_view_past_submissions_to_forms_table.php
@@ -1,11 +1,44 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Database\Migrations\Migration;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('forms', function (Blueprint $table) {

--- a/app-modules/form/routes/widgets.php
+++ b/app-modules/form/routes/widgets.php
@@ -78,7 +78,7 @@ Route::middleware([
                     ->middleware(['signed'])
                     ->name('register-prospect');
                 Route::get('submissions/past-submissions', [FormWidgetController::class, 'getPastSubmissions'])
-                    ->middleware(['signed'])
+                    ->middleware(['signed:page,per_page'])
                     ->name('get-past-submissions');
                 Route::get('submissions/{submission}', [FormWidgetController::class, 'getSubmission'])
                     ->middleware(['signed'])

--- a/app-modules/form/routes/widgets.php
+++ b/app-modules/form/routes/widgets.php
@@ -77,6 +77,12 @@ Route::middleware([
                 Route::post('register', [FormWidgetController::class, 'registerProspect'])
                     ->middleware(['signed'])
                     ->name('register-prospect');
+                Route::get('submissions/past-submissions', [FormWidgetController::class, 'getPastSubmissions'])
+                    ->middleware(['signed'])
+                    ->name('get-past-submissions');
+                Route::get('submissions/{submission}', [FormWidgetController::class, 'getSubmission'])
+                    ->middleware(['signed'])
+                    ->name('get-submission');
 
                 // Handle preflight CORS requests for all routes in this group
                 // MUST remain the last route in this group

--- a/app-modules/form/src/Actions/GenerateFormKitSchema.php
+++ b/app-modules/form/src/Actions/GenerateFormKitSchema.php
@@ -255,7 +255,7 @@ class GenerateFormKitSchema
                         'children' => [
                             [
                                 '$formkit' => 'button',
-                                'disabled' => '$activeStep === "' . ($submissible->steps->first()?->label ?? '') . '"',
+                                'disabled' => '$activeStep === "' . ($submissible->steps->first()->label ?? '') . '"',
                                 'onClick' => '$setStep(-1)',
                                 'children' => 'Previous Step',
                             ],
@@ -263,7 +263,7 @@ class GenerateFormKitSchema
                                 '$el' => 'div',
                                 'attrs' => [
                                     'style' => [
-                                        'if' => '$activeStep === "' . ($submissible->steps->last()?->label ?? '') . '"',
+                                        'if' => '$activeStep === "' . ($submissible->steps->last()->label ?? '') . '"',
                                         'then' => 'display: none;',
                                     ],
                                 ],
@@ -279,7 +279,7 @@ class GenerateFormKitSchema
                                 '$el' => 'div',
                                 'attrs' => [
                                     'style' => [
-                                        'if' => '$activeStep !== "' . ($submissible->steps->last()?->label ?? '') . '"',
+                                        'if' => '$activeStep !== "' . ($submissible->steps->last()->label ?? '') . '"',
                                         'then' => 'display: none;',
                                     ],
                                 ],

--- a/app-modules/form/src/Actions/GenerateFormKitSchema.php
+++ b/app-modules/form/src/Actions/GenerateFormKitSchema.php
@@ -255,7 +255,7 @@ class GenerateFormKitSchema
                         'children' => [
                             [
                                 '$formkit' => 'button',
-                                'disabled' => '$activeStep === "' . $submissible->steps->first()->label . '"',
+                                'disabled' => '$activeStep === "' . ($submissible->steps->first()?->label ?? '') . '"',
                                 'onClick' => '$setStep(-1)',
                                 'children' => 'Previous Step',
                             ],
@@ -263,7 +263,7 @@ class GenerateFormKitSchema
                                 '$el' => 'div',
                                 'attrs' => [
                                     'style' => [
-                                        'if' => '$activeStep === "' . $submissible->steps->last()->label . '"',
+                                        'if' => '$activeStep === "' . ($submissible->steps->last()?->label ?? '') . '"',
                                         'then' => 'display: none;',
                                     ],
                                 ],
@@ -279,7 +279,7 @@ class GenerateFormKitSchema
                                 '$el' => 'div',
                                 'attrs' => [
                                     'style' => [
-                                        'if' => '$activeStep !== "' . $submissible->steps->last()->label . '"',
+                                        'if' => '$activeStep !== "' . ($submissible->steps->last()?->label ?? '') . '"',
                                         'then' => 'display: none;',
                                     ],
                                 ],

--- a/app-modules/form/src/Actions/GenerateSubmissionViewData.php
+++ b/app-modules/form/src/Actions/GenerateSubmissionViewData.php
@@ -57,8 +57,8 @@ class GenerateSubmissionViewData
         // @phpstan-ignore-next-line property.notFound
         $submittedAt = $submission->submitted_at ?? $submission->created_at;
 
-        $fieldResponses = fn(iterable $fields): array => collect($fields)
-            ->map(fn(SubmissibleField $field) => [
+        $fieldResponses = fn (iterable $fields): array => collect($fields)
+            ->map(fn (SubmissibleField $field) => [
                 'label' => $field->label,
                 'type' => $field->type,
                 // @phpstan-ignore-next-line property.notFound
@@ -76,7 +76,7 @@ class GenerateSubmissionViewData
                     $stepFieldIds = $step->fields()->pluck('id')->all();
 
                     $submittedFields = $submission->fields
-                        ->filter(fn(SubmissibleField $field) => in_array($field->getKey(), $stepFieldIds));
+                        ->filter(fn (SubmissibleField $field) => in_array($field->getKey(), $stepFieldIds));
 
                     return [
                         'label' => $step->label,

--- a/app-modules/form/src/Actions/GenerateSubmissionViewData.php
+++ b/app-modules/form/src/Actions/GenerateSubmissionViewData.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Form\Actions;
+
+use AdvisingApp\Form\Models\Submission;
+use AdvisingApp\Form\Models\SubmissibleField;
+
+class GenerateSubmissionViewData
+{
+    public function __invoke(Submission $submission): array
+    {
+        $submissible = $submission->submissible;
+        $submission->loadMissing('fields');
+
+        $authorEmail = $submission->author?->primaryEmailAddress?->address;
+
+        $submittedAt = $submission->submitted_at ?? $submission->created_at;
+
+        $fieldResponses = fn(iterable $fields): array => collect($fields)
+            ->map(fn(SubmissibleField $field) => [
+                'label' => $field->label,
+                'type' => $field->type,
+                'response' => $field->pivot?->response,
+            ])
+            ->values()
+            ->all();
+
+        if ($submissible->is_wizard) {
+            $submissible->loadMissing('steps');
+
+            $steps = $submissible->steps
+                ->sortBy('sort')
+                ->map(function ($step) use ($submission, $fieldResponses) {
+                    $stepFieldIds = $step->fields()->pluck('id')->all();
+
+                    $submittedFields = $submission->fields
+                        ->filter(fn(SubmissibleField $field) => in_array($field->getKey(), $stepFieldIds));
+
+                    return [
+                        'label' => $step->label,
+                        'fields' => $fieldResponses($submittedFields),
+                    ];
+                })
+                ->values()
+                ->all();
+
+            return [
+                'id' => $submission->getKey(),
+                'submitted_at' => $submittedAt?->toIso8601String(),
+                'author_email' => $authorEmail,
+                'is_wizard' => true,
+                'steps' => $steps,
+            ];
+        }
+
+        return [
+            'id' => $submission->getKey(),
+            'submitted_at' => $submittedAt?->toIso8601String(),
+            'author_email' => $authorEmail,
+            'is_wizard' => false,
+            'fields' => $fieldResponses($submission->fields),
+        ];
+    }
+}

--- a/app-modules/form/src/Actions/GenerateSubmissionViewData.php
+++ b/app-modules/form/src/Actions/GenerateSubmissionViewData.php
@@ -114,7 +114,7 @@ class GenerateSubmissionViewData
             if ($name && isset($responses[$name])) {
                 $value = $responses[$name];
 
-                $node['value'] = is_array($value) ? ($value[0] ?? '') : $value;
+                $node['value'] = $value;
             }
         }
 

--- a/app-modules/form/src/Actions/GenerateSubmissionViewData.php
+++ b/app-modules/form/src/Actions/GenerateSubmissionViewData.php
@@ -38,7 +38,6 @@ namespace AdvisingApp\Form\Actions;
 
 use AdvisingApp\Form\Models\Submissible;
 use AdvisingApp\Form\Models\SubmissibleField;
-use AdvisingApp\Form\Models\SubmissibleStep;
 use AdvisingApp\Form\Models\Submission;
 
 class GenerateSubmissionViewData
@@ -46,61 +45,93 @@ class GenerateSubmissionViewData
     /**
      * @return array<string, mixed>
      */
-    public function __invoke(Submission $submission): array
+    public function __invoke(Submission $submission, GenerateFormKitSchema $generateSchema): array
     {
         /** @var Submissible $submissible */
         $submissible = $submission->submissible;
         $submission->loadMissing('fields');
 
-        $authorEmail = $submission->author?->primaryEmailAddress?->address;
+        $author = $submission->author;
 
         // @phpstan-ignore-next-line property.notFound
         $submittedAt = $submission->submitted_at ?? $submission->created_at;
 
-        $fieldResponses = fn (iterable $fields): array => collect($fields)
-            ->map(fn (SubmissibleField $field) => [
-                'label' => $field->label,
-                'type' => $field->type,
-                // @phpstan-ignore-next-line property.notFound
-                'response' => $field->pivot?->response,
-            ])
-            ->values()
-            ->all();
+        $responses = $this->buildResponseMap($submission);
 
-        if ($submissible->is_wizard) {
-            $submissible->loadMissing('steps');
-
-            $steps = $submissible->steps
-                ->sortBy('sort')
-                ->map(function (SubmissibleStep $step) use ($submission, $fieldResponses) {
-                    $stepFieldIds = $step->fields()->pluck('id')->all();
-
-                    $submittedFields = $submission->fields
-                        ->filter(fn (SubmissibleField $field) => in_array($field->getKey(), $stepFieldIds));
-
-                    return [
-                        'label' => $step->label,
-                        'fields' => $fieldResponses($submittedFields),
-                    ];
-                })
-                ->values()
-                ->all();
-
-            return [
-                'id' => $submission->getKey(),
-                'submitted_at' => $submittedAt?->toIso8601String(),
-                'author_email' => $authorEmail,
-                'is_wizard' => true,
-                'steps' => $steps,
-            ];
-        }
+        $schema = $generateSchema->withAuthor($author)($submissible);
+        $schema = $this->disableSchema($schema, $responses);
 
         return [
             'id' => $submission->getKey(),
             'submitted_at' => $submittedAt?->toIso8601String(),
-            'author_email' => $authorEmail,
-            'is_wizard' => false,
-            'fields' => $fieldResponses($submission->fields),
+            'schema' => $schema,
         ];
+    }
+
+    /**
+     * Build a map of field ID => response value from the submission.
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildResponseMap(Submission $submission): array
+    {
+        $map = [];
+
+        foreach ($submission->fields as $field) {
+            /** @var SubmissibleField $field */
+            // @phpstan-ignore-next-line property.notFound
+            $response = $field->pivot?->response;
+
+            $map[$field->getKey()] = $response;
+        }
+
+        return $map;
+    }
+
+    /**
+     * Recursively walk the FormKit schema tree, disabling all fields
+     * and injecting submission response values.
+     *
+     * @param array<string, mixed> $node
+     * @param array<string, mixed> $responses
+     *
+     * @return array<string, mixed>
+     */
+    protected function disableSchema(array $node, array $responses): array
+    {
+        if (isset($node['$formkit'])) {
+            $type = $node['$formkit'];
+
+            if ($type === 'submit') {
+                return [];
+            }
+
+            $node['disabled'] = true;
+            unset($node['validation']);
+
+            $name = $node['name'] ?? null;
+
+            if ($name && isset($responses[$name])) {
+                $value = $responses[$name];
+
+                $node['value'] = is_array($value) ? ($value[0] ?? '') : $value;
+            }
+        }
+
+        if (isset($node['children']) && is_array($node['children'])) {
+            $node['children'] = array_values(array_filter(
+                array_map(fn(array|string $child): array|string => is_array($child) ? $this->disableSchema($child, $responses) : $child, $node['children']),
+                fn(array|string $child): bool => $child !== [],
+            ));
+        }
+
+        if (isset($node['props']['children']) && is_array($node['props']['children'])) {
+            $node['props']['children'] = array_values(array_filter(
+                array_map(fn(array|string $child): array|string => is_array($child) ? $this->disableSchema($child, $responses) : $child, $node['props']['children']),
+                fn(array|string $child): bool => $child !== [],
+            ));
+        }
+
+        return $node;
     }
 }

--- a/app-modules/form/src/Actions/GenerateSubmissionViewData.php
+++ b/app-modules/form/src/Actions/GenerateSubmissionViewData.php
@@ -120,15 +120,15 @@ class GenerateSubmissionViewData
 
         if (isset($node['children']) && is_array($node['children'])) {
             $node['children'] = array_values(array_filter(
-                array_map(fn(array|string $child): array|string => is_array($child) ? $this->disableSchema($child, $responses) : $child, $node['children']),
-                fn(array|string $child): bool => $child !== [],
+                array_map(fn (array|string $child): array|string => is_array($child) ? $this->disableSchema($child, $responses) : $child, $node['children']),
+                fn (array|string $child): bool => $child !== [],
             ));
         }
 
         if (isset($node['props']['children']) && is_array($node['props']['children'])) {
             $node['props']['children'] = array_values(array_filter(
-                array_map(fn(array|string $child): array|string => is_array($child) ? $this->disableSchema($child, $responses) : $child, $node['props']['children']),
-                fn(array|string $child): bool => $child !== [],
+                array_map(fn (array|string $child): array|string => is_array($child) ? $this->disableSchema($child, $responses) : $child, $node['props']['children']),
+                fn (array|string $child): bool => $child !== [],
             ));
         }
 

--- a/app-modules/form/src/Actions/GenerateSubmissionViewData.php
+++ b/app-modules/form/src/Actions/GenerateSubmissionViewData.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of
@@ -36,8 +36,8 @@
 
 namespace AdvisingApp\Form\Actions;
 
-use AdvisingApp\Form\Models\Submission;
 use AdvisingApp\Form\Models\SubmissibleField;
+use AdvisingApp\Form\Models\Submission;
 
 class GenerateSubmissionViewData
 {
@@ -50,8 +50,8 @@ class GenerateSubmissionViewData
 
         $submittedAt = $submission->submitted_at ?? $submission->created_at;
 
-        $fieldResponses = fn(iterable $fields): array => collect($fields)
-            ->map(fn(SubmissibleField $field) => [
+        $fieldResponses = fn (iterable $fields): array => collect($fields)
+            ->map(fn (SubmissibleField $field) => [
                 'label' => $field->label,
                 'type' => $field->type,
                 'response' => $field->pivot?->response,
@@ -68,7 +68,7 @@ class GenerateSubmissionViewData
                     $stepFieldIds = $step->fields()->pluck('id')->all();
 
                     $submittedFields = $submission->fields
-                        ->filter(fn(SubmissibleField $field) => in_array($field->getKey(), $stepFieldIds));
+                        ->filter(fn (SubmissibleField $field) => in_array($field->getKey(), $stepFieldIds));
 
                     return [
                         'label' => $step->label,

--- a/app-modules/form/src/Actions/GenerateSubmissionViewData.php
+++ b/app-modules/form/src/Actions/GenerateSubmissionViewData.php
@@ -36,24 +36,32 @@
 
 namespace AdvisingApp\Form\Actions;
 
+use AdvisingApp\Form\Models\Submissible;
 use AdvisingApp\Form\Models\SubmissibleField;
+use AdvisingApp\Form\Models\SubmissibleStep;
 use AdvisingApp\Form\Models\Submission;
 
 class GenerateSubmissionViewData
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function __invoke(Submission $submission): array
     {
+        /** @var Submissible $submissible */
         $submissible = $submission->submissible;
         $submission->loadMissing('fields');
 
         $authorEmail = $submission->author?->primaryEmailAddress?->address;
 
+        // @phpstan-ignore-next-line property.notFound
         $submittedAt = $submission->submitted_at ?? $submission->created_at;
 
-        $fieldResponses = fn (iterable $fields): array => collect($fields)
-            ->map(fn (SubmissibleField $field) => [
+        $fieldResponses = fn(iterable $fields): array => collect($fields)
+            ->map(fn(SubmissibleField $field) => [
                 'label' => $field->label,
                 'type' => $field->type,
+                // @phpstan-ignore-next-line property.notFound
                 'response' => $field->pivot?->response,
             ])
             ->values()
@@ -64,11 +72,11 @@ class GenerateSubmissionViewData
 
             $steps = $submissible->steps
                 ->sortBy('sort')
-                ->map(function ($step) use ($submission, $fieldResponses) {
+                ->map(function (SubmissibleStep $step) use ($submission, $fieldResponses) {
                     $stepFieldIds = $step->fields()->pluck('id')->all();
 
                     $submittedFields = $submission->fields
-                        ->filter(fn (SubmissibleField $field) => in_array($field->getKey(), $stepFieldIds));
+                        ->filter(fn(SubmissibleField $field) => in_array($field->getKey(), $stepFieldIds));
 
                     return [
                         'label' => $step->label,

--- a/app-modules/form/src/Filament/Blocks/EducatableNameFormFieldBlock.php
+++ b/app-modules/form/src/Filament/Blocks/EducatableNameFormFieldBlock.php
@@ -156,7 +156,7 @@ class EducatableNameFormFieldBlock extends FormFieldBlock
                     '$formkit' => 'text',
                     'name' => 'preferred',
                     'label' => $preferredNameLabel,
-                    'value' => $author->preferred ?? '',
+                    'value' => $author !== null ? ($author->preferred ?? '') : '',
                     ...($disabled ? ['disabled' => true] : []),
                     ...($preferredNameRequired ? ['validation' => 'required'] : []),
                 ],

--- a/app-modules/form/src/Filament/Blocks/Legacy/EducatableNameFormFieldBlock.php
+++ b/app-modules/form/src/Filament/Blocks/Legacy/EducatableNameFormFieldBlock.php
@@ -159,7 +159,7 @@ class EducatableNameFormFieldBlock extends FormFieldBlock
                     '$formkit' => 'text',
                     'name' => 'preferred',
                     'label' => $preferredNameLabel,
-                    'value' => $author->preferred ?? '',
+                    'value' => $author !== null ? ($author->preferred ?? '') : '',
                     ...($disabled ? ['disabled' => true] : []),
                     ...($preferredNameRequired ? ['validation' => 'required'] : []),
                 ],

--- a/app-modules/form/src/Filament/Resources/Forms/Pages/Concerns/HasSharedFormConfiguration.php
+++ b/app-modules/form/src/Filament/Resources/Forms/Pages/Concerns/HasSharedFormConfiguration.php
@@ -111,7 +111,7 @@ trait HasSharedFormConfiguration
             Toggle::make('allow_view_past_submissions')
                 ->label('Allow viewing past submissions')
                 ->helperText('If enabled, students and prospects can view their past submissions on this form.')
-                ->visible(fn(Get $get) => PastSubmissionsFeature::active() && $get('is_authenticated')),
+                ->visible(fn (Get $get) => PastSubmissionsFeature::active() && $get('is_authenticated')),
             Toggle::make('generate_prospects')
                 ->label('Generate Prospects')
                 ->helperText('If enabled, the system will check the primary email address submitted on the form and create a prospect if no match is found.')

--- a/app-modules/form/src/Filament/Resources/Forms/Pages/Concerns/HasSharedFormConfiguration.php
+++ b/app-modules/form/src/Filament/Resources/Forms/Pages/Concerns/HasSharedFormConfiguration.php
@@ -45,6 +45,7 @@ use AdvisingApp\Form\Rules\IsDomain;
 use AdvisingApp\IntegrationGoogleRecaptcha\Settings\GoogleRecaptchaSettings;
 use App\Enums\FontWeight;
 use App\Features\FormVersioningFeature;
+use App\Features\PastSubmissionsFeature;
 use CanyonGBS\Common\Filament\Forms\Components\ColorSelect;
 use Closure;
 use Filament\Forms\Components\Repeater;
@@ -107,6 +108,10 @@ trait HasSharedFormConfiguration
                 ->default((bool) request()->query('is_authenticated'))
                 ->disabled()
                 ->dehydrated(),
+            Toggle::make('allow_view_past_submissions')
+                ->label('Allow viewing past submissions')
+                ->helperText('If enabled, students and prospects can view their past submissions on this form.')
+                ->visible(fn(Get $get) => PastSubmissionsFeature::active() && $get('is_authenticated')),
             Toggle::make('generate_prospects')
                 ->label('Generate Prospects')
                 ->helperText('If enabled, the system will check the primary email address submitted on the form and create a prospect if no match is found.')

--- a/app-modules/form/src/Filament/Resources/Forms/Pages/ListForms.php
+++ b/app-modules/form/src/Filament/Resources/Forms/Pages/ListForms.php
@@ -40,6 +40,8 @@ use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Form\Actions\DuplicateForm;
 use AdvisingApp\Form\Filament\Resources\Forms\FormResource;
 use AdvisingApp\Form\Models\Form;
+use AdvisingApp\Form\Models\FormSubmission;
+use App\Features\FormVersioningFeature;
 use App\Filament\Tables\Columns\IdColumn;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
@@ -53,6 +55,7 @@ use Filament\Resources\Pages\ListRecords;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 class ListForms extends ListRecords
@@ -64,13 +67,26 @@ class ListForms extends ListRecords
     public function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(function (Builder $query) {
+                $submissionsCountQuery = FormVersioningFeature::active()
+                    ? FormSubmission::query()
+                        ->join('forms as version_forms', 'form_submissions.form_id', '=', 'version_forms.id')
+                        ->whereColumn('version_forms.root_id', 'forms.root_id')
+                        ->selectRaw('count(*)')
+                    : FormSubmission::query()
+                        ->whereColumn('form_id', 'forms.id')
+                        ->selectRaw('count(*)');
+
+                $query->addSelect([
+                    'submissions_count' => $submissionsCountQuery,
+                ]);
+            })
             ->columns([
                 IdColumn::make(),
                 TextColumn::make('name')
                     ->description(fn (Form $record) => $record->title),
                 TextColumn::make('submissions_count')
                     ->label('Submissions')
-                    ->counts('submissions')
                     ->default(0),
             ])
             ->recordActions([

--- a/app-modules/form/src/Filament/Resources/Forms/Pages/ViewForm.php
+++ b/app-modules/form/src/Filament/Resources/Forms/Pages/ViewForm.php
@@ -80,7 +80,7 @@ class ViewForm extends ViewRecord
                             ->label('Embed Enabled')
                             ->boolean(),
                         TextEntry::make('allowed_domains')
-                            ->visible(fn(Form $record) => $record->embed_enabled)
+                            ->visible(fn (Form $record) => $record->embed_enabled)
                             ->badge(),
                         IconEntry::make('is_authenticated')
                             ->label('Is Authenticated')
@@ -111,7 +111,7 @@ class ViewForm extends ViewRecord
                             ->columnSpanFull()
                             ->extraInputAttributes(['style' => 'min-height: 12rem;']),
                     ])
-                    ->hidden(fn(Form $record) => $record->is_wizard)
+                    ->hidden(fn (Form $record) => $record->is_wizard)
                     ->disabled(),
                 Repeater::make('steps')
                     ->schema([
@@ -133,8 +133,8 @@ class ViewForm extends ViewRecord
                             ->extraInputAttributes(['style' => 'min-height: 12rem;']),
                     ])
                     ->addActionLabel('New step')
-                    ->itemLabel(fn(array $state): ?string => $state['label'] ?? null)
-                    ->visible(fn(Form $record) => $record->is_wizard)
+                    ->itemLabel(fn (array $state): ?string => $state['label'] ?? null)
+                    ->visible(fn (Form $record) => $record->is_wizard)
                     ->disabled()
                     ->relationship()
                     ->orderColumn('sort')
@@ -143,9 +143,9 @@ class ViewForm extends ViewRecord
                     ->schema([
                         TextEntry::make('title_font_weight'),
                         ColorEntry::make('title_color')
-                            ->state(fn(Form $record): ?string => $record->title_color ? Color::convertToRgb(Color::all()[$record->title_color][600]) : null),
+                            ->state(fn (Form $record): ?string => $record->title_color ? Color::convertToRgb(Color::all()[$record->title_color][600]) : null),
                         ColorEntry::make('primary_color')
-                            ->state(fn(Form $record): ?string => $record->primary_color ? Color::convertToRgb(Color::all()[$record->primary_color][600]) : null),
+                            ->state(fn (Form $record): ?string => $record->primary_color ? Color::convertToRgb(Color::all()[$record->primary_color][600]) : null),
                         TextEntry::make('rounding'),
                     ])
                     ->columns(),
@@ -158,10 +158,10 @@ class ViewForm extends ViewRecord
             Action::make('preview')
                 ->label('Preview')
                 ->icon('heroicon-o-eye')
-                ->url(fn(Form $form) => route('forms.preview', $form))
+                ->url(fn (Form $form) => route('forms.preview', $form))
                 ->openUrlInNewTab(),
             Action::make('view')
-                ->url(fn(Form $form) => route('forms.show', ['form' => $form]))
+                ->url(fn (Form $form) => route('forms.show', ['form' => $form]))
                 ->icon('heroicon-m-arrow-top-right-on-square')
                 ->openUrlInNewTab(),
             Action::make('embed_snippet')
@@ -182,7 +182,7 @@ class ViewForm extends ViewRecord
                                 return str($state)->markdown()->toHtmlString();
                             })
                             ->copyable()
-                            ->copyableState(fn(Form $form) => resolve(GenerateSubmissibleEmbedCode::class)->handle($form))
+                            ->copyableState(fn (Form $form) => resolve(GenerateSubmissibleEmbedCode::class)->handle($form))
                             ->copyMessage('Copied!')
                             ->copyMessageDuration(1500)
                             ->extraAttributes(['class' => 'embed-code-snippet']),
@@ -190,7 +190,7 @@ class ViewForm extends ViewRecord
                 )
                 ->modalSubmitAction(false)
                 ->modalCancelActionLabel('Close')
-                ->hidden(fn(Form $form) => ! $form->embed_enabled),
+                ->hidden(fn (Form $form) => ! $form->embed_enabled),
             DeleteAction::make(),
         ];
     }

--- a/app-modules/form/src/Filament/Resources/Forms/Pages/ViewForm.php
+++ b/app-modules/form/src/Filament/Resources/Forms/Pages/ViewForm.php
@@ -40,6 +40,7 @@ use AdvisingApp\Form\Actions\GenerateSubmissibleEmbedCode;
 use AdvisingApp\Form\Filament\Blocks\FormFieldBlockRegistry;
 use AdvisingApp\Form\Filament\Resources\Forms\FormResource;
 use AdvisingApp\Form\Models\Form;
+use App\Features\PastSubmissionsFeature;
 use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\Repeater;
@@ -79,10 +80,14 @@ class ViewForm extends ViewRecord
                             ->label('Embed Enabled')
                             ->boolean(),
                         TextEntry::make('allowed_domains')
-                            ->visible(fn (Form $record) => $record->embed_enabled)
+                            ->visible(fn(Form $record) => $record->embed_enabled)
                             ->badge(),
                         IconEntry::make('is_authenticated')
                             ->label('Is Authenticated')
+                            ->boolean(),
+                        IconEntry::make('allow_view_past_submissions')
+                            ->label('Allow View Past Submissions')
+                            ->visible(fn (): bool => PastSubmissionsFeature::active())
                             ->boolean(),
                         IconEntry::make('generate_prospects')
                             ->label('Generate Prospects')
@@ -106,7 +111,7 @@ class ViewForm extends ViewRecord
                             ->columnSpanFull()
                             ->extraInputAttributes(['style' => 'min-height: 12rem;']),
                     ])
-                    ->hidden(fn (Form $record) => $record->is_wizard)
+                    ->hidden(fn(Form $record) => $record->is_wizard)
                     ->disabled(),
                 Repeater::make('steps')
                     ->schema([
@@ -128,8 +133,8 @@ class ViewForm extends ViewRecord
                             ->extraInputAttributes(['style' => 'min-height: 12rem;']),
                     ])
                     ->addActionLabel('New step')
-                    ->itemLabel(fn (array $state): ?string => $state['label'] ?? null)
-                    ->visible(fn (Form $record) => $record->is_wizard)
+                    ->itemLabel(fn(array $state): ?string => $state['label'] ?? null)
+                    ->visible(fn(Form $record) => $record->is_wizard)
                     ->disabled()
                     ->relationship()
                     ->orderColumn('sort')
@@ -138,9 +143,9 @@ class ViewForm extends ViewRecord
                     ->schema([
                         TextEntry::make('title_font_weight'),
                         ColorEntry::make('title_color')
-                            ->state(fn (Form $record): ?string => $record->title_color ? Color::convertToRgb(Color::all()[$record->title_color][600]) : null),
+                            ->state(fn(Form $record): ?string => $record->title_color ? Color::convertToRgb(Color::all()[$record->title_color][600]) : null),
                         ColorEntry::make('primary_color')
-                            ->state(fn (Form $record): ?string => $record->primary_color ? Color::convertToRgb(Color::all()[$record->primary_color][600]) : null),
+                            ->state(fn(Form $record): ?string => $record->primary_color ? Color::convertToRgb(Color::all()[$record->primary_color][600]) : null),
                         TextEntry::make('rounding'),
                     ])
                     ->columns(),
@@ -153,10 +158,10 @@ class ViewForm extends ViewRecord
             Action::make('preview')
                 ->label('Preview')
                 ->icon('heroicon-o-eye')
-                ->url(fn (Form $form) => route('forms.preview', $form))
+                ->url(fn(Form $form) => route('forms.preview', $form))
                 ->openUrlInNewTab(),
             Action::make('view')
-                ->url(fn (Form $form) => route('forms.show', ['form' => $form]))
+                ->url(fn(Form $form) => route('forms.show', ['form' => $form]))
                 ->icon('heroicon-m-arrow-top-right-on-square')
                 ->openUrlInNewTab(),
             Action::make('embed_snippet')
@@ -177,7 +182,7 @@ class ViewForm extends ViewRecord
                                 return str($state)->markdown()->toHtmlString();
                             })
                             ->copyable()
-                            ->copyableState(fn (Form $form) => resolve(GenerateSubmissibleEmbedCode::class)->handle($form))
+                            ->copyableState(fn(Form $form) => resolve(GenerateSubmissibleEmbedCode::class)->handle($form))
                             ->copyMessage('Copied!')
                             ->copyMessageDuration(1500)
                             ->extraAttributes(['class' => 'embed-code-snippet']),
@@ -185,7 +190,7 @@ class ViewForm extends ViewRecord
                 )
                 ->modalSubmitAction(false)
                 ->modalCancelActionLabel('Close')
-                ->hidden(fn (Form $form) => ! $form->embed_enabled),
+                ->hidden(fn(Form $form) => ! $form->embed_enabled),
             DeleteAction::make(),
         ];
     }

--- a/app-modules/form/src/Http/Controllers/FormWidgetController.php
+++ b/app-modules/form/src/Http/Controllers/FormWidgetController.php
@@ -147,14 +147,14 @@ class FormWidgetController extends Controller
             'schema' => $form->is_authenticated ? [] : $generateSchema($form),
             'primary_color' => collect(Color::all()[$form->primary_color ?? 'blue'])
                 ->map(Color::convertToRgb(...))
-                ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                 ->all(),
             'rounding' => $form->rounding,
             'on_screen_response' => $form->on_screen_response,
             'title_font_weight' => $form->title_font_weight,
             'title_color' => collect(Color::all()[$form->title_color ?? 'neutral'])
                 ->map(Color::convertToRgb(...))
-                ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                 ->all(),
         ]);
     }
@@ -170,14 +170,14 @@ class FormWidgetController extends Controller
                 'schema' => $generateSchema($form),
                 'primary_color' => collect(Color::all()[$form->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $form->rounding,
                 'on_screen_response' => $form->on_screen_response,
                 'title_font_weight' => $form->title_font_weight,
                 'title_color' => collect(Color::all()[$form->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ]
         );
@@ -507,7 +507,7 @@ class FormWidgetController extends Controller
             ->orderByDesc('submitted_at')
             ->paginate($request->query('per_page', 10));
 
-        $items = $pastSubmissions->map(fn(FormSubmission $submission) => [
+        $items = $pastSubmissions->map(fn (FormSubmission $submission) => [
             'id' => $submission->getKey(),
             'submitted_at' => $submission->submitted_at->toIso8601String(),
             'view_url' => URL::signedRoute(

--- a/app-modules/form/src/Http/Controllers/FormWidgetController.php
+++ b/app-modules/form/src/Http/Controllers/FormWidgetController.php
@@ -38,8 +38,8 @@ namespace AdvisingApp\Form\Http\Controllers;
 
 use AdvisingApp\Form\Actions\CreateProspectFromSubmission;
 use AdvisingApp\Form\Actions\GenerateFormKitSchema;
-use AdvisingApp\Form\Actions\GenerateSubmissionViewData;
 use AdvisingApp\Form\Actions\GenerateSubmissibleValidator;
+use AdvisingApp\Form\Actions\GenerateSubmissionViewData;
 use AdvisingApp\Form\Actions\ProcessSubmissionField;
 use AdvisingApp\Form\Actions\ResolveSubmissionAuthorFromEmail;
 use AdvisingApp\Form\Http\Requests\RegisterProspectRequest;
@@ -147,14 +147,14 @@ class FormWidgetController extends Controller
             'schema' => $form->is_authenticated ? [] : $generateSchema($form),
             'primary_color' => collect(Color::all()[$form->primary_color ?? 'blue'])
                 ->map(Color::convertToRgb(...))
-                ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                 ->all(),
             'rounding' => $form->rounding,
             'on_screen_response' => $form->on_screen_response,
             'title_font_weight' => $form->title_font_weight,
             'title_color' => collect(Color::all()[$form->title_color ?? 'neutral'])
                 ->map(Color::convertToRgb(...))
-                ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                 ->all(),
         ]);
     }
@@ -170,14 +170,14 @@ class FormWidgetController extends Controller
                 'schema' => $generateSchema($form),
                 'primary_color' => collect(Color::all()[$form->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $form->rounding,
                 'on_screen_response' => $form->on_screen_response,
                 'title_font_weight' => $form->title_font_weight,
                 'title_color' => collect(Color::all()[$form->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ]
         );
@@ -478,10 +478,9 @@ class FormWidgetController extends Controller
         Request $request,
         Form $form,
     ): JsonResponse {
-
-    if( ! PastSubmissionsFeature::active()) {
-        abort(Response::HTTP_FORBIDDEN);
-    }
+        if (! PastSubmissionsFeature::active()) {
+            abort(Response::HTTP_FORBIDDEN);
+        }
         $authentication = $request->query('authentication');
 
         if (filled($authentication)) {
@@ -508,7 +507,7 @@ class FormWidgetController extends Controller
             ->orderByDesc('submitted_at')
             ->paginate($request->query('per_page', 10));
 
-        $items = $pastSubmissions->map(fn(FormSubmission $submission) => [
+        $items = $pastSubmissions->map(fn (FormSubmission $submission) => [
             'id' => $submission->getKey(),
             'submitted_at' => $submission->submitted_at->toIso8601String(),
             'view_url' => URL::signedRoute(
@@ -537,7 +536,6 @@ class FormWidgetController extends Controller
         Form $form,
         FormSubmission $submission,
     ): JsonResponse {
-
         if (! PastSubmissionsFeature::active()) {
             abort(Response::HTTP_FORBIDDEN);
         }

--- a/app-modules/form/src/Http/Controllers/FormWidgetController.php
+++ b/app-modules/form/src/Http/Controllers/FormWidgetController.php
@@ -257,7 +257,15 @@ class FormWidgetController extends Controller
         $pastSubmissionsUrl = null;
 
         if (PastSubmissionsFeature::active() && $form->allow_view_past_submissions && $author) {
-            $pastSubmissionsCount = $form->submissions()
+            $pastSubmissionsCount = FormSubmission::query()
+                ->when(
+                    FormVersioningFeature::active(),
+                    fn ($query) => $query->whereHas(
+                        'submissible',
+                        fn ($query) => $query->withoutGlobalScopes()->where('root_id', $form->root_id),
+                    ),
+                    fn ($query) => $query->where('form_id', $form->getKey()),
+                )
                 ->submitted()
                 ->whereMorphedTo('author', $author)
                 ->count();
@@ -501,7 +509,15 @@ class FormWidgetController extends Controller
             ]);
         }
 
-        $pastSubmissions = $form->submissions()
+        $pastSubmissions = FormSubmission::query()
+            ->when(
+                FormVersioningFeature::active(),
+                fn ($query) => $query->whereHas(
+                    'submissible',
+                    fn ($query) => $query->withoutGlobalScopes()->where('root_id', $form->root_id),
+                ),
+                fn ($query) => $query->where('form_id', $form->getKey()),
+            )
             ->submitted()
             ->whereMorphedTo('author', $author)
             ->orderByDesc('submitted_at')
@@ -551,7 +567,12 @@ class FormWidgetController extends Controller
             abort(Response::HTTP_UNAUTHORIZED);
         }
 
-        abort_unless($submission->form_id === $form->getKey(), Response::HTTP_NOT_FOUND);
+        abort_unless(
+            FormVersioningFeature::active()
+                ? $submission->submissible()->withoutGlobalScopes()->value('root_id') === $form->root_id
+                : $submission->form_id === $form->getKey(),
+            Response::HTTP_NOT_FOUND,
+        );
 
         $author = $authentication->author;
 

--- a/app-modules/form/src/Http/Controllers/FormWidgetController.php
+++ b/app-modules/form/src/Http/Controllers/FormWidgetController.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Form\Http\Controllers;
 
 use AdvisingApp\Form\Actions\CreateProspectFromSubmission;
 use AdvisingApp\Form\Actions\GenerateFormKitSchema;
+use AdvisingApp\Form\Actions\GenerateSubmissionViewData;
 use AdvisingApp\Form\Actions\GenerateSubmissibleValidator;
 use AdvisingApp\Form\Actions\ProcessSubmissionField;
 use AdvisingApp\Form\Actions\ResolveSubmissionAuthorFromEmail;
@@ -54,6 +55,7 @@ use AdvisingApp\Prospect\Models\ProspectSource;
 use AdvisingApp\Prospect\Models\ProspectStatus;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Features\FormVersioningFeature;
+use App\Features\PastSubmissionsFeature;
 use App\Features\PhoneNumberLookupFeature;
 use App\Http\Controllers\Controller;
 use Closure;
@@ -126,6 +128,7 @@ class FormWidgetController extends Controller
             'name' => $form->title,
             'description' => $form->description,
             'is_authenticated' => $form->is_authenticated,
+            'allow_view_past_submissions' => $form->is_authenticated && $form->allow_view_past_submissions,
             ...($form->is_authenticated ? [
                 'authentication_url' => URL::signedRoute(
                     name: 'widgets.forms.api.request-authentication',
@@ -144,14 +147,14 @@ class FormWidgetController extends Controller
             'schema' => $form->is_authenticated ? [] : $generateSchema($form),
             'primary_color' => collect(Color::all()[$form->primary_color ?? 'blue'])
                 ->map(Color::convertToRgb(...))
-                ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                 ->all(),
             'rounding' => $form->rounding,
             'on_screen_response' => $form->on_screen_response,
             'title_font_weight' => $form->title_font_weight,
             'title_color' => collect(Color::all()[$form->title_color ?? 'neutral'])
                 ->map(Color::convertToRgb(...))
-                ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                 ->all(),
         ]);
     }
@@ -167,14 +170,14 @@ class FormWidgetController extends Controller
                 'schema' => $generateSchema($form),
                 'primary_color' => collect(Color::all()[$form->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $form->rounding,
                 'on_screen_response' => $form->on_screen_response,
                 'title_font_weight' => $form->title_font_weight,
                 'title_color' => collect(Color::all()[$form->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ]
         );
@@ -250,6 +253,26 @@ class FormWidgetController extends Controller
 
         assert($author instanceof Prospect || $author instanceof Student || $author === null);
 
+        $pastSubmissionsCount = 0;
+        $pastSubmissionsUrl = null;
+
+        if (PastSubmissionsFeature::active() && $form->allow_view_past_submissions && $author) {
+            $pastSubmissionsCount = $form->submissions()
+                ->submitted()
+                ->whereMorphedTo('author', $author)
+                ->count();
+
+            if ($pastSubmissionsCount > 0) {
+                $pastSubmissionsUrl = URL::signedRoute(
+                    name: 'widgets.forms.api.get-past-submissions',
+                    parameters: [
+                        'form' => $form,
+                        'authentication' => $authentication,
+                    ],
+                );
+            }
+        }
+
         return response()->json([
             'submission_url' => URL::signedRoute(
                 name: 'widgets.forms.api.submit',
@@ -259,6 +282,9 @@ class FormWidgetController extends Controller
                 ],
             ),
             'schema' => $generateSchema->withAuthor($author)($form),
+            'allow_view_past_submissions' => PastSubmissionsFeature::active() && $form->allow_view_past_submissions,
+            'past_submissions_count' => $pastSubmissionsCount,
+            'past_submissions_url' => $pastSubmissionsUrl,
         ]);
     }
 
@@ -446,6 +472,98 @@ class FormWidgetController extends Controller
                 ],
             ),
         ]);
+    }
+
+    public function getPastSubmissions(
+        Request $request,
+        Form $form,
+    ): JsonResponse {
+
+    if( ! PastSubmissionsFeature::active()) {
+        abort(Response::HTTP_FORBIDDEN);
+    }
+        $authentication = $request->query('authentication');
+
+        if (filled($authentication)) {
+            $authentication = FormAuthentication::findOrFail($authentication);
+        }
+
+        if (! $authentication || $authentication->isExpired()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        $author = $authentication->author;
+
+        assert($author instanceof Prospect || $author instanceof Student || $author === null);
+
+        if (! $form->allow_view_past_submissions || ! $author) {
+            return response()->json([
+                'past_submissions' => [],
+            ]);
+        }
+
+        $pastSubmissions = $form->submissions()
+            ->submitted()
+            ->whereMorphedTo('author', $author)
+            ->orderByDesc('submitted_at')
+            ->paginate($request->query('per_page', 10));
+
+        $items = $pastSubmissions->map(fn(FormSubmission $submission) => [
+            'id' => $submission->getKey(),
+            'submitted_at' => $submission->submitted_at->toIso8601String(),
+            'view_url' => URL::signedRoute(
+                name: 'widgets.forms.api.get-submission',
+                parameters: [
+                    'form' => $form,
+                    'submission' => $submission,
+                    'authentication' => $authentication,
+                ],
+            ),
+        ])->all();
+
+        return response()->json([
+            'past_submissions' => $items,
+            'meta' => [
+                'current_page' => $pastSubmissions->currentPage(),
+                'last_page' => $pastSubmissions->lastPage(),
+                'per_page' => $pastSubmissions->perPage(),
+                'total' => $pastSubmissions->total(),
+            ],
+        ]);
+    }
+
+    public function getSubmission(
+        GenerateSubmissionViewData $generateSubmissionViewData,
+        Form $form,
+        FormSubmission $submission,
+    ): JsonResponse {
+
+        if (! PastSubmissionsFeature::active()) {
+            abort(Response::HTTP_FORBIDDEN);
+        }
+        $authentication = request()->query('authentication');
+
+        if (filled($authentication)) {
+            $authentication = FormAuthentication::findOrFail($authentication);
+        }
+
+        if (! $authentication || $authentication->isExpired()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        abort_unless($submission->form_id === $form->getKey(), Response::HTTP_NOT_FOUND);
+
+        $author = $authentication->author;
+
+        abort_unless(
+            $submission->author_type === $author?->getMorphClass()
+                && $submission->author_id === $author?->getKey(),
+            Response::HTTP_FORBIDDEN,
+        );
+
+        return response()->json(
+            $generateSubmissionViewData($submission),
+        );
     }
 
     public function uploadFormFiles(Request $request): JsonResponse

--- a/app-modules/form/src/Http/Controllers/FormWidgetController.php
+++ b/app-modules/form/src/Http/Controllers/FormWidgetController.php
@@ -147,14 +147,14 @@ class FormWidgetController extends Controller
             'schema' => $form->is_authenticated ? [] : $generateSchema($form),
             'primary_color' => collect(Color::all()[$form->primary_color ?? 'blue'])
                 ->map(Color::convertToRgb(...))
-                ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                 ->all(),
             'rounding' => $form->rounding,
             'on_screen_response' => $form->on_screen_response,
             'title_font_weight' => $form->title_font_weight,
             'title_color' => collect(Color::all()[$form->title_color ?? 'neutral'])
                 ->map(Color::convertToRgb(...))
-                ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                 ->all(),
         ]);
     }
@@ -170,14 +170,14 @@ class FormWidgetController extends Controller
                 'schema' => $generateSchema($form),
                 'primary_color' => collect(Color::all()[$form->primary_color ?? 'blue'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
                 'rounding' => $form->rounding,
                 'on_screen_response' => $form->on_screen_response,
                 'title_font_weight' => $form->title_font_weight,
                 'title_color' => collect(Color::all()[$form->title_color ?? 'neutral'])
                     ->map(Color::convertToRgb(...))
-                    ->map(fn (string $value): string => (string) str($value)->after('rgb(')->before(')'))
+                    ->map(fn(string $value): string => (string) str($value)->after('rgb(')->before(')'))
                     ->all(),
             ]
         );
@@ -507,7 +507,7 @@ class FormWidgetController extends Controller
             ->orderByDesc('submitted_at')
             ->paginate($request->query('per_page', 10));
 
-        $items = $pastSubmissions->map(fn (FormSubmission $submission) => [
+        $items = $pastSubmissions->map(fn(FormSubmission $submission) => [
             'id' => $submission->getKey(),
             'submitted_at' => $submission->submitted_at->toIso8601String(),
             'view_url' => URL::signedRoute(
@@ -533,6 +533,7 @@ class FormWidgetController extends Controller
 
     public function getSubmission(
         GenerateSubmissionViewData $generateSubmissionViewData,
+        GenerateFormKitSchema $generateSchema,
         Form $form,
         FormSubmission $submission,
     ): JsonResponse {
@@ -560,7 +561,7 @@ class FormWidgetController extends Controller
         );
 
         return response()->json(
-            $generateSubmissionViewData($submission),
+            $generateSubmissionViewData($submission, $generateSchema),
         );
     }
 

--- a/app-modules/form/src/Http/Controllers/FormWidgetController.php
+++ b/app-modules/form/src/Http/Controllers/FormWidgetController.php
@@ -505,7 +505,7 @@ class FormWidgetController extends Controller
             ->submitted()
             ->whereMorphedTo('author', $author)
             ->orderByDesc('submitted_at')
-            ->paginate($request->query('per_page', 10));
+            ->paginate(min((int) $request->query('per_page', 10), 50));
 
         $items = $pastSubmissions->map(fn (FormSubmission $submission) => [
             'id' => $submission->getKey(),
@@ -532,6 +532,7 @@ class FormWidgetController extends Controller
     }
 
     public function getSubmission(
+        Request $request,
         GenerateSubmissionViewData $generateSubmissionViewData,
         GenerateFormKitSchema $generateSchema,
         Form $form,
@@ -540,7 +541,7 @@ class FormWidgetController extends Controller
         if (! PastSubmissionsFeature::active()) {
             abort(Response::HTTP_FORBIDDEN);
         }
-        $authentication = request()->query('authentication');
+        $authentication = $request->query('authentication');
 
         if (filled($authentication)) {
             $authentication = FormAuthentication::findOrFail($authentication);

--- a/app-modules/form/src/Http/Controllers/FormWidgetController.php
+++ b/app-modules/form/src/Http/Controllers/FormWidgetController.php
@@ -128,7 +128,7 @@ class FormWidgetController extends Controller
             'name' => $form->title,
             'description' => $form->description,
             'is_authenticated' => $form->is_authenticated,
-            'allow_view_past_submissions' => $form->is_authenticated && $form->allow_view_past_submissions,
+            'allow_view_past_submissions' => PastSubmissionsFeature::active() && $form->is_authenticated && $form->allow_view_past_submissions,
             ...($form->is_authenticated ? [
                 'authentication_url' => URL::signedRoute(
                     name: 'widgets.forms.api.request-authentication',

--- a/app-modules/form/src/Models/Form.php
+++ b/app-modules/form/src/Models/Form.php
@@ -82,6 +82,7 @@ class Form extends Submissible
         'notify_via_app',
         'notify_via_email',
         'root_id',
+        'allow_view_past_submissions'
     ];
 
     protected $casts = [
@@ -98,6 +99,7 @@ class Form extends Submissible
         'notify_to_subscribers' => 'boolean',
         'notify_via_app' => 'boolean',
         'notify_via_email' => 'boolean',
+        'allow_view_past_submissions' => 'boolean',
     ];
 
     /**

--- a/app-modules/form/src/Models/Form.php
+++ b/app-modules/form/src/Models/Form.php
@@ -82,7 +82,7 @@ class Form extends Submissible
         'notify_via_app',
         'notify_via_email',
         'root_id',
-        'allow_view_past_submissions'
+        'allow_view_past_submissions',
     ];
 
     protected $casts = [

--- a/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/ListFormsTest.php
+++ b/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/ListFormsTest.php
@@ -84,3 +84,62 @@ it('will not duplicate form submissions if they exist', function () {
 
     expect($duplicatedForm->submissions()->count())->toBe(0);
 });
+
+it('displays the correct submissions count for a form', function () {
+    asSuperAdmin();
+
+    $form = Form::factory()->create();
+
+    FormSubmission::factory()->count(5)->create([
+        'form_id' => $form->id,
+        'submitted_at' => now(),
+    ]);
+
+    livewire(ListForms::class)
+        ->assertTableColumnStateSet('submissions_count', 5, $form);
+});
+
+it('displays the correct submissions count across all versions', function () {
+    asSuperAdmin();
+
+    $form = Form::factory()->create();
+
+    FormSubmission::factory()->count(3)->create([
+        'form_id' => $form->id,
+        'submitted_at' => now(),
+    ]);
+
+    $archivedVersion = Form::factory()->create([
+        'root_id' => $form->root_id,
+        'archived_at' => now(),
+    ]);
+
+    FormSubmission::factory()->count(4)->create([
+        'form_id' => $archivedVersion->id,
+        'submitted_at' => now(),
+    ]);
+
+    livewire(ListForms::class)
+        ->assertTableColumnStateSet('submissions_count', 7, $form);
+});
+
+it('does not count submissions from unrelated forms in the submissions count', function () {
+    asSuperAdmin();
+
+    $form = Form::factory()->create();
+
+    FormSubmission::factory()->count(2)->create([
+        'form_id' => $form->id,
+        'submitted_at' => now(),
+    ]);
+
+    $unrelatedForm = Form::factory()->create();
+
+    FormSubmission::factory()->count(10)->create([
+        'form_id' => $unrelatedForm->id,
+        'submitted_at' => now(),
+    ]);
+
+    livewire(ListForms::class)
+        ->assertTableColumnStateSet('submissions_count', 2, $form);
+});

--- a/app-modules/form/tests/Tenant/FormPastSubmissionsApiTest.php
+++ b/app-modules/form/tests/Tenant/FormPastSubmissionsApiTest.php
@@ -99,7 +99,7 @@ test('authenticate returns past_submissions_count and url when toggle is on and 
 
     $prospect = Prospect::factory()->create();
 
-    $code = 123456;
+    $code = '123456';
 
     $authentication = new FormAuthentication();
     $authentication->author()->associate($prospect);
@@ -138,7 +138,7 @@ test('authenticate returns zero past_submissions_count when toggle is on but no 
 
     $prospect = Prospect::factory()->create();
 
-    $code = 123456;
+    $code = '123456';
 
     $authentication = new FormAuthentication();
     $authentication->author()->associate($prospect);
@@ -168,7 +168,7 @@ test('authenticate returns zero past_submissions_count when toggle is off', func
 
     $prospect = Prospect::factory()->create();
 
-    $code = 123456;
+    $code = '123456';
 
     $authentication = new FormAuthentication();
     $authentication->author()->associate($prospect);

--- a/app-modules/form/tests/Tenant/FormPastSubmissionsApiTest.php
+++ b/app-modules/form/tests/Tenant/FormPastSubmissionsApiTest.php
@@ -325,7 +325,7 @@ test('getPastSubmissions returns 401 with expired authentication', function () {
 
     // Expire the authentication
     FormAuthentication::withoutTimestamps(
-        fn () => FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn() => FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 
@@ -384,8 +384,7 @@ test('getSubmission returns submission detail data', function () {
 
     expect($response->json('id'))->toBe($submission->getKey());
     expect($response->json('submitted_at'))->not->toBeNull();
-    expect($response->json('is_wizard'))->toBeFalse();
-    expect($response->json('fields'))->toBeArray();
+    expect($response->json('schema'))->toBeArray();
 });
 
 test('getSubmission returns 401 with expired authentication', function () {
@@ -403,7 +402,7 @@ test('getSubmission returns 401 with expired authentication', function () {
     $authentication->save();
 
     FormAuthentication::withoutTimestamps(
-        fn () => FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn() => FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 

--- a/app-modules/form/tests/Tenant/FormPastSubmissionsApiTest.php
+++ b/app-modules/form/tests/Tenant/FormPastSubmissionsApiTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of
@@ -325,8 +325,7 @@ test('getPastSubmissions returns 401 with expired authentication', function () {
 
     // Expire the authentication
     FormAuthentication::withoutTimestamps(
-        fn() =>
-        FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn () => FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 
@@ -404,8 +403,7 @@ test('getSubmission returns 401 with expired authentication', function () {
     $authentication->save();
 
     FormAuthentication::withoutTimestamps(
-        fn() =>
-        FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn () => FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 

--- a/app-modules/form/tests/Tenant/FormPastSubmissionsApiTest.php
+++ b/app-modules/form/tests/Tenant/FormPastSubmissionsApiTest.php
@@ -325,7 +325,7 @@ test('getPastSubmissions returns 401 with expired authentication', function () {
 
     // Expire the authentication
     FormAuthentication::withoutTimestamps(
-        fn() => FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn () => FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 
@@ -402,7 +402,7 @@ test('getSubmission returns 401 with expired authentication', function () {
     $authentication->save();
 
     FormAuthentication::withoutTimestamps(
-        fn() => FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+        fn () => FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
     );
     $authentication->refresh();
 

--- a/app-modules/form/tests/Tenant/FormPastSubmissionsApiTest.php
+++ b/app-modules/form/tests/Tenant/FormPastSubmissionsApiTest.php
@@ -1,0 +1,491 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Form\Http\Middleware\EnsureSubmissibleIsEmbeddableAndAuthorized;
+use AdvisingApp\Form\Models\Form;
+use AdvisingApp\Form\Models\FormAuthentication;
+use AdvisingApp\Form\Models\FormSubmission;
+use AdvisingApp\Prospect\Models\Prospect;
+use App\Settings\LicenseSettings;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\URL;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\post;
+use function Pest\Laravel\withoutMiddleware;
+
+beforeEach(function () {
+    withoutMiddleware([EnsureSubmissibleIsEmbeddableAndAuthorized::class]);
+
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->onlineForms = true;
+    $settings->save();
+});
+
+test('view endpoint returns allow_view_past_submissions false when form is not authenticated', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => false,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $response = get(route('widgets.forms.api.entry', ['form' => $form]))
+        ->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeFalse();
+});
+
+test('view endpoint returns allow_view_past_submissions true when form is authenticated and toggle is on', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $response = get(route('widgets.forms.api.entry', ['form' => $form]))
+        ->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeTrue();
+});
+
+test('view endpoint returns allow_view_past_submissions false when form is authenticated but toggle is off', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => false,
+    ]);
+
+    $response = get(route('widgets.forms.api.entry', ['form' => $form]))
+        ->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeFalse();
+});
+
+test('authenticate returns past_submissions_count and url when toggle is on and submissions exist', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $code = 123456;
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make($code);
+    $authentication->save();
+
+    FormSubmission::factory()->count(3)->create([
+        'form_id' => $form->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    $response = post(URL::signedRoute(
+        name: 'widgets.forms.api.authenticate',
+        parameters: [
+            'form' => $form,
+            'authentication' => $authentication,
+            'code' => $code,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeTrue();
+    expect($response->json('past_submissions_count'))->toBe(3);
+    expect($response->json('past_submissions_url'))->not->toBeNull();
+    expect($response->json('schema'))->toBeArray();
+    expect($response->json('submission_url'))->not->toBeNull();
+});
+
+test('authenticate returns zero past_submissions_count when toggle is on but no submissions exist', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $code = 123456;
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make($code);
+    $authentication->save();
+
+    $response = post(URL::signedRoute(
+        name: 'widgets.forms.api.authenticate',
+        parameters: [
+            'form' => $form,
+            'authentication' => $authentication,
+            'code' => $code,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeTrue();
+    expect($response->json('past_submissions_count'))->toBe(0);
+    expect($response->json('past_submissions_url'))->toBeNull();
+});
+
+test('authenticate returns zero past_submissions_count when toggle is off', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => false,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $code = 123456;
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make($code);
+    $authentication->save();
+
+    FormSubmission::factory()->count(2)->create([
+        'form_id' => $form->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    $response = post(URL::signedRoute(
+        name: 'widgets.forms.api.authenticate',
+        parameters: [
+            'form' => $form,
+            'authentication' => $authentication,
+            'code' => $code,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('allow_view_past_submissions'))->toBeFalse();
+    expect($response->json('past_submissions_count'))->toBe(0);
+    expect($response->json('past_submissions_url'))->toBeNull();
+});
+
+test('getPastSubmissions returns paginated past submissions', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make('123456');
+    $authentication->save();
+
+    FormSubmission::factory()->count(3)->create([
+        'form_id' => $form->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    $response = get(URL::signedRoute(
+        name: 'widgets.forms.api.get-past-submissions',
+        parameters: [
+            'form' => $form,
+            'authentication' => $authentication,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('past_submissions'))->toHaveCount(3);
+    expect($response->json('meta.total'))->toBe(3);
+    expect($response->json('meta.current_page'))->toBe(1);
+
+    $firstSubmission = $response->json('past_submissions.0');
+    expect($firstSubmission)->toHaveKeys(['id', 'submitted_at', 'view_url']);
+});
+
+test('getPastSubmissions returns empty when toggle is off', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => false,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make('123456');
+    $authentication->save();
+
+    FormSubmission::factory()->create([
+        'form_id' => $form->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    $response = get(URL::signedRoute(
+        name: 'widgets.forms.api.get-past-submissions',
+        parameters: [
+            'form' => $form,
+            'authentication' => $authentication,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('past_submissions'))->toBeEmpty();
+});
+
+test('getPastSubmissions does not return submissions from other authors', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+    $otherProspect = Prospect::factory()->create();
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make('123456');
+    $authentication->save();
+
+    // Submissions from the authenticated author
+    FormSubmission::factory()->count(2)->create([
+        'form_id' => $form->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    // Submissions from a different author
+    FormSubmission::factory()->count(3)->create([
+        'form_id' => $form->id,
+        'author_type' => $otherProspect->getMorphClass(),
+        'author_id' => $otherProspect->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    $response = get(URL::signedRoute(
+        name: 'widgets.forms.api.get-past-submissions',
+        parameters: [
+            'form' => $form,
+            'authentication' => $authentication,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('past_submissions'))->toHaveCount(2);
+    expect($response->json('meta.total'))->toBe(2);
+});
+
+test('getPastSubmissions returns 401 with expired authentication', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make('123456');
+    $authentication->save();
+
+    // Expire the authentication
+    FormAuthentication::withoutTimestamps(
+        fn() =>
+        FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+    );
+    $authentication->refresh();
+
+    get(URL::signedRoute(
+        name: 'widgets.forms.api.get-past-submissions',
+        parameters: [
+            'form' => $form,
+            'authentication' => $authentication,
+        ],
+    ))->assertUnauthorized();
+});
+
+test('getPastSubmissions returns 401 without authentication parameter', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    get(URL::signedRoute(
+        name: 'widgets.forms.api.get-past-submissions',
+        parameters: [
+            'form' => $form,
+        ],
+    ))->assertUnauthorized();
+});
+
+test('getSubmission returns submission detail data', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make('123456');
+    $authentication->save();
+
+    $submission = FormSubmission::factory()->create([
+        'form_id' => $form->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    $response = get(URL::signedRoute(
+        name: 'widgets.forms.api.get-submission',
+        parameters: [
+            'form' => $form,
+            'submission' => $submission,
+            'authentication' => $authentication,
+        ],
+    ))->assertSuccessful();
+
+    expect($response->json('id'))->toBe($submission->getKey());
+    expect($response->json('submitted_at'))->not->toBeNull();
+    expect($response->json('is_wizard'))->toBeFalse();
+    expect($response->json('fields'))->toBeArray();
+});
+
+test('getSubmission returns 401 with expired authentication', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make('123456');
+    $authentication->save();
+
+    FormAuthentication::withoutTimestamps(
+        fn() =>
+        FormAuthentication::where('id', $authentication->id)->update(['created_at' => now()->subDays(2)])
+    );
+    $authentication->refresh();
+
+    $submission = FormSubmission::factory()->create([
+        'form_id' => $form->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    get(URL::signedRoute(
+        name: 'widgets.forms.api.get-submission',
+        parameters: [
+            'form' => $form,
+            'submission' => $submission,
+            'authentication' => $authentication,
+        ],
+    ))->assertUnauthorized();
+});
+
+test('getSubmission returns 403 when author does not match', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+
+    $prospect = Prospect::factory()->create();
+    $otherProspect = Prospect::factory()->create();
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make('123456');
+    $authentication->save();
+
+    $submission = FormSubmission::factory()->create([
+        'form_id' => $form->id,
+        'author_type' => $otherProspect->getMorphClass(),
+        'author_id' => $otherProspect->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    get(URL::signedRoute(
+        name: 'widgets.forms.api.get-submission',
+        parameters: [
+            'form' => $form,
+            'submission' => $submission,
+            'authentication' => $authentication,
+        ],
+    ))->assertForbidden();
+});
+
+test('getSubmission returns 404 when submission does not belong to form', function () {
+    $form = Form::factory()->create([
+        'is_authenticated' => true,
+        'allow_view_past_submissions' => true,
+    ]);
+    $otherForm = Form::factory()->create();
+
+    $prospect = Prospect::factory()->create();
+
+    $authentication = new FormAuthentication();
+    $authentication->author()->associate($prospect);
+    $authentication->submissible()->associate($form);
+    $authentication->code = Hash::make('123456');
+    $authentication->save();
+
+    $submission = FormSubmission::factory()->create([
+        'form_id' => $otherForm->id,
+        'author_type' => $prospect->getMorphClass(),
+        'author_id' => $prospect->getKey(),
+        'submitted_at' => now(),
+    ]);
+
+    get(URL::signedRoute(
+        name: 'widgets.forms.api.get-submission',
+        parameters: [
+            'form' => $form,
+            'submission' => $submission,
+            'authentication' => $authentication,
+        ],
+    ))->assertNotFound();
+});

--- a/app/Features/PastSubmissionsFeature.php
+++ b/app/Features/PastSubmissionsFeature.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/app/Features/PastSubmissionsFeature.php
+++ b/app/Features/PastSubmissionsFeature.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class PastSubmissionsFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/database/migrations/2026_06_15_165529_data_activate_past_submissions_feature.php
+++ b/database/migrations/2026_06_15_165529_data_activate_past_submissions_feature.php
@@ -1,12 +1,43 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\PastSubmissionsFeature;
 use Illuminate\Database\Migrations\Migration;
-use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
-use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         PastSubmissionsFeature::activate();

--- a/database/migrations/2026_06_15_165529_data_activate_past_submissions_feature.php
+++ b/database/migrations/2026_06_15_165529_data_activate_past_submissions_feature.php
@@ -1,0 +1,19 @@
+<?php
+
+use App\Features\PastSubmissionsFeature;
+use Illuminate\Database\Migrations\Migration;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        PastSubmissionsFeature::activate();
+    }
+
+    public function down(): void
+    {
+        PastSubmissionsFeature::deactivate();
+    }
+};

--- a/widgets/application/src/App.vue
+++ b/widgets/application/src/App.vue
@@ -32,6 +32,7 @@
 </COPYRIGHT>
 -->
 <script setup>
+    import { ArrowLeftIcon, ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/outline';
     import { defineProps, reactive, ref } from 'vue';
     import asteriskPlugin from '../../form/src/FormKit/asterisk.js';
     import wizard from '../../form/src/FormKit/wizard';
@@ -113,6 +114,18 @@
     const applicationTitleFontWeight = ref('');
     const schema = ref([]);
 
+    const allowViewPastSubmissions = ref(false);
+    const pastSubmissionsCount = ref(0);
+    const pastSubmissionsUrl = ref(null);
+
+    const currentView = ref('form');
+    const pastSubmissions = ref([]);
+    const pastSubmissionsMeta = ref(null);
+    const pastSubmissionsCurrentPage = ref(1);
+    const isLoadingSubmissions = ref(false);
+    const isLoadingSubmission = ref(false);
+    const currentSubmission = ref(null);
+
     const authentication = ref({
         code: null,
         email: null,
@@ -122,6 +135,63 @@
         url: null,
         registrationAllowed: false,
     });
+
+    function formatSubmissionDateTime(isoString) {
+        if (!isoString) return '';
+        return new Date(isoString).toLocaleString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+        });
+    }
+
+    async function loadPastSubmissions(page = 1) {
+        isLoadingSubmissions.value = true;
+        try {
+            const url = new URL(pastSubmissionsUrl.value);
+            url.searchParams.set('page', page);
+            url.searchParams.set('per_page', 10);
+            const response = await fetch(url.toString(), { headers: { Accept: 'application/json' } });
+            const json = await response.json();
+            pastSubmissions.value = json.past_submissions ?? [];
+            pastSubmissionsMeta.value = json.meta ?? null;
+            pastSubmissionsCurrentPage.value = page;
+            currentView.value = 'table';
+        } catch (e) {
+            console.error('Error loading past submissions', e);
+        } finally {
+            isLoadingSubmissions.value = false;
+        }
+    }
+
+    async function loadSubmission(viewUrl) {
+        isLoadingSubmission.value = true;
+        try {
+            const response = await fetch(viewUrl, { headers: { Accept: 'application/json' } });
+            const json = await response.json();
+            currentSubmission.value = json;
+            currentView.value = 'submission';
+        } catch (e) {
+            console.error('Error loading submission', e);
+        } finally {
+            isLoadingSubmission.value = false;
+        }
+    }
+
+    function startNewSubmission() {
+        currentView.value = 'form';
+    }
+
+    function backToTable() {
+        currentView.value = 'table';
+    }
+
+    function backToSplash() {
+        currentView.value = 'splash';
+    }
 
     fetch(props.entryUrl)
         .then((response) => response.json())
@@ -248,6 +318,14 @@
 
                     applicationSubmissionUrl.value = json.submission_url;
                     schema.value = json.schema;
+
+                    allowViewPastSubmissions.value = json.allow_view_past_submissions ?? false;
+                    pastSubmissionsCount.value = json.past_submissions_count ?? 0;
+                    pastSubmissionsUrl.value = json.past_submissions_url ?? null;
+
+                    if (allowViewPastSubmissions.value && pastSubmissionsCount.value > 0) {
+                        currentView.value = 'splash';
+                    }
                 })
                 .catch((error) => {
                     node.setErrors([error]);
@@ -378,6 +456,7 @@
             </div>
 
             <h1
+                v-if="applicationName"
                 :style="{
                     fontWeight: applicationTitleFontWeight,
                     color: `rgb(${applicationTitleColor[900]})`,
@@ -386,7 +465,7 @@
                 {{ applicationName }}
             </h1>
 
-            <p>
+            <p v-if="applicationDescription">
                 {{ applicationDescription }}
             </p>
 
@@ -525,11 +604,150 @@
             </div>
 
             <div v-if="applicationSubmissionUrl" class="space-y-6">
-                <p v-if="authentication.email" class="text-sm">
-                    Signed in as <strong>{{ authentication.email }}</strong>
-                </p>
+                <div v-if="currentView === 'splash'" class="py-4 not-prose">
+                    <p v-if="authentication.email" class="text-sm text-gray-500 mb-6">
+                        Signed in as <strong class="font-semibold text-gray-800">{{ authentication.email }}</strong>
+                    </p>
+                    <div class="flex flex-col items-center gap-5">
+                        <h2 class="text-base font-semibold text-gray-800">What would you like to do?</h2>
+                        <div class="flex flex-col sm:flex-row gap-3 w-full max-w-sm">
+                            <button
+                                @click="loadPastSubmissions(1)"
+                                :disabled="isLoadingSubmissions"
+                                class="flex-1 h-11 px-5 rounded-[--rounding] border-2 border-[rgb(var(--primary-600))] text-[rgb(var(--primary-600))] text-sm font-semibold whitespace-nowrap hover:bg-[rgb(var(--primary-50))] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                <span v-if="isLoadingSubmissions">Loading…</span>
+                                <span v-else>View Past Submissions</span>
+                            </button>
+                            <button
+                                @click="startNewSubmission"
+                                class="flex-1 h-11 px-5 rounded-[--rounding] bg-[rgb(var(--primary-600))] text-white text-sm font-semibold whitespace-nowrap hover:bg-[rgb(var(--primary-700))] transition-colors"
+                            >
+                                New Submission
+                            </button>
+                        </div>
+                    </div>
+                </div>
 
-                <FormKitSchema :schema="schema" :data="data" />
+                <!-- Past submissions table -->
+                <div v-else-if="currentView === 'table'" class="space-y-4 not-prose">
+                    <div class="flex items-center justify-between">
+                        <button
+                            @click="backToSplash"
+                            class="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--primary-600))] hover:text-[rgb(var(--primary-800))] cursor-pointer transition-colors"
+                        >
+                            <ArrowLeftIcon class="w-4 h-4" />
+                            Back
+                        </button>
+                        <p class="text-sm text-gray-500">
+                            Signed in as <strong class="font-semibold text-gray-700">{{ authentication.email }}</strong>
+                        </p>
+                    </div>
+                    <h2 class="text-base font-semibold text-gray-800">Past Submissions</h2>
+                    <div v-if="isLoadingSubmissions" class="py-8 text-center text-sm text-gray-500">
+                        Loading submissions…
+                    </div>
+                    <div v-else-if="pastSubmissions.length === 0" class="py-8 text-center text-sm text-gray-500">
+                        No past submissions found.
+                    </div>
+                    <div v-else class="overflow-hidden rounded-[--rounding] border border-gray-200 not-prose">
+                        <table class="w-full text-sm border-collapse">
+                            <thead>
+                                <tr class="bg-gray-50 border-b border-gray-200 text-left">
+                                    <th class="px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                                        Date Submitted
+                                    </th>
+                                    <th class="px-4 py-3 w-24"></th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-gray-200">
+                                <tr
+                                    v-for="submission in pastSubmissions"
+                                    :key="submission.id"
+                                    @click="!isLoadingSubmission && loadSubmission(submission.view_url)"
+                                    :class="[
+                                        'transition-colors',
+                                        isLoadingSubmission
+                                            ? 'opacity-60 cursor-not-allowed'
+                                            : 'cursor-pointer hover:bg-[rgb(var(--primary-50))]',
+                                    ]"
+                                >
+                                    <td class="px-4 py-3 text-gray-700">
+                                        {{ formatSubmissionDateTime(submission.submitted_at) }}
+                                    </td>
+                                    <td class="px-4 py-3 text-right">
+                                        <ChevronRightIcon class="w-4 h-4 text-gray-400 ml-auto" />
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- Pagination -->
+                        <div
+                            v-if="pastSubmissionsMeta && pastSubmissionsMeta.last_page > 1"
+                            class="flex items-center justify-between px-4 py-3 border-t border-gray-200 bg-gray-50"
+                        >
+                            <button
+                                @click="loadPastSubmissions(pastSubmissionsCurrentPage - 1)"
+                                :disabled="pastSubmissionsCurrentPage <= 1 || isLoadingSubmissions"
+                                class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-600 disabled:opacity-40 hover:bg-white transition-colors"
+                            >
+                                <ChevronLeftIcon class="w-3 h-3" />
+                                Previous
+                            </button>
+                            <span class="text-xs text-gray-500">
+                                Page {{ pastSubmissionsCurrentPage }} of {{ pastSubmissionsMeta.last_page }}
+                            </span>
+                            <button
+                                @click="loadPastSubmissions(pastSubmissionsCurrentPage + 1)"
+                                :disabled="
+                                    pastSubmissionsCurrentPage >= pastSubmissionsMeta.last_page || isLoadingSubmissions
+                                "
+                                class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-600 disabled:opacity-40 hover:bg-white transition-colors"
+                            >
+                                Next
+                                <ChevronRightIcon class="w-3 h-3" />
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Read-only submission detail -->
+                <div v-else-if="currentView === 'submission'" class="space-y-4 not-prose">
+                    <button
+                        @click="backToTable"
+                        class="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--primary-600))] hover:text-[rgb(var(--primary-800))] cursor-pointer transition-colors"
+                    >
+                        <ArrowLeftIcon class="w-4 h-4" />
+                        Back to Submissions
+                    </button>
+                    <div v-if="isLoadingSubmission" class="py-8 text-center text-sm text-gray-500">Loading…</div>
+                    <div v-else-if="currentSubmission" class="space-y-4">
+                        <div
+                            class="rounded-[--rounding] bg-[rgb(var(--primary-50))] border border-[rgb(var(--primary-200))] px-4 py-3 text-sm text-[rgb(var(--primary-900))]"
+                        >
+                            This application was submitted by <strong>{{ authentication.email }}</strong> on
+                            {{ formatSubmissionDateTime(currentSubmission.submitted_at) }}.
+                        </div>
+
+                        <FormKitSchema
+                            v-if="currentSubmission.schema"
+                            :schema="currentSubmission.schema"
+                            :data="data"
+                        />
+                    </div>
+                </div>
+
+                <!-- Normal new submission form -->
+                <div v-else class="space-y-6">
+                    <p
+                        v-if="authentication.email && !(props.preview === 'true' || props.preview === true)"
+                        class="text-sm"
+                    >
+                        Signed in as <strong>{{ authentication.email }}</strong>
+                    </p>
+
+                    <FormKitSchema :schema="schema" :data="data" />
+                </div>
             </div>
         </div>
 

--- a/widgets/application/src/App.vue
+++ b/widgets/application/src/App.vue
@@ -614,14 +614,14 @@
                             <button
                                 @click="loadPastSubmissions(1)"
                                 :disabled="isLoadingSubmissions"
-                                class="flex-1 h-11 px-5 rounded-[--rounding] border-2 border-[rgb(var(--primary-600))] text-[rgb(var(--primary-600))] text-sm font-semibold whitespace-nowrap hover:bg-[rgb(var(--primary-50))] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                class="flex-1 h-11 px-5 rounded border-2 border-primary-600 text-primary-600 text-sm font-semibold whitespace-nowrap hover:bg-primary-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                                 <span v-if="isLoadingSubmissions">Loading…</span>
                                 <span v-else>View Past Submissions</span>
                             </button>
                             <button
                                 @click="startNewSubmission"
-                                class="flex-1 h-11 px-5 rounded-[--rounding] bg-[rgb(var(--primary-600))] text-white text-sm font-semibold whitespace-nowrap hover:bg-[rgb(var(--primary-700))] transition-colors"
+                                class="flex-1 h-11 px-5 rounded bg-primary-600 text-white text-sm font-semibold whitespace-nowrap hover:bg-primary-700 transition-colors"
                             >
                                 New Submission
                             </button>
@@ -634,7 +634,7 @@
                     <div class="flex items-center justify-between">
                         <button
                             @click="backToSplash"
-                            class="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--primary-600))] hover:text-[rgb(var(--primary-800))] cursor-pointer transition-colors"
+                            class="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 hover:text-primary-800 cursor-pointer transition-colors"
                         >
                             <ArrowLeftIcon class="w-4 h-4" />
                             Back
@@ -650,7 +650,7 @@
                     <div v-else-if="pastSubmissions.length === 0" class="py-8 text-center text-sm text-gray-500">
                         No past submissions found.
                     </div>
-                    <div v-else class="overflow-hidden rounded-[--rounding] border border-gray-200 not-prose">
+                    <div v-else class="overflow-hidden rounded border border-gray-200 not-prose">
                         <table class="w-full text-sm border-collapse">
                             <thead>
                                 <tr class="bg-gray-50 border-b border-gray-200 text-left">
@@ -669,7 +669,7 @@
                                         'transition-colors',
                                         isLoadingSubmission
                                             ? 'opacity-60 cursor-not-allowed'
-                                            : 'cursor-pointer hover:bg-[rgb(var(--primary-50))]',
+                                            : 'cursor-pointer hover:bg-primary-50',
                                     ]"
                                 >
                                     <td class="px-4 py-3 text-gray-700">
@@ -715,16 +715,14 @@
                 <div v-else-if="currentView === 'submission'" class="space-y-4 not-prose">
                     <button
                         @click="backToTable"
-                        class="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--primary-600))] hover:text-[rgb(var(--primary-800))] cursor-pointer transition-colors"
+                        class="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 hover:text-primary-800 cursor-pointer transition-colors"
                     >
                         <ArrowLeftIcon class="w-4 h-4" />
                         Back to Submissions
                     </button>
                     <div v-if="isLoadingSubmission" class="py-8 text-center text-sm text-gray-500">Loading…</div>
                     <div v-else-if="currentSubmission" class="space-y-4">
-                        <div
-                            class="rounded-[--rounding] bg-[rgb(var(--primary-50))] border border-[rgb(var(--primary-200))] px-4 py-3 text-sm text-[rgb(var(--primary-900))]"
-                        >
+                        <div class="rounded bg-primary-50 border border-primary-200 px-4 py-3 text-sm text-primary-900">
                             This application was submitted by <strong>{{ authentication.email }}</strong> on
                             {{ formatSubmissionDateTime(currentSubmission.submitted_at) }}.
                         </div>

--- a/widgets/form/src/App.vue
+++ b/widgets/form/src/App.vue
@@ -32,6 +32,7 @@
 </COPYRIGHT>
 -->
 <script setup>
+    import { ArrowLeftIcon, ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/outline';
     import DOMPurify from 'dompurify';
     import { marked } from 'marked';
     import { defineProps, onMounted, reactive, ref } from 'vue';
@@ -143,6 +144,18 @@
     const formTitleFontWeight = ref('');
     const formTitleColor = ref({});
 
+    const allowViewPastSubmissions = ref(false);
+    const pastSubmissionsCount = ref(0);
+    const pastSubmissionsUrl = ref(null);
+
+    const currentView = ref('form');
+    const pastSubmissions = ref([]);
+    const pastSubmissionsMeta = ref(null);
+    const pastSubmissionsCurrentPage = ref(1);
+    const isLoadingSubmissions = ref(false);
+    const isLoadingSubmission = ref(false);
+    const currentSubmission = ref(null);
+
     const authentication = ref({
         code: null,
         email: null,
@@ -152,6 +165,63 @@
         url: null,
         registrationAllowed: false,
     });
+
+    function formatSubmissionDateTime(isoString) {
+        if (!isoString) return '';
+        return new Date(isoString).toLocaleString('en-US', {
+            year: 'numeric',
+            month: 'long',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+        });
+    }
+
+    async function loadPastSubmissions(page = 1) {
+        isLoadingSubmissions.value = true;
+        try {
+            const url = new URL(pastSubmissionsUrl.value);
+            url.searchParams.set('page', page);
+            url.searchParams.set('per_page', 10);
+            const response = await fetch(url.toString(), { headers: { Accept: 'application/json' } });
+            const json = await response.json();
+            pastSubmissions.value = json.past_submissions ?? [];
+            pastSubmissionsMeta.value = json.meta ?? null;
+            pastSubmissionsCurrentPage.value = page;
+            currentView.value = 'table';
+        } catch (e) {
+            console.error('Error loading past submissions', e);
+        } finally {
+            isLoadingSubmissions.value = false;
+        }
+    }
+
+    async function loadSubmission(viewUrl) {
+        isLoadingSubmission.value = true;
+        try {
+            const response = await fetch(viewUrl, { headers: { Accept: 'application/json' } });
+            const json = await response.json();
+            currentSubmission.value = json;
+            currentView.value = 'submission';
+        } catch (e) {
+            console.error('Error loading submission', e);
+        } finally {
+            isLoadingSubmission.value = false;
+        }
+    }
+
+    function startNewSubmission() {
+        currentView.value = 'form';
+    }
+
+    function backToTable() {
+        currentView.value = 'table';
+    }
+
+    function backToSplash() {
+        currentView.value = 'splash';
+    }
 
     async function getForm() {
         await fetch(props.entryUrl)
@@ -293,6 +363,14 @@
                     if (json.schema) {
                         schema.value = json.schema;
                     }
+
+                    allowViewPastSubmissions.value = json.allow_view_past_submissions ?? false;
+                    pastSubmissionsCount.value = json.past_submissions_count ?? 0;
+                    pastSubmissionsUrl.value = json.past_submissions_url ?? null;
+
+                    if (allowViewPastSubmissions.value && pastSubmissionsCount.value > 0) {
+                        currentView.value = 'splash';
+                    }
                 })
                 .catch((error) => {
                     node.setErrors([error]);
@@ -422,6 +500,7 @@
             </div>
 
             <h1
+                v-if="formName"
                 :style="{
                     fontWeight: formTitleFontWeight,
                     color: `rgb(${formTitleColor[900]})`,
@@ -430,7 +509,7 @@
                 {{ formName }}
             </h1>
 
-            <p>
+            <p v-if="formDescription">
                 {{ formDescription }}
             </p>
 
@@ -571,11 +650,148 @@
             </div>
 
             <div v-if="formSubmissionUrl" class="space-y-6">
-                <p v-if="formIsAuthenticated" class="text-sm">
-                    Signed in as <strong>{{ authentication.email }}</strong>
-                </p>
+                <!-- Splash screen: View Past Submissions or New Submission -->
+                <div v-if="currentView === 'splash'" class="py-4 not-prose">
+                    <p v-if="authentication.email" class="text-sm text-gray-500 mb-6">
+                        Signed in as <strong class="font-semibold text-gray-800">{{ authentication.email }}</strong>
+                    </p>
+                    <div class="flex flex-col items-center gap-5">
+                        <h2 class="text-base font-semibold text-gray-800">What would you like to do?</h2>
+                        <div class="flex flex-col sm:flex-row gap-3 w-full max-w-sm">
+                            <button
+                                @click="loadPastSubmissions(1)"
+                                :disabled="isLoadingSubmissions"
+                                class="flex-1 h-11 px-5 rounded-[--rounding] border-2 border-[rgb(var(--primary-600))] text-[rgb(var(--primary-600))] text-sm font-semibold whitespace-nowrap hover:bg-[rgb(var(--primary-50))] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                <span v-if="isLoadingSubmissions">Loading…</span>
+                                <span v-else>View Past Submissions</span>
+                            </button>
+                            <button
+                                @click="startNewSubmission"
+                                class="flex-1 h-11 px-5 rounded-[--rounding] bg-[rgb(var(--primary-600))] text-white text-sm font-semibold whitespace-nowrap hover:bg-[rgb(var(--primary-700))] transition-colors"
+                            >
+                                New Submission
+                            </button>
+                        </div>
+                    </div>
+                </div>
 
-                <FormKitSchema :schema="schema" :data="data" />
+                <!-- Past submissions table -->
+                <div v-else-if="currentView === 'table'" class="space-y-4 not-prose">
+                    <div class="flex items-center justify-between">
+                        <button
+                            @click="backToSplash"
+                            class="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--primary-600))] hover:text-[rgb(var(--primary-800))] cursor-pointer transition-colors"
+                        >
+                            <ArrowLeftIcon class="w-4 h-4" />
+                            Back
+                        </button>
+                        <p class="text-sm text-gray-500">
+                            Signed in as <strong class="font-semibold text-gray-700">{{ authentication.email }}</strong>
+                        </p>
+                    </div>
+                    <h2 class="text-base font-semibold text-gray-800">Past Submissions</h2>
+                    <div v-if="isLoadingSubmissions" class="py-8 text-center text-sm text-gray-500">
+                        Loading submissions…
+                    </div>
+                    <div v-else-if="pastSubmissions.length === 0" class="py-8 text-center text-sm text-gray-500">
+                        No past submissions found.
+                    </div>
+                    <div v-else class="overflow-hidden rounded-[--rounding] border border-gray-200 not-prose">
+                        <table class="w-full text-sm border-collapse">
+                            <thead>
+                                <tr class="bg-gray-50 border-b border-gray-200 text-left">
+                                    <th class="px-4 py-3 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                                        Date Submitted
+                                    </th>
+                                    <th class="px-4 py-3 w-24"></th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-gray-200">
+                                <tr
+                                    v-for="submission in pastSubmissions"
+                                    :key="submission.id"
+                                    @click="!isLoadingSubmission && loadSubmission(submission.view_url)"
+                                    :class="[
+                                        'transition-colors',
+                                        isLoadingSubmission
+                                            ? 'opacity-60 cursor-not-allowed'
+                                            : 'cursor-pointer hover:bg-[rgb(var(--primary-50))]',
+                                    ]"
+                                >
+                                    <td class="px-4 py-3 text-gray-700">
+                                        {{ formatSubmissionDateTime(submission.submitted_at) }}
+                                    </td>
+                                    <td class="px-4 py-3 text-right">
+                                        <ChevronRightIcon class="w-4 h-4 text-gray-400 ml-auto" />
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <!-- Pagination -->
+                        <div
+                            v-if="pastSubmissionsMeta && pastSubmissionsMeta.last_page > 1"
+                            class="flex items-center justify-between px-4 py-3 border-t border-gray-200 bg-gray-50"
+                        >
+                            <button
+                                @click="loadPastSubmissions(pastSubmissionsCurrentPage - 1)"
+                                :disabled="pastSubmissionsCurrentPage <= 1 || isLoadingSubmissions"
+                                class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-600 disabled:opacity-40 hover:bg-white transition-colors"
+                            >
+                                <ChevronLeftIcon class="w-3 h-3" />
+                                Previous
+                            </button>
+                            <span class="text-xs text-gray-500">
+                                Page {{ pastSubmissionsCurrentPage }} of {{ pastSubmissionsMeta.last_page }}
+                            </span>
+                            <button
+                                @click="loadPastSubmissions(pastSubmissionsCurrentPage + 1)"
+                                :disabled="
+                                    pastSubmissionsCurrentPage >= pastSubmissionsMeta.last_page || isLoadingSubmissions
+                                "
+                                class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium rounded border border-gray-300 text-gray-600 disabled:opacity-40 hover:bg-white transition-colors"
+                            >
+                                Next
+                                <ChevronRightIcon class="w-3 h-3" />
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Read-only submission detail -->
+                <div v-else-if="currentView === 'submission'" class="space-y-4 not-prose">
+                    <button
+                        @click="backToTable"
+                        class="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--primary-600))] hover:text-[rgb(var(--primary-800))] cursor-pointer transition-colors"
+                    >
+                        <ArrowLeftIcon class="w-4 h-4" />
+                        Back to Submissions
+                    </button>
+                    <div v-if="isLoadingSubmission" class="py-8 text-center text-sm text-gray-500">Loading…</div>
+                    <div v-else-if="currentSubmission" class="space-y-4">
+                        <div
+                            class="rounded-[--rounding] bg-[rgb(var(--primary-50))] border border-[rgb(var(--primary-200))] px-4 py-3 text-sm text-[rgb(var(--primary-900))]"
+                        >
+                            This form was submitted by <strong>{{ authentication.email }}</strong> on
+                            {{ formatSubmissionDateTime(currentSubmission.submitted_at) }}.
+                        </div>
+
+                        <FormKitSchema
+                            v-if="currentSubmission.schema"
+                            :schema="currentSubmission.schema"
+                            :data="data"
+                        />
+                    </div>
+                </div>
+
+                <!-- Normal new submission form -->
+                <div v-else class="space-y-6">
+                    <p v-if="formIsAuthenticated && authentication.email" class="text-sm">
+                        Signed in as <strong>{{ authentication.email }}</strong>
+                    </p>
+
+                    <FormKitSchema :schema="schema" :data="data" />
+                </div>
             </div>
         </div>
 

--- a/widgets/form/src/App.vue
+++ b/widgets/form/src/App.vue
@@ -661,14 +661,14 @@
                             <button
                                 @click="loadPastSubmissions(1)"
                                 :disabled="isLoadingSubmissions"
-                                class="flex-1 h-11 px-5 rounded-[--rounding] border-2 border-[rgb(var(--primary-600))] text-[rgb(var(--primary-600))] text-sm font-semibold whitespace-nowrap hover:bg-[rgb(var(--primary-50))] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                                class="flex-1 h-11 px-5 rounded border-2 border-primary-600 text-primary-600 text-sm font-semibold whitespace-nowrap hover:bg-primary-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                             >
                                 <span v-if="isLoadingSubmissions">Loading…</span>
                                 <span v-else>View Past Submissions</span>
                             </button>
                             <button
                                 @click="startNewSubmission"
-                                class="flex-1 h-11 px-5 rounded-[--rounding] bg-[rgb(var(--primary-600))] text-white text-sm font-semibold whitespace-nowrap hover:bg-[rgb(var(--primary-700))] transition-colors"
+                                class="flex-1 h-11 px-5 rounded bg-primary-600 text-white text-sm font-semibold whitespace-nowrap hover:bg-primary-700 transition-colors"
                             >
                                 New Submission
                             </button>
@@ -681,7 +681,7 @@
                     <div class="flex items-center justify-between">
                         <button
                             @click="backToSplash"
-                            class="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--primary-600))] hover:text-[rgb(var(--primary-800))] cursor-pointer transition-colors"
+                            class="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 hover:text-primary-800 cursor-pointer transition-colors"
                         >
                             <ArrowLeftIcon class="w-4 h-4" />
                             Back
@@ -697,7 +697,7 @@
                     <div v-else-if="pastSubmissions.length === 0" class="py-8 text-center text-sm text-gray-500">
                         No past submissions found.
                     </div>
-                    <div v-else class="overflow-hidden rounded-[--rounding] border border-gray-200 not-prose">
+                    <div v-else class="overflow-hidden rounded border border-gray-200 not-prose">
                         <table class="w-full text-sm border-collapse">
                             <thead>
                                 <tr class="bg-gray-50 border-b border-gray-200 text-left">
@@ -716,7 +716,7 @@
                                         'transition-colors',
                                         isLoadingSubmission
                                             ? 'opacity-60 cursor-not-allowed'
-                                            : 'cursor-pointer hover:bg-[rgb(var(--primary-50))]',
+                                            : 'cursor-pointer hover:bg-primary-50',
                                     ]"
                                 >
                                     <td class="px-4 py-3 text-gray-700">
@@ -762,16 +762,14 @@
                 <div v-else-if="currentView === 'submission'" class="space-y-4 not-prose">
                     <button
                         @click="backToTable"
-                        class="inline-flex items-center gap-1.5 text-sm font-medium text-[rgb(var(--primary-600))] hover:text-[rgb(var(--primary-800))] cursor-pointer transition-colors"
+                        class="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 hover:text-primary-800 cursor-pointer transition-colors"
                     >
                         <ArrowLeftIcon class="w-4 h-4" />
                         Back to Submissions
                     </button>
                     <div v-if="isLoadingSubmission" class="py-8 text-center text-sm text-gray-500">Loading…</div>
                     <div v-else-if="currentSubmission" class="space-y-4">
-                        <div
-                            class="rounded-[--rounding] bg-[rgb(var(--primary-50))] border border-[rgb(var(--primary-200))] px-4 py-3 text-sm text-[rgb(var(--primary-900))]"
-                        >
+                        <div class="rounded bg-primary-50 border border-primary-200 px-4 py-3 text-sm text-primary-900">
                             This form was submitted by <strong>{{ authentication.email }}</strong> on
                             {{ formatSubmissionDateTime(currentSubmission.submitted_at) }}.
                         </div>


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2712

### Technical Description

> Introduce the ability for submitters to see their past form or admissions application submission when form authentication is active

### Any deployment steps required?

> No

### Cleanup Tasks

> Yes, Feature Flag: `PastSubmissionsFeature`

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
