### PR TITLE
[ADVAPP-2713]: Some users have reported that personal booking appointment slots that cross midnight boundaries are behaving unexpectedly

### DIFF
--- a/app-modules/meeting-center/src/Actions/GetAvailableAppointmentSlots.php
+++ b/app-modules/meeting-center/src/Actions/GetAvailableAppointmentSlots.php
@@ -167,6 +167,17 @@ class GetAvailableAppointmentSlots
                 $start = Carbon::parse("{$date->toDateString()} {$startTime}", 'UTC');
                 $end = Carbon::parse("{$date->toDateString()} {$endTime}", 'UTC');
 
+                if ($start->gte($end)) {
+                    $startMinutesFromMidnight = (24 * 60) - ($start->hour * 60 + $start->minute);
+                    $endMinutesFromMidnight = $end->hour * 60 + $end->minute;
+
+                    if ($startMinutesFromMidnight <= $endMinutesFromMidnight) {
+                        $start = $start->copy()->subDay();
+                    } else {
+                        $end = $end->copy()->addDay();
+                    }
+                }
+
                 return $this->carveOutBusyPeriods($start, $end, $busyPeriods);
             })
             ->filter(fn (array $block) => $block['end']->isAfter($now))

--- a/app-modules/meeting-center/src/Http/Controllers/PersonalBookingPageWidgetController.php
+++ b/app-modules/meeting-center/src/Http/Controllers/PersonalBookingPageWidgetController.php
@@ -43,6 +43,7 @@ use AdvisingApp\MeetingCenter\Models\CalendarEvent;
 use AdvisingApp\MeetingCenter\Models\PersonalBookingPage;
 use AdvisingApp\StudentDataModel\Models\StudentEmailAddress;
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use App\Settings\CollegeBrandingSettings;
 use Carbon\Carbon;
 use Filament\Support\Colors\Color;
@@ -232,34 +233,13 @@ class PersonalBookingPageWidgetController extends Controller
             }
         }
 
-        // Validate the booking time falls within the user's office hours
-        if ($user->office_hours_are_enabled && $user->office_hours) {
-            $dayOfWeek = strtolower($startsAt->format('l'));
-            $dayHours = $user->office_hours[$dayOfWeek] ?? null;
-
-            $isEnabled = $dayHours['is_enabled'] ?? $dayHours['enabled'] ?? false;
-
-            if (! $dayHours || ! $isEnabled) {
-                return response()->json([
-                    'success' => false,
-                    'message' => 'No availability for the selected day.',
-                ], 422);
-            }
-
-            $startTime = $dayHours['starts_at'] ?? $dayHours['start'] ?? null;
-            $endTime = $dayHours['ends_at'] ?? $dayHours['end'] ?? null;
-
-            if ($startTime && $endTime) {
-                $dayStart = Carbon::parse("{$startsAt->toDateString()} {$startTime}", 'UTC');
-                $dayEnd = Carbon::parse("{$startsAt->toDateString()} {$endTime}", 'UTC');
-
-                if ($startsAt->lt($dayStart) || $endsAt->gt($dayEnd)) {
-                    return response()->json([
-                        'success' => false,
-                        'message' => 'The selected time is outside available booking hours.',
-                    ], 422);
-                }
-            }
+        // Validate the booking time falls within available slots
+        // (reuses GetAvailableAppointmentSlots which already handles midnight-crossing office hours)
+        if (! $this->slotIsAvailable($user, $bookingPage, $startsAt, $endsAt)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'The selected time is outside available booking hours.',
+            ], 422);
         }
 
         // Check if slot is still available using a database lock
@@ -308,6 +288,28 @@ class PersonalBookingPageWidgetController extends Controller
                     'ends_at' => $event->ends_at->toIso8601String(),
                 ],
             ], 201);
+        });
+    }
+
+    protected function slotIsAvailable(
+        User $user,
+        PersonalBookingPage $bookingPage,
+        Carbon $startsAt,
+        Carbon $endsAt,
+    ): bool {
+        $availableBlocks = app(GetAvailableAppointmentSlots::class)(
+            $user,
+            $startsAt->year,
+            $startsAt->month,
+            $bookingPage->minimum_booking_lead_time_hours ?? 0,
+            $bookingPage->maximum_booking_lead_time_days ?? 0,
+        );
+
+        return collect($availableBlocks)->contains(function (array $block) use ($startsAt, $endsAt) {
+            $blockStart = Carbon::parse($block['start']);
+            $blockEnd = Carbon::parse($block['end']);
+
+            return $startsAt->gte($blockStart) && $endsAt->lte($blockEnd);
         });
     }
 }

