### PR TITLE
[ADVAPP-2716]: Users without the ability to update settings can change the default care team roles

### DIFF
--- a/app-modules/care-team/src/Filament/Resources/ProspectCareTeamRoles/Pages/CreateProspectCareTeamRole.php
+++ b/app-modules/care-team/src/Filament/Resources/ProspectCareTeamRoles/Pages/CreateProspectCareTeamRole.php
@@ -93,6 +93,7 @@ class CreateProspectCareTeamRole extends CreateRecord
         if ($record['is_default']) {
             CareTeamRole::query()
                 ->where('is_default', true)
+                ->where('type', CareTeamRoleType::Prospect)
                 ->update(['is_default' => false]);
         }
     }

--- a/app-modules/care-team/src/Filament/Resources/ProspectCareTeamRoles/Pages/EditProspectCareTeamRole.php
+++ b/app-modules/care-team/src/Filament/Resources/ProspectCareTeamRoles/Pages/EditProspectCareTeamRole.php
@@ -88,6 +88,20 @@ class EditProspectCareTeamRole extends EditRecord
             ]);
     }
 
+    protected function beforeSave(): void
+    {
+        /** @var CareTeamRole $record */
+        $record = $this->record;
+
+        if ($this->data['is_default'] ?? false) {
+            CareTeamRole::query()
+                ->where('id', '!=', $record->getKey())
+                ->where('type', CareTeamRoleType::Prospect)
+                ->where('is_default', true)
+                ->update(['is_default' => false]);
+        }
+    }
+
     protected function getHeaderActions(): array
     {
         return [

--- a/app-modules/care-team/src/Filament/Resources/ProspectCareTeamRoles/Pages/ListProspectCareTeamRoles.php
+++ b/app-modules/care-team/src/Filament/Resources/ProspectCareTeamRoles/Pages/ListProspectCareTeamRoles.php
@@ -64,6 +64,7 @@ class ListProspectCareTeamRoles extends ListRecords
                     ->searchable(),
                 ToggleColumn::make('is_default')
                     ->label('Default')
+                    ->disabled(! auth()->user()->can('settings.*.update'))
                     ->beforeStateUpdated(
                         fn (CareTeamRole $record) => CareTeamRole::where('id', '!=', $record->getKey())
                             ->where('type', CareTeamRoleType::Prospect)

--- a/app-modules/care-team/src/Filament/Resources/StudentCareTeamRoles/Pages/CreateStudentCareTeamRole.php
+++ b/app-modules/care-team/src/Filament/Resources/StudentCareTeamRoles/Pages/CreateStudentCareTeamRole.php
@@ -97,6 +97,7 @@ class CreateStudentCareTeamRole extends CreateRecord
         if ($record['is_default']) {
             CareTeamRole::query()
                 ->where('is_default', true)
+                ->where('type', CareTeamRoleType::Student)
                 ->update(['is_default' => false]);
         }
     }

--- a/app-modules/care-team/src/Filament/Resources/StudentCareTeamRoles/Pages/EditStudentCareTeamRole.php
+++ b/app-modules/care-team/src/Filament/Resources/StudentCareTeamRoles/Pages/EditStudentCareTeamRole.php
@@ -73,7 +73,7 @@ class EditStudentCareTeamRole extends EditRecord
 
                         $currentDefault = CareTeamRole::query()
                             ->where('is_default', true)
-                            ->where('type', CareTeamRoleType::Prospect)
+                            ->where('type', CareTeamRoleType::Student)
                             ->value('name');
 
                         if (blank($currentDefault)) {
@@ -86,6 +86,20 @@ class EditStudentCareTeamRole extends EditRecord
                     ->columnStart(1)
                     ->live(),
             ]);
+    }
+
+    protected function beforeSave(): void
+    {
+        /** @var CareTeamRole $record */
+        $record = $this->record;
+
+        if ($this->data['is_default'] ?? false) {
+            CareTeamRole::query()
+                ->where('id', '!=', $record->getKey())
+                ->where('type', CareTeamRoleType::Student)
+                ->where('is_default', true)
+                ->update(['is_default' => false]);
+        }
     }
 
     protected function getHeaderActions(): array

--- a/app-modules/care-team/src/Filament/Resources/StudentCareTeamRoles/Pages/ListStudentCareTeamRoles.php
+++ b/app-modules/care-team/src/Filament/Resources/StudentCareTeamRoles/Pages/ListStudentCareTeamRoles.php
@@ -64,6 +64,7 @@ class ListStudentCareTeamRoles extends ListRecords
                     ->searchable(),
                 ToggleColumn::make('is_default')
                     ->label('Default')
+                    ->disabled(! auth()->user()->can('settings.*.update'))
                     ->beforeStateUpdated(
                         fn (CareTeamRole $record) => CareTeamRole::where('id', '!=', $record->getKey())
                             ->where('type', CareTeamRoleType::Student)


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2716

### Technical Description

- disable default toggle for care team roles based on user permissions
- Edit pages(`EditStudentCareTeamRole` and `EditProspectCareTeamRole`): Added missing `beforeSave()` to clear existing defaults before save, preventing unique constraint violation. Fixed Student edit hint querying wrong type (Prospect → Student).
- Create pages(`CreateStudentCareTeamRole` and `CreateProspectCareTeamRole`): Added ->where('type', ...) filter to beforeCreate() so clearing defaults is scoped to the correct type.

### Any deployment steps required?

No

### Cleanup Tasks

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