--- a/app-modules/meeting-center/tests/Tenant/Http/Controllers/PersonalBookingPageWidgetControllerTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Http/Controllers/PersonalBookingPageWidgetControllerTest.php
@@ -436,7 +436,7 @@ it('rejects booking on a day with office hours disabled', function () use ($offi
 
     $response->assertStatus(422);
     $response->assertJsonFragment(['success' => false]);
-    expect($response->json('message'))->toContain('No availability for the selected day');
+    expect($response->json('message'))->toContain('The selected time is outside available booking hours');
 });
 
 it('rejects booking outside office hours on an enabled day', function () use ($officeHours) {
@@ -562,9 +562,9 @@ it('rejects booking when a busy calendar event overlaps', function () use ($offi
         ]
     );
 
-    $response->assertStatus(409);
+    $response->assertStatus(422);
     $response->assertJsonFragment(['success' => false]);
-    expect($response->json('message'))->toContain('already been booked');
+    expect($response->json('message'))->toContain('The selected time is outside available booking hours');
 });
 
 it('allows booking when only a free calendar event overlaps', function () use ($officeHours) {
@@ -635,7 +635,168 @@ it('rejects booking when an out of office calendar event overlaps', function () 
         ]
     );
 
-    $response->assertStatus(409);
+    $response->assertStatus(422);
     $response->assertJsonFragment(['success' => false]);
-    expect($response->json('message'))->toContain('already been booked');
+    expect($response->json('message'))->toContain('The selected time is outside available booking hours');
+});
+
+// Midnight-Crossing Office Hours Tests (non-UTC timezones)
+
+$bstOfficeHours = [
+    'monday' => ['is_enabled' => true, 'starts_at' => '23:00', 'ends_at' => '07:00'],
+    'tuesday' => ['is_enabled' => true, 'starts_at' => '23:00', 'ends_at' => '07:00'],
+    'wednesday' => ['is_enabled' => true, 'starts_at' => '23:00', 'ends_at' => '07:00'],
+    'thursday' => ['is_enabled' => true, 'starts_at' => '23:00', 'ends_at' => '07:00'],
+    'friday' => ['is_enabled' => true, 'starts_at' => '23:00', 'ends_at' => '07:00'],
+    'saturday' => ['is_enabled' => false, 'starts_at' => null, 'ends_at' => null],
+    'sunday' => ['is_enabled' => false, 'starts_at' => null, 'ends_at' => null],
+];
+
+$hstOfficeHours = [
+    'monday' => ['is_enabled' => true, 'starts_at' => '18:00', 'ends_at' => '03:00'],
+    'tuesday' => ['is_enabled' => true, 'starts_at' => '18:00', 'ends_at' => '03:00'],
+    'wednesday' => ['is_enabled' => true, 'starts_at' => '18:00', 'ends_at' => '03:00'],
+    'thursday' => ['is_enabled' => true, 'starts_at' => '18:00', 'ends_at' => '03:00'],
+    'friday' => ['is_enabled' => true, 'starts_at' => '18:00', 'ends_at' => '03:00'],
+    'saturday' => ['is_enabled' => false, 'starts_at' => null, 'ends_at' => null],
+    'sunday' => ['is_enabled' => false, 'starts_at' => null, 'ends_at' => null],
+];
+
+it('produces available slots when office hours cross midnight UTC (BST positive offset)', function () use ($bstOfficeHours) {
+    Carbon::setTestNow(Carbon::parse('2026-04-01 00:00:00', 'UTC'));
+
+    $user = User::factory()
+        ->has(Calendar::factory()->state(['provider_id' => 'test-provider']))
+        ->create([
+            'office_hours_are_enabled' => true,
+            'office_hours' => $bstOfficeHours,
+        ]);
+
+    PersonalBookingPage::factory()
+        ->for($user)
+        ->enabled()
+        ->create([
+            'slug' => 'test-bst-crossing',
+        ]);
+
+    $response = getJson(
+        route('widgets.booking-page.personal.api.available-slots', ['slug' => 'test-bst-crossing']) . '?year=2026&month=4'
+    );
+
+    $response->assertOk();
+
+    /** @var array<int, array{start: string, end: string}> $blocksData */
+    $blocksData = $response->json('blocks');
+    $blocks = collect($blocksData);
+
+    expect($blocks)->not->toBeEmpty();
+
+    // Monday Apr 6: hours cross midnight, should produce Sun Apr 5 23:00 to Mon Apr 6 07:00
+    $mondayBlock = $blocks->first(fn (array $block) => str_contains($block['start'], '2026-04-05T23:00'));
+    expect($mondayBlock)->not->toBeNull();
+    expect($mondayBlock['end'])->toBe('2026-04-06T07:00:00+00:00');
+});
+
+it('produces available slots when office hours cross midnight UTC (HST negative offset)', function () use ($hstOfficeHours) {
+    Carbon::setTestNow(Carbon::parse('2026-04-01 00:00:00', 'UTC'));
+
+    $user = User::factory()
+        ->has(Calendar::factory()->state(['provider_id' => 'test-provider']))
+        ->create([
+            'office_hours_are_enabled' => true,
+            'office_hours' => $hstOfficeHours,
+        ]);
+
+    PersonalBookingPage::factory()
+        ->for($user)
+        ->enabled()
+        ->create([
+            'slug' => 'test-hst-crossing',
+        ]);
+
+    $response = getJson(
+        route('widgets.booking-page.personal.api.available-slots', ['slug' => 'test-hst-crossing']) . '?year=2026&month=4'
+    );
+
+    $response->assertOk();
+
+    /** @var array<int, array{start: string, end: string}> $blocksData */
+    $blocksData = $response->json('blocks');
+    $blocks = collect($blocksData);
+
+    expect($blocks)->not->toBeEmpty();
+
+    // Monday Apr 6: hours 18:00 to 03:00 next day
+    $mondayBlock = $blocks->first(fn (array $block) => str_contains($block['start'], '2026-04-06T18:00'));
+    expect($mondayBlock)->not->toBeNull();
+    expect($mondayBlock['end'])->toBe('2026-04-07T03:00:00+00:00');
+});
+
+it('does not produce Saturday slots when Saturday is disabled with midnight-crossing hours', function () use ($bstOfficeHours) {
+    Carbon::setTestNow(Carbon::parse('2026-04-01 00:00:00', 'UTC'));
+
+    $user = User::factory()
+        ->has(Calendar::factory()->state(['provider_id' => 'test-provider']))
+        ->create([
+            'office_hours_are_enabled' => true,
+            'office_hours' => $bstOfficeHours,
+        ]);
+
+    PersonalBookingPage::factory()
+        ->for($user)
+        ->enabled()
+        ->create([
+            'slug' => 'test-bst-no-saturday',
+        ]);
+
+    $response = getJson(
+        route('widgets.booking-page.personal.api.available-slots', ['slug' => 'test-bst-no-saturday']) . '?year=2026&month=4'
+    );
+
+    $response->assertOk();
+
+    /** @var array<int, array{start: string, end: string}> $blocksData */
+    $blocksData = $response->json('blocks');
+    $blocks = collect($blocksData);
+
+    // Saturday is disabled, so no block should represent Saturday (Fri 23:00 to Sat 07:00)
+    $saturdayBlocks = $blocks->filter(function (array $block) {
+        $end = Carbon::parse($block['end']);
+
+        return $end->isSaturday() && $end->hour === 7;
+    });
+
+    expect($saturdayBlocks)->toBeEmpty();
+});
+
+it('allows booking within midnight-crossing office hours', function () use ($bstOfficeHours) {
+    Carbon::setTestNow(Carbon::parse('2026-04-06 08:00:00', 'UTC'));
+
+    $user = User::factory()
+        ->has(Calendar::factory()->state(['provider_id' => 'test-provider']))
+        ->create([
+            'office_hours_are_enabled' => true,
+            'office_hours' => $bstOfficeHours,
+        ]);
+
+    PersonalBookingPage::factory()
+        ->for($user)
+        ->enabled()
+        ->create([
+            'slug' => 'test-bst-book',
+        ]);
+
+    // Book at 00:00-00:30 UTC on Tuesday Apr 7 (within Mon 23:00 - Tue 07:00 window)
+    $response = postJson(
+        route('widgets.booking-page.personal.api.book', ['slug' => 'test-bst-book']),
+        [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'starts_at' => Carbon::parse('2026-04-07 00:00:00', 'UTC')->toIso8601String(),
+            'ends_at' => Carbon::parse('2026-04-07 00:30:00', 'UTC')->toIso8601String(),
+        ]
+    );
+
+    $response->assertStatus(201);
+    $response->assertJsonFragment(['success' => true]);
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2713

### Technical Description

> Fix the issue where personal booking appointments were not working as expected when the slots had midnight rollover.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A
---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
