### PR TITLE
[ADVAPP-2715]: Some actions are not properly gated by permissions

### DIFF
--- a/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/EditAiAssistant.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/EditAiAssistant.php
@@ -76,7 +76,7 @@ class EditAiAssistant extends EditRecord
     {
         return [
             Action::make('archive')
-                ->authorize(fn (): bool => auth()->user()->can('delete', $this->getRecord()))
+                ->authorize(fn (): bool => auth()->user()->can('assistant_custom.*.delete'))
                 ->color('danger')
                 ->action(function () {
                     $assistant = $this->getRecord();
@@ -90,7 +90,7 @@ class EditAiAssistant extends EditRecord
                 })
                 ->hidden(fn (): bool => (bool) $this->getRecord()->archived_at),
             Action::make('restore')
-                ->authorize(fn (): bool => auth()->user()->can('restore', $this->getRecord()))
+                ->authorize(fn (): bool => auth()->user()->can('assistant_custom.*.restore'))
                 ->action(function () {
                     $assistant = $this->getRecord();
                     $assistant->archived_at = null;

--- a/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/EditAiAssistant.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/EditAiAssistant.php
@@ -76,6 +76,7 @@ class EditAiAssistant extends EditRecord
     {
         return [
             Action::make('archive')
+                ->authorize(fn (): bool => auth()->user()->can('delete', $this->getRecord()))
                 ->color('danger')
                 ->action(function () {
                     $assistant = $this->getRecord();
@@ -89,6 +90,7 @@ class EditAiAssistant extends EditRecord
                 })
                 ->hidden(fn (): bool => (bool) $this->getRecord()->archived_at),
             Action::make('restore')
+                ->authorize(fn (): bool => auth()->user()->can('restore', $this->getRecord()))
                 ->action(function () {
                     $assistant = $this->getRecord();
                     $assistant->archived_at = null;

--- a/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/ManageEmployeeAdvisorQuestions.php
+++ b/app-modules/ai/src/Filament/Resources/AiAssistants/Pages/ManageEmployeeAdvisorQuestions.php
@@ -157,7 +157,8 @@ class ManageEmployeeAdvisorQuestions extends ManageRelatedRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->emptyStateHeading('No Employee Advisor Questions Found')

--- a/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/EditCustomerAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/EditCustomerAdvisor.php
@@ -168,7 +168,7 @@ class EditCustomerAdvisor extends EditRecord
     {
         return [
             Action::make('archive')
-                ->authorize(fn (CustomerAdvisor $record): bool => auth()->user()->can('delete', $record))
+                ->authorize(fn (): bool => auth()->user()->can('customer_advisor.*.delete'))
                 ->color('danger')
                 ->action(function () {
                     /** @var CustomerAdvisor $customerAdvisor */
@@ -183,7 +183,7 @@ class EditCustomerAdvisor extends EditRecord
                 })
                 ->hidden(fn (CustomerAdvisor $record): bool => (bool) $record->archived_at),
             Action::make('restore')
-                ->authorize(fn (CustomerAdvisor $record): bool => auth()->user()->can('restore', $record))
+                ->authorize(fn (): bool => auth()->user()->can('customer_advisor.*.restore'))
                 ->action(function () {
                     /** @var CustomerAdvisor $customerAdvisor */
                     $customerAdvisor = $this->getRecord();

--- a/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/EditCustomerAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/EditCustomerAdvisor.php
@@ -168,6 +168,7 @@ class EditCustomerAdvisor extends EditRecord
     {
         return [
             Action::make('archive')
+                ->authorize(fn (CustomerAdvisor $record): bool => auth()->user()->can('delete', $record))
                 ->color('danger')
                 ->action(function () {
                     /** @var CustomerAdvisor $customerAdvisor */
@@ -182,6 +183,7 @@ class EditCustomerAdvisor extends EditRecord
                 })
                 ->hidden(fn (CustomerAdvisor $record): bool => (bool) $record->archived_at),
             Action::make('restore')
+                ->authorize(fn (CustomerAdvisor $record): bool => auth()->user()->can('restore', $record))
                 ->action(function () {
                     /** @var CustomerAdvisor $customerAdvisor */
                     $customerAdvisor = $this->getRecord();

--- a/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/ManageCustomerQuestions.php
+++ b/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/ManageCustomerQuestions.php
@@ -153,7 +153,8 @@ class ManageCustomerQuestions extends ManageRelatedRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->emptyStateHeading('No Customer Advisor Questions Found')

--- a/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/ViewCustomerAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/ViewCustomerAdvisor.php
@@ -137,6 +137,7 @@ class ViewCustomerAdvisor extends ViewRecord
     {
         return [
             Action::make('archive')
+                ->authorize(fn (CustomerAdvisor $record): bool => auth()->user()->can('delete', $record))
                 ->color('danger')
                 ->action(function () {
                     /** @var CustomerAdvisor $record */
@@ -151,6 +152,7 @@ class ViewCustomerAdvisor extends ViewRecord
                 })
                 ->hidden(fn (CustomerAdvisor $record): bool => (bool) $record->archived_at),
             Action::make('restore')
+                ->authorize(fn (CustomerAdvisor $record): bool => auth()->user()->can('restore', $record))
                 ->action(function () {
                     /** @var CustomerAdvisor $record */
                     $record = $this->getRecord();

--- a/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/ViewCustomerAdvisor.php
+++ b/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/ViewCustomerAdvisor.php
@@ -137,7 +137,7 @@ class ViewCustomerAdvisor extends ViewRecord
     {
         return [
             Action::make('archive')
-                ->authorize(fn (CustomerAdvisor $record): bool => auth()->user()->can('delete', $record))
+                ->authorize(fn (): bool => auth()->user()->can('customer_advisor.*.delete'))
                 ->color('danger')
                 ->action(function () {
                     /** @var CustomerAdvisor $record */
@@ -152,7 +152,7 @@ class ViewCustomerAdvisor extends ViewRecord
                 })
                 ->hidden(fn (CustomerAdvisor $record): bool => (bool) $record->archived_at),
             Action::make('restore')
-                ->authorize(fn (CustomerAdvisor $record): bool => auth()->user()->can('restore', $record))
+                ->authorize(fn (): bool => auth()->user()->can('customer_advisor.*.restore'))
                 ->action(function () {
                     /** @var CustomerAdvisor $record */
                     $record = $this->getRecord();

--- a/app-modules/ai/src/Filament/Resources/DataAdvisors/DataAdvisorResource.php
+++ b/app-modules/ai/src/Filament/Resources/DataAdvisors/DataAdvisorResource.php
@@ -76,7 +76,8 @@ class DataAdvisorResource extends Resource
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/ai/src/Filament/Resources/LegacyAiMessageLogs/LegacyAiMessageLogResource.php
+++ b/app-modules/ai/src/Filament/Resources/LegacyAiMessageLogs/LegacyAiMessageLogResource.php
@@ -115,7 +115,8 @@ class LegacyAiMessageLogResource extends Resource
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                     ExportBulkAction::make()
                         ->exporter(AssistantUtilizationExporter::class),
                 ]),

--- a/app-modules/ai/src/Filament/Resources/LegacyAiMessageLogs/LegacyAiMessageLogResource.php
+++ b/app-modules/ai/src/Filament/Resources/LegacyAiMessageLogs/LegacyAiMessageLogResource.php
@@ -42,8 +42,6 @@ use AdvisingApp\Ai\Models\LegacyAiMessageLog;
 use App\Filament\Clusters\UsageAuditing;
 use App\Filament\Infolists\Components\CodeEntry;
 use Filament\Actions\BulkActionGroup;
-use Filament\Actions\DeleteAction;
-use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\ExportBulkAction;
 use Filament\Actions\ViewAction;
 use Filament\Infolists\Components\TextEntry;
@@ -111,12 +109,9 @@ class LegacyAiMessageLogResource extends Resource
             ])
             ->recordActions([
                 ViewAction::make()->slideOver(),
-                DeleteAction::make(),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make()
-                        ->authorizeIndividualRecords('delete'),
                     ExportBulkAction::make()
                         ->exporter(AssistantUtilizationExporter::class),
                 ]),

--- a/app-modules/ai/src/Filament/Resources/Prompts/Pages/ListPrompts.php
+++ b/app-modules/ai/src/Filament/Resources/Prompts/Pages/ListPrompts.php
@@ -104,6 +104,7 @@ class ListPrompts extends ListRecords
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete')
                         ->visible(auth()->user()->isSuperAdmin()),
                 ]),
             ]);

--- a/app-modules/ai/src/Policies/AiAssistantPolicy.php
+++ b/app-modules/ai/src/Policies/AiAssistantPolicy.php
@@ -109,12 +109,27 @@ class AiAssistantPolicy
         return Response::deny('AI Assistants cannot be deleted.');
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('AI Assistants cannot be deleted.');
+    }
+
     public function restore(Authenticatable $authenticatable, AiAssistant $aiAssistant): Response
     {
         return Response::deny('AI Assistants cannot be restored.');
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('AI Assistants cannot be restored.');
+    }
+
     public function forceDelete(Authenticatable $authenticatable, AiAssistant $aiAssistant): Response
+    {
+        return Response::deny('AI Assistants cannot be permanently deleted.');
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
     {
         return Response::deny('AI Assistants cannot be permanently deleted.');
     }

--- a/app-modules/ai/src/Policies/AiAssistantPolicy.php
+++ b/app-modules/ai/src/Policies/AiAssistantPolicy.php
@@ -106,34 +106,22 @@ class AiAssistantPolicy
 
     public function delete(Authenticatable $authenticatable, AiAssistant $aiAssistant): Response
     {
-        return $authenticatable->canOrElse(
-            abilities: ['assistant_custom.*.delete'],
-            denyResponse: 'You do not have permission to delete this AI Assistant.'
-        );
+        return Response::deny('AI Assistants cannot be deleted.');
     }
 
     public function deleteAny(Authenticatable $authenticatable): Response
     {
-        return $authenticatable->canOrElse(
-            abilities: ['assistant_custom.*.delete'],
-            denyResponse: 'You do not have permission to delete any AI Assistant.'
-        );
+        return Response::deny('AI Assistants cannot be deleted.');
     }
 
     public function restore(Authenticatable $authenticatable, AiAssistant $aiAssistant): Response
     {
-        return $authenticatable->canOrElse(
-            abilities: ['assistant_custom.*.restore'],
-            denyResponse: 'You do not have permission to restore this AI Assistant.'
-        );
+        return Response::deny('AI Assistants cannot be restored.');
     }
 
     public function restoreAny(Authenticatable $authenticatable): Response
     {
-        return $authenticatable->canOrElse(
-            abilities: ['assistant_custom.*.restore'],
-            denyResponse: 'You do not have permission to restore any AI Assistant.'
-        );
+        return Response::deny('AI Assistants cannot be restored.');
     }
 
     public function forceDelete(Authenticatable $authenticatable, AiAssistant $aiAssistant): Response

--- a/app-modules/ai/src/Policies/AiAssistantPolicy.php
+++ b/app-modules/ai/src/Policies/AiAssistantPolicy.php
@@ -106,22 +106,34 @@ class AiAssistantPolicy
 
     public function delete(Authenticatable $authenticatable, AiAssistant $aiAssistant): Response
     {
-        return Response::deny('AI Assistants cannot be deleted.');
+        return $authenticatable->canOrElse(
+            abilities: ['assistant_custom.*.delete'],
+            denyResponse: 'You do not have permission to delete this AI Assistant.'
+        );
     }
 
     public function deleteAny(Authenticatable $authenticatable): Response
     {
-        return Response::deny('AI Assistants cannot be deleted.');
+        return $authenticatable->canOrElse(
+            abilities: ['assistant_custom.*.delete'],
+            denyResponse: 'You do not have permission to delete any AI Assistant.'
+        );
     }
 
     public function restore(Authenticatable $authenticatable, AiAssistant $aiAssistant): Response
     {
-        return Response::deny('AI Assistants cannot be restored.');
+        return $authenticatable->canOrElse(
+            abilities: ['assistant_custom.*.restore'],
+            denyResponse: 'You do not have permission to restore this AI Assistant.'
+        );
     }
 
     public function restoreAny(Authenticatable $authenticatable): Response
     {
-        return Response::deny('AI Assistants cannot be restored.');
+        return $authenticatable->canOrElse(
+            abilities: ['assistant_custom.*.restore'],
+            denyResponse: 'You do not have permission to restore any AI Assistant.'
+        );
     }
 
     public function forceDelete(Authenticatable $authenticatable, AiAssistant $aiAssistant): Response

--- a/app-modules/ai/src/Policies/CustomerAdvisorCategoryPolicy.php
+++ b/app-modules/ai/src/Policies/CustomerAdvisorCategoryPolicy.php
@@ -97,7 +97,7 @@ class CustomerAdvisorCategoryPolicy
     public function deleteAny(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
-            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.delete' : 'qna_advisor.*.delete'],
+            abilities: ['customer_advisor.*.delete'],
             denyResponse: 'You do not have permission to delete any Customer Advisor Category.'
         );
     }
@@ -113,7 +113,7 @@ class CustomerAdvisorCategoryPolicy
     public function restoreAny(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
-            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.restore' : 'qna_advisor.*.restore'],
+            abilities: ['customer_advisor.*.restore'],
             denyResponse: 'You do not have permission to restore any Customer Advisor Category.'
         );
     }
@@ -129,7 +129,7 @@ class CustomerAdvisorCategoryPolicy
     public function forceDeleteAny(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
-            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.force-delete' : 'qna_advisor.*.force-delete'],
+            abilities: ['customer_advisor.*.force-delete'],
             denyResponse: 'You do not have permission to force-delete any Customer Advisor Category.'
         );
     }

--- a/app-modules/ai/src/Policies/CustomerAdvisorCategoryPolicy.php
+++ b/app-modules/ai/src/Policies/CustomerAdvisorCategoryPolicy.php
@@ -94,6 +94,14 @@ class CustomerAdvisorCategoryPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.delete' : 'qna_advisor.*.delete'],
+            denyResponse: 'You do not have permission to delete any Customer Advisor Category.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
@@ -102,11 +110,27 @@ class CustomerAdvisorCategoryPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.restore' : 'qna_advisor.*.restore'],
+            denyResponse: 'You do not have permission to restore any Customer Advisor Category.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['customer_advisor.*.force-delete'],
             denyResponse: 'You do not have permission to force-delete this Customer Advisor Category.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.force-delete' : 'qna_advisor.*.force-delete'],
+            denyResponse: 'You do not have permission to force-delete any Customer Advisor Category.'
         );
     }
 }

--- a/app-modules/ai/src/Policies/CustomerAdvisorPolicy.php
+++ b/app-modules/ai/src/Policies/CustomerAdvisorPolicy.php
@@ -102,12 +102,27 @@ class CustomerAdvisorPolicy
         return Response::deny('Customer Advisor cannot be deleted.');
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('Customer Advisor cannot be deleted.');
+    }
+
     public function restore(Authenticatable $authenticatable): Response
     {
         return Response::deny('Customer Advisor cannot be restored.');
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('Customer Advisor cannot be restored.');
+    }
+
     public function forceDelete(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('Customer Advisor cannot be permanently deleted.');
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
     {
         return Response::deny('Customer Advisor cannot be permanently deleted.');
     }

--- a/app-modules/ai/src/Policies/CustomerAdvisorPolicy.php
+++ b/app-modules/ai/src/Policies/CustomerAdvisorPolicy.php
@@ -99,34 +99,22 @@ class CustomerAdvisorPolicy
 
     public function delete(Authenticatable $authenticatable): Response
     {
-        return $authenticatable->canOrElse(
-            abilities: ['customer_advisor.*.delete'],
-            denyResponse: 'You do not have permission to delete this Customer Advisor.'
-        );
+        return Response::deny('Customer Advisor cannot be deleted.');
     }
 
     public function deleteAny(Authenticatable $authenticatable): Response
     {
-        return $authenticatable->canOrElse(
-            abilities: ['customer_advisor.*.delete'],
-            denyResponse: 'You do not have permission to delete any Customer Advisor.'
-        );
+        return Response::deny('Customer Advisor cannot be deleted.');
     }
 
     public function restore(Authenticatable $authenticatable): Response
     {
-        return $authenticatable->canOrElse(
-            abilities: ['customer_advisor.*.restore'],
-            denyResponse: 'You do not have permission to restore this Customer Advisor.'
-        );
+        return Response::deny('Customer Advisor cannot be restored.');
     }
 
     public function restoreAny(Authenticatable $authenticatable): Response
     {
-        return $authenticatable->canOrElse(
-            abilities: ['customer_advisor.*.restore'],
-            denyResponse: 'You do not have permission to restore any Customer Advisor.'
-        );
+        return Response::deny('Customer Advisor cannot be restored.');
     }
 
     public function forceDelete(Authenticatable $authenticatable): Response

--- a/app-modules/ai/src/Policies/CustomerAdvisorPolicy.php
+++ b/app-modules/ai/src/Policies/CustomerAdvisorPolicy.php
@@ -99,22 +99,34 @@ class CustomerAdvisorPolicy
 
     public function delete(Authenticatable $authenticatable): Response
     {
-        return Response::deny('Customer Advisor cannot be deleted.');
+        return $authenticatable->canOrElse(
+            abilities: ['customer_advisor.*.delete'],
+            denyResponse: 'You do not have permission to delete this Customer Advisor.'
+        );
     }
 
     public function deleteAny(Authenticatable $authenticatable): Response
     {
-        return Response::deny('Customer Advisor cannot be deleted.');
+        return $authenticatable->canOrElse(
+            abilities: ['customer_advisor.*.delete'],
+            denyResponse: 'You do not have permission to delete any Customer Advisor.'
+        );
     }
 
     public function restore(Authenticatable $authenticatable): Response
     {
-        return Response::deny('Customer Advisor cannot be restored.');
+        return $authenticatable->canOrElse(
+            abilities: ['customer_advisor.*.restore'],
+            denyResponse: 'You do not have permission to restore this Customer Advisor.'
+        );
     }
 
     public function restoreAny(Authenticatable $authenticatable): Response
     {
-        return Response::deny('Customer Advisor cannot be restored.');
+        return $authenticatable->canOrElse(
+            abilities: ['customer_advisor.*.restore'],
+            denyResponse: 'You do not have permission to restore any Customer Advisor.'
+        );
     }
 
     public function forceDelete(Authenticatable $authenticatable): Response

--- a/app-modules/ai/src/Policies/CustomerAdvisorQuestionPolicy.php
+++ b/app-modules/ai/src/Policies/CustomerAdvisorQuestionPolicy.php
@@ -97,7 +97,7 @@ class CustomerAdvisorQuestionPolicy
     public function deleteAny(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
-            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.delete' : 'qna_advisor.*.delete'],
+            abilities: ['customer_advisor.*.delete'],
             denyResponse: 'You do not have permission to delete any Customer Advisor Question.'
         );
     }
@@ -113,7 +113,7 @@ class CustomerAdvisorQuestionPolicy
     public function restoreAny(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
-            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.restore' : 'qna_advisor.*.restore'],
+            abilities: ['customer_advisor.*.restore'],
             denyResponse: 'You do not have permission to restore any Customer Advisor Question.'
         );
     }
@@ -129,7 +129,7 @@ class CustomerAdvisorQuestionPolicy
     public function forceDeleteAny(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
-            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.force-delete' : 'qna_advisor.*.force-delete'],
+            abilities: ['customer_advisor.*.force-delete'],
             denyResponse: 'You do not have permission to force-delete any Customer Advisor Question.'
         );
     }

--- a/app-modules/ai/src/Policies/CustomerAdvisorQuestionPolicy.php
+++ b/app-modules/ai/src/Policies/CustomerAdvisorQuestionPolicy.php
@@ -94,6 +94,14 @@ class CustomerAdvisorQuestionPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.delete' : 'qna_advisor.*.delete'],
+            denyResponse: 'You do not have permission to delete any Customer Advisor Question.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
@@ -102,11 +110,27 @@ class CustomerAdvisorQuestionPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.restore' : 'qna_advisor.*.restore'],
+            denyResponse: 'You do not have permission to restore any Customer Advisor Question.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['customer_advisor.*.force-delete'],
             denyResponse: 'You do not have permission to force-delete this Customer Advisor Question.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: [RenameQnaAdvisorsFeature::active() ? 'customer_advisor.*.force-delete' : 'qna_advisor.*.force-delete'],
+            denyResponse: 'You do not have permission to force-delete any Customer Advisor Question.'
         );
     }
 }

--- a/app-modules/ai/src/Policies/DataAdvisorPolicy.php
+++ b/app-modules/ai/src/Policies/DataAdvisorPolicy.php
@@ -95,6 +95,14 @@ class DataAdvisorPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['ai-data-advisors.*.delete'],
+            denyResponse: 'You do not have permission to delete any data advisor.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, DataAdvisor $dataAdvisor): Response
     {
         return $authenticatable->canOrElse(
@@ -103,11 +111,27 @@ class DataAdvisorPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['ai-data-advisors.*.restore'],
+            denyResponse: 'You do not have permission to restore any data advisor.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, DataAdvisor $dataAdvisor): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['ai-data-advisors.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this data advisor.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['ai-data-advisors.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any data advisor.'
         );
     }
 

--- a/app-modules/ai/src/Policies/EmployeeAdvisorCategoryPolicy.php
+++ b/app-modules/ai/src/Policies/EmployeeAdvisorCategoryPolicy.php
@@ -100,6 +100,14 @@ class EmployeeAdvisorCategoryPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['assistant_custom.*.delete'],
+            denyResponse: 'You do not have permission to delete any Employee Advisor Category.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
@@ -108,11 +116,27 @@ class EmployeeAdvisorCategoryPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['assistant_custom.*.restore'],
+            denyResponse: 'You do not have permission to restore any Employee Advisor Category.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['assistant_custom.*.force-delete'],
             denyResponse: 'You do not have permission to force-delete this Employee Advisor Category.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['assistant_custom.*.force-delete'],
+            denyResponse: 'You do not have permission to force-delete any Employee Advisor Category.'
         );
     }
 }

--- a/app-modules/ai/src/Policies/EmployeeAdvisorQuestionPolicy.php
+++ b/app-modules/ai/src/Policies/EmployeeAdvisorQuestionPolicy.php
@@ -100,6 +100,14 @@ class EmployeeAdvisorQuestionPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['assistant_custom.*.delete'],
+            denyResponse: 'You do not have permission to delete any Employee Advisor Question.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
@@ -108,11 +116,27 @@ class EmployeeAdvisorQuestionPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['assistant_custom.*.restore'],
+            denyResponse: 'You do not have permission to restore any Employee Advisor Question.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['assistant_custom.*.force-delete'],
             denyResponse: 'You do not have permission to force-delete this Employee Advisor Question.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['assistant_custom.*.force-delete'],
+            denyResponse: 'You do not have permission to force-delete any Employee Advisor Question.'
         );
     }
 }

--- a/app-modules/ai/src/Policies/PromptPolicy.php
+++ b/app-modules/ai/src/Policies/PromptPolicy.php
@@ -108,6 +108,14 @@ class PromptPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['prompt.*.delete'],
+            denyResponse: 'You do not have permission to delete any prompt.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Prompt $prompt): Response
     {
         return $authenticatable->canOrElse(
@@ -116,11 +124,27 @@ class PromptPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['prompt.*.restore'],
+            denyResponse: 'You do not have permission to restore any prompt.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Prompt $prompt): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['prompt.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this prompt.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['prompt.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any prompt.'
         );
     }
 }

--- a/app-modules/ai/src/Policies/PromptTypePolicy.php
+++ b/app-modules/ai/src/Policies/PromptTypePolicy.php
@@ -124,6 +124,14 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.delete'],
+            denyResponse: 'You do not have permission to delete any prompt type.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, PromptType $promptType): Response
     {
         if ($authenticatable->isAiAdmin()) {
@@ -133,6 +141,14 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: ['settings.*.restore'],
             denyResponse: 'You do not have permission to restore this prompt type.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.restore'],
+            denyResponse: 'You do not have permission to restore any prompt type.'
         );
     }
 
@@ -149,6 +165,14 @@ class PromptTypePolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: ['settings.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this prompt type.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any prompt type.'
         );
     }
 }

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptResource/ListPromptsTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptResource/ListPromptsTest.php
@@ -42,6 +42,7 @@ use AdvisingApp\Ai\Models\Prompt;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Team\Models\Team;
 use App\Models\Authenticatable;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseCount;
@@ -104,6 +105,32 @@ it('can list records', function () use ($licenses, $permissions) {
         ->assertSuccessful()
         ->assertCountTableRecords($records->count())
         ->assertCanSeeTableRecords($records);
+});
+
+it('hides the bulk delete action from a user who is not a super admin', function () use ($licenses, $permissions) {
+    actingAs(user(
+        licenses: $licenses,
+        permissions: [...$permissions, 'prompt.*.delete']
+    ));
+
+    Prompt::factory()->count(2)->create();
+
+    livewire(ListPrompts::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the bulk delete action to a super admin', function () use ($licenses, $permissions) {
+    actingAs(user(
+        licenses: $licenses,
+        permissions: $permissions
+    )->assignRole(Authenticatable::SUPER_ADMIN_ROLE));
+
+    Prompt::factory()->count(2)->create();
+
+    livewire(ListPrompts::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });
 
 it('Filter prompts based on Smart', function () use ($licenses, $permissions) {

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptTypeResource/ListPromptTypesTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Resources/PromptTypeResource/ListPromptTypesTest.php
@@ -38,6 +38,7 @@ use AdvisingApp\Ai\Filament\Resources\PromptTypes\Pages\ListPromptTypes;
 use AdvisingApp\Ai\Filament\Resources\PromptTypes\PromptTypeResource;
 use AdvisingApp\Ai\Models\PromptType;
 use AdvisingApp\Authorization\Enums\LicenseType;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseCount;
@@ -100,4 +101,30 @@ it('can list records', function () use ($licenses, $permissions) {
         ->assertSuccessful()
         ->assertCountTableRecords($records->count())
         ->assertCanSeeTableRecords($records);
+});
+
+it('hides the bulk delete action from a user without the delete permission', function () use ($licenses, $permissions) {
+    actingAs(user(
+        licenses: $licenses,
+        permissions: $permissions
+    ));
+
+    PromptType::factory()->count(2)->create();
+
+    livewire(ListPromptTypes::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the bulk delete action to a user with the delete permission', function () use ($licenses, $permissions) {
+    actingAs(user(
+        licenses: $licenses,
+        permissions: [...$permissions, 'settings.*.delete']
+    ));
+
+    PromptType::factory()->count(2)->create();
+
+    livewire(ListPromptTypes::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/ai/tests/Tenant/Filament/Resources/CustomerAdvisors/Pages/EditCustomerAdvisorTest.php
+++ b/app-modules/ai/tests/Tenant/Filament/Resources/CustomerAdvisors/Pages/EditCustomerAdvisorTest.php
@@ -191,6 +191,7 @@ test('archive action visible when Customer Advisor is not archived', function ()
     $user->givePermissionTo('customer_advisor.view-any');
     $user->givePermissionTo('customer_advisor.*.view');
     $user->givePermissionTo('customer_advisor.*.update');
+    $user->givePermissionTo('customer_advisor.*.delete');
 
     actingAs($user);
 
@@ -218,6 +219,7 @@ test('restore action visible when Customer Advisor is archived', function () {
     $user->givePermissionTo('customer_advisor.view-any');
     $user->givePermissionTo('customer_advisor.*.view');
     $user->givePermissionTo('customer_advisor.*.update');
+    $user->givePermissionTo('customer_advisor.*.restore');
 
     actingAs($user);
 

--- a/app-modules/ai/tests/Tenant/Filament/Resources/CustomerAdvisors/Pages/ViewCustomerAdvisorTest.php
+++ b/app-modules/ai/tests/Tenant/Filament/Resources/CustomerAdvisors/Pages/ViewCustomerAdvisorTest.php
@@ -86,6 +86,7 @@ test('archive action visible when Customer Advisor is not archived', function ()
 
     $user->givePermissionTo('customer_advisor.view-any');
     $user->givePermissionTo('customer_advisor.*.view');
+    $user->givePermissionTo('customer_advisor.*.delete');
 
     actingAs($user);
 
@@ -112,6 +113,7 @@ test('restore action visible when Customer Advisor is archived', function () {
 
     $user->givePermissionTo('customer_advisor.view-any');
     $user->givePermissionTo('customer_advisor.*.view');
+    $user->givePermissionTo('customer_advisor.*.restore');
 
     actingAs($user);
 

--- a/app-modules/application/src/Filament/Resources/Applications/Pages/ListApplications.php
+++ b/app-modules/application/src/Filament/Resources/Applications/Pages/ListApplications.php
@@ -112,7 +112,8 @@ class ListApplications extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultSort('created_at', 'desc');

--- a/app-modules/application/src/Filament/Resources/Applications/Pages/ManageApplicationSubmissions.php
+++ b/app-modules/application/src/Filament/Resources/Applications/Pages/ManageApplicationSubmissions.php
@@ -229,7 +229,8 @@ class ManageApplicationSubmissions extends ManageRelatedRecords
 
                             return Excel::download(new ApplicationSubmissionExport($records), $filename);
                         }),
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/application/src/Filament/Resources/Applications/Pages/ManageApplicationWorkflows.php
+++ b/app-modules/application/src/Filament/Resources/Applications/Pages/ManageApplicationWorkflows.php
@@ -153,6 +153,7 @@ class ManageApplicationWorkflows extends ManageRelatedRecords
     public function getHeaderActions(): array
     {
         $action = Action::make('create')
+            ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
             ->label('Create New Workflow')
             ->slideOver()
             ->modalHeading('Create New Workflow')

--- a/app-modules/application/src/Livewire/ApplicationSubmissionsChecklist.php
+++ b/app-modules/application/src/Livewire/ApplicationSubmissionsChecklist.php
@@ -75,6 +75,8 @@ class ApplicationSubmissionsChecklist extends Component implements HasForms, Has
 
     public function addChecklistItem(): void
     {
+        abort_unless(auth()->user()?->can('application.*.update') ?? false, 403);
+
         $this->validate(
             rules: [
                 'data.title' => ['required', 'string', 'max:255'],
@@ -108,6 +110,8 @@ class ApplicationSubmissionsChecklist extends Component implements HasForms, Has
 
     public function toggleItem(string $itemId): void
     {
+        abort_unless(auth()->user()?->can('application.*.update') ?? false, 403);
+
         $item = $this->applicationSubmission->checklistItems()->where('id', $itemId)->first();
 
         if ($item instanceof ApplicationSubmissionsChecklistItem) {
@@ -123,6 +127,8 @@ class ApplicationSubmissionsChecklist extends Component implements HasForms, Has
 
     public function deleteItem(string $itemId): void
     {
+        abort_unless(auth()->user()?->can('application.*.update') ?? false, 403);
+
         $this->applicationSubmission->checklistItems()->find($itemId)?->delete();
     }
 

--- a/app-modules/application/src/Policies/ApplicationPolicy.php
+++ b/app-modules/application/src/Policies/ApplicationPolicy.php
@@ -87,6 +87,14 @@ class ApplicationPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function replicate(Authenticatable $authenticatable, Application $application): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'application.create',
+            denyResponse: 'You do not have permission to duplicate this application.'
+        );
+    }
+
     public function update(Authenticatable $authenticatable, Application $application): Response
     {
         return $authenticatable->canOrElse(
@@ -103,6 +111,14 @@ class ApplicationPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['application.*.delete'],
+            denyResponse: 'You do not have permission to delete any application.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Application $application): Response
     {
         return $authenticatable->canOrElse(
@@ -111,11 +127,27 @@ class ApplicationPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['application.*.restore'],
+            denyResponse: 'You do not have permission to restore any application.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Application $application): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['application.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this application.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['application.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any application.'
         );
     }
 

--- a/app-modules/application/src/Policies/ApplicationSubmissionPolicy.php
+++ b/app-modules/application/src/Policies/ApplicationSubmissionPolicy.php
@@ -34,51 +34,35 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Prospect\Filament\Resources\Prospects\Actions;
+namespace AdvisingApp\Application\Policies;
 
-use AdvisingApp\Prospect\Enums\SystemProspectClassification;
-use AdvisingApp\Prospect\Models\Prospect;
-use AdvisingApp\Prospect\Models\ProspectStatus;
-use Filament\Actions\Action;
-use Filament\Notifications\Notification;
+use AdvisingApp\Application\Models\ApplicationSubmission;
+use App\Models\Authenticatable;
+use Illuminate\Auth\Access\Response;
 
-class DisassociateStudent extends Action
+class ApplicationSubmissionPolicy
 {
-    protected function setUp(): void
+    public function update(Authenticatable $authenticatable, ApplicationSubmission $applicationSubmission): Response
     {
-        parent::setUp();
-
-        $this
-            ->authorize(fn (): bool => auth()->user()->can('prospect.*.update'))
-            ->modalHeading('Disassociate Prospect from Student?')
-            ->requiresConfirmation()
-            ->color('danger')
-            ->modalSubmitActionLabel('Yes')
-            ->action(function (Prospect $record) {
-                /** @var Prospect $record */
-                $record->student()->dissociate();
-
-                $record->status()->associate(
-                    ProspectStatus::query()
-                        ->where('classification', SystemProspectClassification::New)
-                        ->where('name', 'New')
-                        ->where('is_system_protected', true)
-                        ->firstOrFail()
-                );
-
-                $record->save();
-
-                $this->dispatch('reload-prospect');
-
-                Notification::make()
-                    ->title('Prospect disassociated from Student')
-                    ->success()
-                    ->send();
-            });
+        return $authenticatable->canOrElse(
+            abilities: ['application.*.update'],
+            denyResponse: 'You do not have permission to update this application submission.'
+        );
     }
 
-    public static function getDefaultName(): ?string
+    public function delete(Authenticatable $authenticatable, ApplicationSubmission $applicationSubmission): Response
     {
-        return 'disassociate';
+        return $authenticatable->canOrElse(
+            abilities: ['application.*.update'],
+            denyResponse: 'You do not have permission to delete this application submission.'
+        );
+    }
+
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['application.*.update'],
+            denyResponse: 'You do not have permission to delete application submissions.'
+        );
     }
 }

--- a/app-modules/application/src/Policies/ApplicationSubmissionStatePolicy.php
+++ b/app-modules/application/src/Policies/ApplicationSubmissionStatePolicy.php
@@ -104,6 +104,14 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any state.'
+        );
+    }
+
     public function archive(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
         return $authenticatable->canOrElse(
@@ -120,6 +128,14 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any state.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, ApplicationSubmissionState $model): Response
     {
         if ($model->submissions()->exists()) {
@@ -129,6 +145,14 @@ class ApplicationSubmissionStatePolicy implements PerformsChecksBeforeAuthorizat
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this state.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any state.'
         );
     }
 

--- a/app-modules/application/tests/Tenant/Application/ListApplicationsTest.php
+++ b/app-modules/application/tests/Tenant/Application/ListApplicationsTest.php
@@ -41,11 +41,55 @@ use AdvisingApp\Application\Models\Application;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\seed;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
+
+function listApplicationsTestUser(): User
+{
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->onlineAdmissions = true;
+    $settings->save();
+
+    return User::factory()->licensed(LicenseType::cases())->create();
+}
+
+it('the delete bulk action is gated by the delete permission', function () {
+    $user = listApplicationsTestUser();
+    $user->givePermissionTo('application.view-any');
+
+    actingAs($user);
+
+    livewire(ListApplications::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('application.*.delete');
+
+    livewire(ListApplications::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});
+
+it('the duplicate action is gated by the create permission', function () {
+    seed(ApplicationSubmissionStateSeeder::class);
+
+    $user = listApplicationsTestUser();
+    $user->givePermissionTo('application.view-any');
+
+    actingAs($user);
+
+    $application = Application::factory()->create();
+
+    livewire(ListApplications::class)
+        ->assertTableActionHidden('Duplicate', $application);
+
+    $user->givePermissionTo('application.create');
+
+    livewire(ListApplications::class)
+        ->assertTableActionVisible('Duplicate', $application);
+});
 
 // TODO: Write ListApplications tests
 //test('The correct details are displayed on the ListApplications page', function () {});

--- a/app-modules/audit/src/Policies/AuditPolicy.php
+++ b/app-modules/audit/src/Policies/AuditPolicy.php
@@ -82,6 +82,14 @@ class AuditPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['audit.*.delete'],
+            denyResponse: 'You do not have permission to delete any audit.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Audit $audit): Response
     {
         return $authenticatable->canOrElse(
@@ -90,11 +98,27 @@ class AuditPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['audit.*.restore'],
+            denyResponse: 'You do not have permission to restore any audit.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Audit $audit): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['audit.*.force-delete'],
             denyResponse: 'You do not have permission to force delete this audit.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['audit.*.force-delete'],
+            denyResponse: 'You do not have permission to force delete any audit.'
         );
     }
 }

--- a/app-modules/authorization/src/Filament/Resources/Roles/Pages/ListRoles.php
+++ b/app-modules/authorization/src/Filament/Resources/Roles/Pages/ListRoles.php
@@ -101,6 +101,7 @@ class ListRoles extends ListRecords
             ])
             ->recordActions([
                 Action::make('duplicateRole')
+                    ->authorize(fn (): bool => auth()->user()->can('role.create'))
                     ->label('Duplicate')
                     ->icon('heroicon-o-document-duplicate')
                     ->requiresConfirmation()

--- a/app-modules/authorization/src/Policies/LicensePolicy.php
+++ b/app-modules/authorization/src/Policies/LicensePolicy.php
@@ -82,6 +82,14 @@ class LicensePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['license.*.delete'],
+            denyResponse: 'You do not have permission to delete any license.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, License $license): Response
     {
         return $authenticatable->canOrElse(
@@ -90,11 +98,27 @@ class LicensePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['license.*.restore'],
+            denyResponse: 'You do not have permission to restore any license.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, License $license): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['license.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this license.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['license.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any license.'
         );
     }
 }

--- a/app-modules/authorization/src/Policies/PermissionPolicy.php
+++ b/app-modules/authorization/src/Policies/PermissionPolicy.php
@@ -67,12 +67,27 @@ class PermissionPolicy
         return Response::deny('Permissions cannot be deleted.');
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('Permissions cannot be deleted.');
+    }
+
     public function restore(Authenticatable $authenticatable, Permission $permission): Response
     {
         return Response::deny('Permissions cannot be restored.');
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('Permissions cannot be restored.');
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Permission $permission): Response
+    {
+        return Response::deny('Permissions cannot be force deleted.');
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
     {
         return Response::deny('Permissions cannot be force deleted.');
     }

--- a/app-modules/authorization/src/Policies/RolePolicy.php
+++ b/app-modules/authorization/src/Policies/RolePolicy.php
@@ -86,6 +86,14 @@ class RolePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['role.*.delete'],
+            denyResponse: 'You do not have permission to delete any role.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Role $role): Response
     {
         return $authenticatable->canOrElse(
@@ -94,11 +102,27 @@ class RolePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['role.*.restore'],
+            denyResponse: 'You do not have permission to restore any role.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Role $role): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['role.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this role.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['role.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any role.'
         );
     }
 }

--- a/app-modules/authorization/tests/Tenant/Feature/Filament/Resources/Users/ListUsersTest.php
+++ b/app-modules/authorization/tests/Tenant/Feature/Filament/Resources/Users/ListUsersTest.php
@@ -41,6 +41,8 @@ use App\Filament\Resources\Users\Actions\AssignLicensesBulkAction;
 use App\Filament\Resources\Users\Pages\ListUsers;
 use App\Models\Authenticatable;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\RestoreBulkAction;
 use Lab404\Impersonate\Services\ImpersonateManager;
 
 use function Pest\Laravel\actingAs;
@@ -149,6 +151,55 @@ it('allows a user to leave impersonate', function () {
 
     expect($second->isImpersonated())->toBeFalse()
         ->and(auth()->id())->toBe($first->id);
+});
+
+it('hides the bulk delete action from a user without the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('user.view-any');
+    actingAs($user);
+
+    User::factory(2)->create();
+
+    livewire(ListUsers::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the bulk delete action to a user with the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('user.view-any', 'user.*.delete');
+    actingAs($user);
+
+    User::factory(2)->create();
+
+    livewire(ListUsers::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});
+
+it('hides the bulk restore action from a user without the restore permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('user.view-any');
+    actingAs($user);
+
+    User::factory(2)->create()->each(fn (User $record) => $record->delete());
+
+    livewire(ListUsers::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionHidden(RestoreBulkAction::class);
+});
+
+it('shows the bulk restore action to a user with the restore permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('user.view-any', 'user.*.restore');
+    actingAs($user);
+
+    User::factory(2)->create()->each(fn (User $record) => $record->delete());
+
+    livewire(ListUsers::class)
+        ->assertSuccessful()
+        ->filterTable('trashed', '0')
+        ->assertTableBulkActionVisible(RestoreBulkAction::class);
 });
 
 it('does not allow a user without permission to assign licenses in bulk', function () {

--- a/app-modules/basic-needs/src/Filament/Resources/BasicNeedsCategories/Pages/ListBasicNeedsCategories.php
+++ b/app-modules/basic-needs/src/Filament/Resources/BasicNeedsCategories/Pages/ListBasicNeedsCategories.php
@@ -85,6 +85,7 @@ class ListBasicNeedsCategories extends ListRecords
             ->toolbarActions([
                 BulkActionGroup::make([
                     BulkAction::make('delete')
+                        ->authorize(fn (): bool => auth()->user()->can('settings.*.delete'))
                         ->requiresConfirmation()
                         ->color('danger')
                         ->icon('heroicon-s-trash')

--- a/app-modules/basic-needs/src/Filament/Resources/BasicNeedsPrograms/Pages/ListBasicNeedsPrograms.php
+++ b/app-modules/basic-needs/src/Filament/Resources/BasicNeedsPrograms/Pages/ListBasicNeedsPrograms.php
@@ -137,7 +137,8 @@ class ListBasicNeedsPrograms extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/basic-needs/src/Policies/BasicNeedsCategoryPolicy.php
+++ b/app-modules/basic-needs/src/Policies/BasicNeedsCategoryPolicy.php
@@ -100,6 +100,14 @@ class BasicNeedsCategoryPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.delete'],
+            denyResponse: 'You do not have permission to delete any basic needs category.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
@@ -108,11 +116,27 @@ class BasicNeedsCategoryPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.restore'],
+            denyResponse: 'You do not have permission to restore any basic needs category.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['settings.*.force-delete'],
             denyResponse: 'You do not have permission to force delete this basic needs category.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.force-delete'],
+            denyResponse: 'You do not have permission to force delete any basic needs category.'
         );
     }
 

--- a/app-modules/basic-needs/src/Policies/BasicNeedsProgramPolicy.php
+++ b/app-modules/basic-needs/src/Policies/BasicNeedsProgramPolicy.php
@@ -100,6 +100,14 @@ class BasicNeedsProgramPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['support_program.*.delete'],
+            denyResponse: 'You do not have permission to delete any basic needs program.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
@@ -108,11 +116,27 @@ class BasicNeedsProgramPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['support_program.*.restore'],
+            denyResponse: 'You do not have permission to restore any basic needs program.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['support_program.*.force-delete'],
             denyResponse: 'You do not have permission to force delete this basic needs program.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['support_program.*.force-delete'],
+            denyResponse: 'You do not have permission to force delete any basic needs program.'
         );
     }
 

--- a/app-modules/basic-needs/tests/Tenant/BasicNeedsProgram/BasicNeedsProgramTest.php
+++ b/app-modules/basic-needs/tests/Tenant/BasicNeedsProgram/BasicNeedsProgramTest.php
@@ -337,6 +337,27 @@ it('can bulk delete basic needs programs', function () {
     }
 });
 
+it('hides the delete bulk action for users without the delete permission', function () {
+    $user = User::factory()->licensed(Student::getLicenseType())->create();
+    $user->givePermissionTo('support_program.view-any');
+
+    actingAs($user);
+
+    livewire(ListBasicNeedsPrograms::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the delete bulk action for users with the delete permission', function () {
+    $user = User::factory()->licensed(Student::getLicenseType())->create();
+    $user->givePermissionTo('support_program.view-any');
+    $user->givePermissionTo('support_program.*.delete');
+
+    actingAs($user);
+
+    livewire(ListBasicNeedsPrograms::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});
+
 it('can filter basic needs program by `program category`', function () {
     $user = User::factory()->licensed(Student::getLicenseType())->create();
     $basicNeedsPrograms = BasicNeedsProgram::factory()->count(10)->create();

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/RelationManagers/CampaignActionsRelationManager.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/RelationManagers/CampaignActionsRelationManager.php
@@ -98,6 +98,7 @@ class CampaignActionsRelationManager extends RelationManager
             ])
             ->headerActions([
                 Action::make('create')
+                    ->authorize(fn (): bool => auth()->user()->can('update', $campaign))
                     ->slideOver()
                     ->label('New')
                     ->modalHeading('Create Journey Steps')
@@ -174,7 +175,8 @@ class CampaignActionsRelationManager extends RelationManager
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ])
                     ->hidden(fn () => $campaign->hasBeenExecuted() === true),
             ]);

--- a/app-modules/campaign/src/Policies/CampaignActionPolicy.php
+++ b/app-modules/campaign/src/Policies/CampaignActionPolicy.php
@@ -81,6 +81,14 @@ class CampaignActionPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['journey_step.*.delete'],
+            denyResponse: 'You do not have permission to delete any journey step.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
@@ -89,11 +97,27 @@ class CampaignActionPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['journey_step.*.restore'],
+            denyResponse: 'You do not have permission to restore any journey step.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['journey_step.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this journey step.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['journey_step.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any journey step.'
         );
     }
 }

--- a/app-modules/campaign/src/Policies/CampaignPolicy.php
+++ b/app-modules/campaign/src/Policies/CampaignPolicy.php
@@ -117,6 +117,14 @@ class CampaignPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['campaign.*.delete'],
+            denyResponse: 'You do not have permission to delete any campaign.'
+        );
+    }
+
     public function archive(Authenticatable $authenticatable, Campaign $campaign): Response
     {
         if ($authenticatable->cannot('view', $campaign->group)) {
@@ -141,6 +149,14 @@ class CampaignPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['campaign.*.restore'],
+            denyResponse: 'You do not have permission to restore any campaign.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Campaign $campaign): Response
     {
         if ($authenticatable->cannot('view', $campaign->group)) {
@@ -150,6 +166,14 @@ class CampaignPolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: ['campaign.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this campaign.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['campaign.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any campaign.'
         );
     }
 }

--- a/app-modules/care-team/src/Filament/Actions/AddCareTeamMemberToEducatableAttachAction.php
+++ b/app-modules/care-team/src/Filament/Actions/AddCareTeamMemberToEducatableAttachAction.php
@@ -63,7 +63,8 @@ class AddCareTeamMemberToEducatableAttachAction extends AttachAction
     {
         parent::setUp();
 
-        $this->label('New')
+        $this->authorize(fn (): bool => auth()->user()->can('create', CareTeam::class))
+            ->label('New')
             ->slideOver()
             ->modalHeading(fn () => "Add Users to {$this->getLivewire()->getOwnerRecord()->display_name}'s Care Team")
             ->modalSubmitActionLabel('Add')

--- a/app-modules/care-team/src/Filament/Resources/ProspectCareTeamRoles/Pages/ListProspectCareTeamRoles.php
+++ b/app-modules/care-team/src/Filament/Resources/ProspectCareTeamRoles/Pages/ListProspectCareTeamRoles.php
@@ -77,7 +77,8 @@ class ListProspectCareTeamRoles extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/care-team/src/Filament/Resources/StudentCareTeamRoles/Pages/ListStudentCareTeamRoles.php
+++ b/app-modules/care-team/src/Filament/Resources/StudentCareTeamRoles/Pages/ListStudentCareTeamRoles.php
@@ -77,7 +77,8 @@ class ListStudentCareTeamRoles extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/care-team/src/Policies/CareTeamPolicy.php
+++ b/app-modules/care-team/src/Policies/CareTeamPolicy.php
@@ -82,6 +82,14 @@ class CareTeamPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['care_team.*.delete'],
+            denyResponse: 'You do not have permission to delete any care team.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, CareTeam $careTeam): Response
     {
         return $authenticatable->canOrElse(
@@ -90,11 +98,27 @@ class CareTeamPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['care_team.*.restore'],
+            denyResponse: 'You do not have permission to restore any care team.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, CareTeam $careTeam): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['care_team.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this care team.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['care_team.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any care team.'
         );
     }
 }

--- a/app-modules/care-team/src/Policies/CareTeamRolePolicy.php
+++ b/app-modules/care-team/src/Policies/CareTeamRolePolicy.php
@@ -82,6 +82,14 @@ class CareTeamRolePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.delete'],
+            denyResponse: 'You do not have permission to delete any care team role.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, CareTeamRole $careTeamRole): Response
     {
         return $authenticatable->canOrElse(
@@ -90,11 +98,27 @@ class CareTeamRolePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.restore'],
+            denyResponse: 'You do not have permission to restore any care team role.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, CareTeamRole $careTeamRole): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['settings.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this care team role.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any care team role.'
         );
     }
 }

--- a/app-modules/care-team/tests/Tenant/Filament/Actions/AddCareTeamMemberToEducatableAttachActionTest.php
+++ b/app-modules/care-team/tests/Tenant/Filament/Actions/AddCareTeamMemberToEducatableAttachActionTest.php
@@ -46,6 +46,7 @@ use App\Models\User;
 use Filament\Actions\Testing\TestAction;
 use Filament\Forms\Components\Repeater;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
@@ -183,4 +184,24 @@ it('can attach users with care team roles to a prospect', function () {
     expect($prospect->careTeam->pluck('id'))->toContain($user2->getKey());
     expect(CareTeam::where('user_id', $user1->getKey())->where('educatable_id', $prospect->getKey())->first()->care_team_role_id)->toBe($careTeamRole1->getKey());
     expect(CareTeam::where('user_id', $user2->getKey())->where('educatable_id', $prospect->getKey())->first()->care_team_role_id)->toBe($careTeamRole2->getKey());
+});
+
+it('gates the care team attach action behind the care_team.create permission', function () {
+    $student = Student::factory()->create();
+
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('student.view-any');
+    $user->givePermissionTo('student.*.view');
+    $user->givePermissionTo('care_team.view-any');
+
+    actingAs($user);
+
+    // Can reach the care team page (view + care_team.view-any) but cannot add members without create.
+    livewire(ManageStudentCareTeam::class, ['record' => $student->getKey()])
+        ->assertActionHidden(TestAction::make('attach')->table());
+
+    $user->givePermissionTo('care_team.create');
+
+    livewire(ManageStudentCareTeam::class, ['record' => $student->getKey()])
+        ->assertActionVisible(TestAction::make('attach')->table());
 });

--- a/app-modules/care-team/tests/Tenant/ProspectCareTeamRole/ListProspectCareTeamRoleTest.php
+++ b/app-modules/care-team/tests/Tenant/ProspectCareTeamRole/ListProspectCareTeamRoleTest.php
@@ -40,6 +40,7 @@ use AdvisingApp\CareTeam\Models\CareTeamRole;
 use AdvisingApp\Prospect\Models\Prospect;
 use App\Enums\CareTeamRoleType;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -101,4 +102,22 @@ test('The correct details are displayed on the ListProspectCareTeamRole page', f
                 $careTeamRole
             )
     );
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(Prospect::getLicenseType())->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListProspectCareTeamRoles::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListProspectCareTeamRoles::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/care-team/tests/Tenant/StudentCareTeamRole/ListStudentCareTeamRoleTest.php
+++ b/app-modules/care-team/tests/Tenant/StudentCareTeamRole/ListStudentCareTeamRoleTest.php
@@ -40,6 +40,7 @@ use AdvisingApp\CareTeam\Models\CareTeamRole;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Enums\CareTeamRoleType;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -92,4 +93,22 @@ test('The correct details are displayed on the ListStudentCareTeamRole page', fu
                 $careTeamRole
             )
     );
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(Student::getLicenseType())->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListStudentCareTeamRoles::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListStudentCareTeamRoles::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/case-management/src/Filament/Resources/CaseForms/Pages/ListCaseForms.php
+++ b/app-modules/case-management/src/Filament/Resources/CaseForms/Pages/ListCaseForms.php
@@ -69,7 +69,8 @@ class ListCaseForms extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/case-management/src/Filament/Resources/CaseStatuses/Pages/ListCaseStatuses.php
+++ b/app-modules/case-management/src/Filament/Resources/CaseStatuses/Pages/ListCaseStatuses.php
@@ -83,7 +83,8 @@ class ListCaseStatuses extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->filters([

--- a/app-modules/case-management/src/Filament/Resources/CaseTypes/Pages/ListCaseTypes.php
+++ b/app-modules/case-management/src/Filament/Resources/CaseTypes/Pages/ListCaseTypes.php
@@ -76,7 +76,8 @@ class ListCaseTypes extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->filters([

--- a/app-modules/case-management/src/Filament/Resources/CaseTypes/RelationManagers/CasePrioritiesRelationManager.php
+++ b/app-modules/case-management/src/Filament/Resources/CaseTypes/RelationManagers/CasePrioritiesRelationManager.php
@@ -111,7 +111,8 @@ class CasePrioritiesRelationManager extends RelationManager
                 DeleteAction::make(),
             ])
             ->groupedBulkActions([
-                DeleteBulkAction::make(),
+                DeleteBulkAction::make()
+                    ->authorizeIndividualRecords('delete'),
             ]);
     }
 }

--- a/app-modules/case-management/src/Filament/Resources/CaseTypes/RelationManagers/CasePrioritiesRelationManager.php
+++ b/app-modules/case-management/src/Filament/Resources/CaseTypes/RelationManagers/CasePrioritiesRelationManager.php
@@ -102,6 +102,7 @@ class CasePrioritiesRelationManager extends RelationManager
             ])
             ->defaultSort('order')
             ->reorderable('order')
+            ->authorizeReorder(fn (): bool => auth()->user()->can('product_admin.*.update'))
             ->paginated(false)
             ->headerActions([
                 CreateAction::make(),

--- a/app-modules/case-management/src/Filament/Resources/CaseUpdates/CaseUpdateResource.php
+++ b/app-modules/case-management/src/Filament/Resources/CaseUpdates/CaseUpdateResource.php
@@ -178,7 +178,8 @@ class CaseUpdateResource extends Resource
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/case-management/src/Filament/Resources/Cases/Pages/ListCases.php
+++ b/app-modules/case-management/src/Filament/Resources/Cases/Pages/ListCases.php
@@ -179,7 +179,8 @@ class ListCases extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultSort('created_at', 'desc')

--- a/app-modules/case-management/src/Filament/Resources/Cases/RelationManagers/CaseUpdatesRelationManager.php
+++ b/app-modules/case-management/src/Filament/Resources/Cases/RelationManagers/CaseUpdatesRelationManager.php
@@ -113,7 +113,8 @@ class CaseUpdatesRelationManager extends RelationManager
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/case-management/src/Filament/Resources/Slas/Pages/ListSlas.php
+++ b/app-modules/case-management/src/Filament/Resources/Slas/Pages/ListSlas.php
@@ -61,7 +61,8 @@ class ListSlas extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/case-management/src/Policies/CaseAssignmentPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseAssignmentPolicy.php
@@ -102,6 +102,14 @@ class CaseAssignmentPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case_assignment.*.delete'],
+            denyResponse: 'You do not have permissions to delete any case assignment.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, CaseAssignment $caseAssignment): Response
     {
         return $authenticatable->canOrElse(
@@ -110,11 +118,27 @@ class CaseAssignmentPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case_assignment.*.restore'],
+            denyResponse: 'You do not have permissions to restore any case assignment.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, CaseAssignment $caseAssignment): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['case_assignment.*.force-delete'],
             denyResponse: 'You do not have permissions to force delete this case assignment.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case_assignment.*.force-delete'],
+            denyResponse: 'You do not have permissions to force delete any case assignment.'
         );
     }
 

--- a/app-modules/case-management/src/Policies/CaseFormPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseFormPolicy.php
@@ -103,6 +103,14 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.delete'],
+            denyResponse: 'You do not have permission to delete any case form.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
         return $authenticatable->canOrElse(
@@ -111,11 +119,27 @@ class CaseFormPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.restore'],
+            denyResponse: 'You do not have permission to restore any case form.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, CaseForm $caseForm): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['settings.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this case form.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any case form.'
         );
     }
 

--- a/app-modules/case-management/src/Policies/CaseHistoryPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseHistoryPolicy.php
@@ -102,6 +102,14 @@ class CaseHistoryPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case_history.*.delete'],
+            denyResponse: 'You do not have permissions to delete any case history.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, CaseHistory $caseHistory): Response
     {
         return $authenticatable->canOrElse(
@@ -110,11 +118,27 @@ class CaseHistoryPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case_history.*.restore'],
+            denyResponse: 'You do not have permissions to restore any case history.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, CaseHistory $caseHistory): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['case_history.*.force-delete'],
             denyResponse: 'You do not have permissions to force delete this case history.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case_history.*.force-delete'],
+            denyResponse: 'You do not have permissions to force delete any case history.'
         );
     }
 

--- a/app-modules/case-management/src/Policies/CaseModelPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseModelPolicy.php
@@ -131,6 +131,14 @@ class CaseModelPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case.*.delete'],
+            denyResponse: 'You do not have permission to delete any case.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, CaseModel $case): Response
     {
         /** @var Student|Prospect|null $respondent */
@@ -146,6 +154,14 @@ class CaseModelPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case.*.restore'],
+            denyResponse: 'You do not have permission to restore any case.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, CaseModel $case): Response
     {
         /** @var Student|Prospect|null $respondent */
@@ -158,6 +174,14 @@ class CaseModelPolicy
         return $authenticatable->canOrElse(
             abilities: ['case.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this case.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any case.'
         );
     }
 

--- a/app-modules/case-management/src/Policies/CasePriorityPolicy.php
+++ b/app-modules/case-management/src/Policies/CasePriorityPolicy.php
@@ -102,6 +102,14 @@ class CasePriorityPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['product_admin.*.delete'],
+            denyResponse: 'You do not have permissions to delete any case priority.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, CasePriority $casePriority): Response
     {
         return $authenticatable->canOrElse(
@@ -110,11 +118,27 @@ class CasePriorityPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['product_admin.*.restore'],
+            denyResponse: 'You do not have permissions to restore any case priority.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, CasePriority $casePriority): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['product_admin.*.force-delete'],
             denyResponse: 'You do not have permissions to force delete this case priority.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['product_admin.*.force-delete'],
+            denyResponse: 'You do not have permissions to force delete any case priority.'
         );
     }
 

--- a/app-modules/case-management/src/Policies/CaseStatusPolicy.php
+++ b/app-modules/case-management/src/Policies/CaseStatusPolicy.php
@@ -102,11 +102,27 @@ class CaseStatusPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.delete'],
+            denyResponse: 'You do not have permissions to delete any case status.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, CaseStatus $caseStatus): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['settings.*.restore'],
             denyResponse: 'You do not have permissions to restore this case status.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.restore'],
+            denyResponse: 'You do not have permissions to restore any case status.'
         );
     }
 
@@ -119,6 +135,14 @@ class CaseStatusPolicy
         return $authenticatable->canOrElse(
             abilities: ['settings.*.force-delete'],
             denyResponse: 'You do not have permissions to force delete this case status.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.force-delete'],
+            denyResponse: 'You do not have permissions to force delete any case status.'
         );
     }
 

--- a/app-modules/case-management/src/Policies/CaseTypePolicy.php
+++ b/app-modules/case-management/src/Policies/CaseTypePolicy.php
@@ -102,11 +102,27 @@ class CaseTypePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.delete'],
+            denyResponse: 'You do not have permissions to delete any case type.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, CaseType $caseType): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['settings.*.restore'],
             denyResponse: 'You do not have permissions to restore this case type.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.restore'],
+            denyResponse: 'You do not have permissions to restore any case type.'
         );
     }
 
@@ -119,6 +135,14 @@ class CaseTypePolicy
         return $authenticatable->canOrElse(
             abilities: ['settings.*.force-delete'],
             denyResponse: 'You do not have permissions to force-delete this case type.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.force-delete'],
+            denyResponse: 'You do not have permissions to force-delete any case type.'
         );
     }
 

--- a/app-modules/case-management/src/Policies/CaseUpdatePolicy.php
+++ b/app-modules/case-management/src/Policies/CaseUpdatePolicy.php
@@ -102,6 +102,14 @@ class CaseUpdatePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case_update.*.delete'],
+            denyResponse: 'You do not have permissions to delete any case update.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, CaseUpdate $caseUpdate): Response
     {
         return $authenticatable->canOrElse(
@@ -110,11 +118,27 @@ class CaseUpdatePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case_update.*.restore'],
+            denyResponse: 'You do not have permissions to restore any case update.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, CaseUpdate $caseUpdate): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['case_update.*.force-delete'],
             denyResponse: 'You do not have permissions to force delete this case update.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['case_update.*.force-delete'],
+            denyResponse: 'You do not have permissions to force delete any case update.'
         );
     }
 

--- a/app-modules/case-management/src/Policies/SlaPolicy.php
+++ b/app-modules/case-management/src/Policies/SlaPolicy.php
@@ -102,6 +102,14 @@ class SlaPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.delete'],
+            denyResponse: 'You do not have permission to delete any SLA.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Sla $sla): Response
     {
         return $authenticatable->canOrElse(
@@ -110,11 +118,27 @@ class SlaPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.restore'],
+            denyResponse: 'You do not have permission to restore any SLA.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Sla $sla): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['settings.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this SLA.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any SLA.'
         );
     }
 

--- a/app-modules/case-management/tests/Tenant/Case/ListCasesTest.php
+++ b/app-modules/case-management/tests/Tenant/Case/ListCasesTest.php
@@ -42,6 +42,7 @@ use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -146,4 +147,22 @@ test('ListCases is gated with proper feature access control', function () {
         ->get(
             CaseResource::getUrl()
         )->assertSuccessful();
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
+
+    $user->givePermissionTo('case.view-any');
+
+    actingAs($user);
+
+    livewire(ListCases::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('case.*.delete');
+
+    livewire(ListCases::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/case-management/tests/Tenant/CaseForm/ListCaseFormsTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseForm/ListCaseFormsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\CaseManagement\Filament\Resources\CaseForms\Pages\ListCaseForms;
+use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Models\Student;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListCaseForms::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListCaseForms::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});

--- a/app-modules/case-management/tests/Tenant/CaseStatus/ListCaseStatusesTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseStatus/ListCaseStatusesTest.php
@@ -42,6 +42,7 @@ use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -134,4 +135,22 @@ test('ListCaseStatuses is gated with proper feature access control', function ()
         ->get(
             CaseStatusResource::getUrl()
         )->assertSuccessful();
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListCaseStatuses::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListCaseStatuses::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/case-management/tests/Tenant/CaseType/ListCaseTypeTest.php
+++ b/app-modules/case-management/tests/Tenant/CaseType/ListCaseTypeTest.php
@@ -42,6 +42,7 @@ use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -124,4 +125,22 @@ test('ListCaseTypes is gated with proper feature access control', function () {
         ->get(
             CaseTypeResource::getUrl()
         )->assertSuccessful();
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListCaseTypes::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListCaseTypes::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/case-management/tests/Tenant/Filament/Resources/CaseTypes/Pages/ManageCaseTypeAuditorsTest.php
+++ b/app-modules/case-management/tests/Tenant/Filament/Resources/CaseTypes/Pages/ManageCaseTypeAuditorsTest.php
@@ -59,6 +59,7 @@ it('can attach audit member to case type', function () {
         )->assertForbidden();
 
     $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
     $user->givePermissionTo('team.view-any');
 
     livewire(ManageCaseTypeAuditors::class, [

--- a/app-modules/case-management/tests/Tenant/Filament/Resources/CaseTypes/Pages/ManageCaseTypeManagersTest.php
+++ b/app-modules/case-management/tests/Tenant/Filament/Resources/CaseTypes/Pages/ManageCaseTypeManagersTest.php
@@ -59,6 +59,7 @@ it('can attach team member to case type', function () {
         )->assertForbidden();
 
     $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.update');
     $user->givePermissionTo('team.view-any');
 
     livewire(ManageCaseTypeManagers::class, [

--- a/app-modules/case-management/tests/Tenant/Sla/ListSlasTest.php
+++ b/app-modules/case-management/tests/Tenant/Sla/ListSlasTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\CaseManagement\Filament\Resources\Slas\Pages\ListSlas;
+use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Models\Student;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed([Student::getLicenseType(), Prospect::getLicenseType()])->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListSlas::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListSlas::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});

--- a/app-modules/concern/src/Filament/Resources/ConcernStatuses/Pages/ListConcernStatuses.php
+++ b/app-modules/concern/src/Filament/Resources/ConcernStatuses/Pages/ListConcernStatuses.php
@@ -74,6 +74,7 @@ class ListConcernStatuses extends ListRecords
             ])
             ->defaultSort('order')
             ->reorderable('order')
+            ->authorizeReorder(fn (): bool => auth()->user()->can('settings.*.update'))
             ->recordActions([
                 ViewAction::make(),
                 EditAction::make(),

--- a/app-modules/concern/src/Filament/Resources/Concerns/Pages/ListConcerns.php
+++ b/app-modules/concern/src/Filament/Resources/Concerns/Pages/ListConcerns.php
@@ -163,7 +163,8 @@ class ListConcerns extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultSort('created_at', 'desc');

--- a/app-modules/concern/src/Policies/ConcernPolicy.php
+++ b/app-modules/concern/src/Policies/ConcernPolicy.php
@@ -113,6 +113,14 @@ class ConcernPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['concern.*.delete'],
+            denyResponse: 'You do not have permission to delete any concern.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Concern $concern): Response
     {
         if (! $authenticatable->hasLicense($concern->concern?->getLicenseType())) {
@@ -125,6 +133,14 @@ class ConcernPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['concern.*.restore'],
+            denyResponse: 'You do not have permission to restore any concern.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Concern $concern): Response
     {
         if (! $authenticatable->hasLicense($concern->concern?->getLicenseType())) {
@@ -134,6 +150,14 @@ class ConcernPolicy
         return $authenticatable->canOrElse(
             abilities: ['concern.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this concern.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['concern.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any concern.'
         );
     }
 }

--- a/app-modules/concern/src/Policies/ConcernStatusPolicy.php
+++ b/app-modules/concern/src/Policies/ConcernStatusPolicy.php
@@ -97,11 +97,27 @@ class ConcernStatusPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.delete'],
+            denyResponse: 'You do not have permission to delete any concern status.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, ConcernStatus $concernStatus): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['settings.*.restore'],
             denyResponse: 'You do not have permission to restore this concern status.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.restore'],
+            denyResponse: 'You do not have permission to restore any concern status.'
         );
     }
 
@@ -114,6 +130,14 @@ class ConcernStatusPolicy
         return $authenticatable->canOrElse(
             abilities: ['settings.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this concern status.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any concern status.'
         );
     }
 }

--- a/app-modules/concern/tests/Tenant/Filament/Resources/Concerns/ListConcernsTest.php
+++ b/app-modules/concern/tests/Tenant/Filament/Resources/Concerns/ListConcernsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\Concern\Filament\Resources\Concerns\Pages\ListConcerns;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+it('hides the delete bulk action for users without the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('concern.view-any');
+
+    actingAs($user);
+
+    livewire(ListConcerns::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the delete bulk action for users with the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('concern.view-any');
+    $user->givePermissionTo('concern.*.delete');
+
+    actingAs($user);
+
+    livewire(ListConcerns::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});

--- a/app-modules/consent/src/Policies/ConsentAgreementPolicy.php
+++ b/app-modules/consent/src/Policies/ConsentAgreementPolicy.php
@@ -98,12 +98,27 @@ class ConsentAgreementPolicy
         return Response::deny('Consent Agreements cannot be deleted.');
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('Consent Agreements cannot be deleted.');
+    }
+
     public function restore(Authenticatable $authenticatable, ConsentAgreement $agreement): Response
     {
         return Response::deny('Consent Agreements cannot be restored.');
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('Consent Agreements cannot be restored.');
+    }
+
     public function forceDelete(Authenticatable $authenticatable, ConsentAgreement $agreement): Response
+    {
+        return Response::deny('Consent Agreements cannot be permanently deleted.');
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
     {
         return Response::deny('Consent Agreements cannot be permanently deleted.');
     }

--- a/app-modules/division/src/Filament/Resources/Divisions/Pages/ListDivisions.php
+++ b/app-modules/division/src/Filament/Resources/Divisions/Pages/ListDivisions.php
@@ -83,7 +83,8 @@ class ListDivisions extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/division/src/Policies/DivisionPolicy.php
+++ b/app-modules/division/src/Policies/DivisionPolicy.php
@@ -82,6 +82,14 @@ class DivisionPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['division.*.delete'],
+            denyResponse: 'You do not have permission to delete any division.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Division $division): Response
     {
         return $authenticatable->canOrElse(
@@ -90,11 +98,27 @@ class DivisionPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['division.*.restore'],
+            denyResponse: 'You do not have permission to restore any division.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Division $division): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['division.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this division.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['division.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any division.'
         );
     }
 }

--- a/app-modules/division/tests/Tenant/Filament/Divisions/ListDivisionsTest.php
+++ b/app-modules/division/tests/Tenant/Filament/Divisions/ListDivisionsTest.php
@@ -35,9 +35,12 @@
 */
 
 use AdvisingApp\Division\Filament\Resources\Divisions\DivisionResource;
+use AdvisingApp\Division\Filament\Resources\Divisions\Pages\ListDivisions;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 
 test('ListDivisions is gated with proper access control', function () {
     $user = User::factory()->create();
@@ -53,4 +56,25 @@ test('ListDivisions is gated with proper access control', function () {
         ->get(
             DivisionResource::getUrl('index')
         )->assertSuccessful();
+});
+
+test('the delete bulk action is hidden for users without the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('division.view-any');
+
+    actingAs($user);
+
+    livewire(ListDivisions::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+test('the delete bulk action is visible for users with the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('division.view-any');
+    $user->givePermissionTo('division.*.delete');
+
+    actingAs($user);
+
+    livewire(ListDivisions::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/engagement/src/Filament/Resources/EmailTemplates/Pages/ListEmailTemplates.php
+++ b/app-modules/engagement/src/Filament/Resources/EmailTemplates/Pages/ListEmailTemplates.php
@@ -61,7 +61,8 @@ class ListEmailTemplates extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/engagement/src/Filament/Resources/EngagementFiles/Pages/ListEngagementFiles.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementFiles/Pages/ListEngagementFiles.php
@@ -67,7 +67,8 @@ class ListEngagementFiles extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/engagement/src/Filament/Resources/EngagementFiles/RelationManagers/EngagementFilesRelationManager.php
+++ b/app-modules/engagement/src/Filament/Resources/EngagementFiles/RelationManagers/EngagementFilesRelationManager.php
@@ -147,7 +147,8 @@ class EngagementFilesRelationManager extends RelationManager
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/engagement/src/Filament/Resources/SmsTemplates/Pages/ListSmsTemplates.php
+++ b/app-modules/engagement/src/Filament/Resources/SmsTemplates/Pages/ListSmsTemplates.php
@@ -61,7 +61,8 @@ class ListSmsTemplates extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/EmailTemplatePolicy.php
@@ -93,6 +93,14 @@ class EmailTemplatePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any email template.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
         return $authenticatable->canOrElse(
@@ -101,11 +109,27 @@ class EmailTemplatePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any email template.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, EmailTemplate $emailTemplate): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this email template.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any email template.'
         );
     }
 }

--- a/app-modules/engagement/src/Policies/EngagementFilePolicy.php
+++ b/app-modules/engagement/src/Policies/EngagementFilePolicy.php
@@ -91,6 +91,14 @@ class EngagementFilePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['engagement_file.*.delete'],
+            denyResponse: 'You do not have permissions to delete any engagement file.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, EngagementFile $engagementFile): Response
     {
         return $authenticatable->canOrElse(
@@ -99,11 +107,27 @@ class EngagementFilePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['engagement_file.*.restore'],
+            denyResponse: 'You do not have permissions to restore any engagement file.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, EngagementFile $engagementFile): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['engagement_file.*.force-delete'],
             denyResponse: 'You do not have permissions to force delete this engagement file.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['engagement_file.*.force-delete'],
+            denyResponse: 'You do not have permissions to force delete any engagement file.'
         );
     }
 }

--- a/app-modules/engagement/src/Policies/EngagementPolicy.php
+++ b/app-modules/engagement/src/Policies/EngagementPolicy.php
@@ -117,6 +117,14 @@ class EngagementPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['engagement.*.delete'],
+            denyResponse: 'You do not have permission to delete any engagement.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Engagement $engagement): Response
     {
         if (! $authenticatable->hasLicense($engagement->recipient?->getLicenseType())) {
@@ -126,6 +134,14 @@ class EngagementPolicy
         return $authenticatable->canOrElse(
             abilities: ['engagement.*.restore'],
             denyResponse: 'You do not have permission to restore this engagement.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['engagement.*.restore'],
+            denyResponse: 'You do not have permission to restore any engagement.'
         );
     }
 
@@ -142,6 +158,14 @@ class EngagementPolicy
         return $authenticatable->canOrElse(
             abilities: ['engagement.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this engagement.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['engagement.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any engagement.'
         );
     }
 }

--- a/app-modules/engagement/src/Policies/EngagementResponsePolicy.php
+++ b/app-modules/engagement/src/Policies/EngagementResponsePolicy.php
@@ -82,6 +82,14 @@ class EngagementResponsePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['engagement_response.*.delete'],
+            denyResponse: 'You do not have permission to delete any engagement response.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, EngagementResponse $engagementResponse): Response
     {
         return $authenticatable->canOrElse(
@@ -90,11 +98,27 @@ class EngagementResponsePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['engagement_response.*.restore'],
+            denyResponse: 'You do not have permission to restore any engagement response.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, EngagementResponse $engagementResponse): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['engagement_response.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this engagement response.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['engagement_response.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any engagement response.'
         );
     }
 }

--- a/app-modules/engagement/src/Policies/SmsTemplatePolicy.php
+++ b/app-modules/engagement/src/Policies/SmsTemplatePolicy.php
@@ -93,6 +93,14 @@ class SmsTemplatePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any sms template.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
         return $authenticatable->canOrElse(
@@ -101,11 +109,27 @@ class SmsTemplatePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any sms template.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, SmsTemplate $smsTemplate): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this sms template.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any sms template.'
         );
     }
 }

--- a/app-modules/engagement/tests/Tenant/Feature/EngagementFile/ListEngagementFileTest.php
+++ b/app-modules/engagement/tests/Tenant/Feature/EngagementFile/ListEngagementFileTest.php
@@ -36,9 +36,12 @@
 
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Engagement\Filament\Resources\EngagementFiles\EngagementFileResource;
+use AdvisingApp\Engagement\Filament\Resources\EngagementFiles\Pages\ListEngagementFiles;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 
 // TODO: Add tests for the ListEngagementFiles
 //test('The correct details are displayed on the ListEngagementFiles page', function () {});
@@ -61,4 +64,25 @@ test('ListEngagementFiles is gated with proper access control', function () {
         ->get(
             EngagementFileResource::getUrl('index')
         )->assertSuccessful();
+});
+
+it('hides the delete bulk action for users without the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('engagement_file.view-any');
+
+    actingAs($user);
+
+    livewire(ListEngagementFiles::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the delete bulk action for users with the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('engagement_file.view-any');
+    $user->givePermissionTo('engagement_file.*.delete');
+
+    actingAs($user);
+
+    livewire(ListEngagementFiles::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/engagement/tests/Tenant/Filament/Resources/EmailTemplates/ListEmailTemplatesTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Resources/EmailTemplates/ListEmailTemplatesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\Engagement\Filament\Resources\EmailTemplates\Pages\ListEmailTemplates;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+it('hides the delete bulk action for users without the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListEmailTemplates::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the delete bulk action for users with the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.delete');
+
+    actingAs($user);
+
+    livewire(ListEmailTemplates::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});

--- a/app-modules/engagement/tests/Tenant/Filament/Resources/SmsTemplates/ListSmsTemplatesTest.php
+++ b/app-modules/engagement/tests/Tenant/Filament/Resources/SmsTemplates/ListSmsTemplatesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\Engagement\Filament\Resources\SmsTemplates\Pages\ListSmsTemplates;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+it('hides the delete bulk action for users without the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListSmsTemplates::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the delete bulk action for users with the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('settings.view-any');
+    $user->givePermissionTo('settings.*.delete');
+
+    actingAs($user);
+
+    livewire(ListSmsTemplates::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});

--- a/app-modules/form/src/Filament/Resources/Forms/Pages/ListForms.php
+++ b/app-modules/form/src/Filament/Resources/Forms/Pages/ListForms.php
@@ -111,7 +111,8 @@ class ListForms extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }
@@ -120,6 +121,7 @@ class ListForms extends ListRecords
     {
         return [
             Action::make('create')
+                ->authorize('create', Form::class)
                 ->label('New')
                 ->requiresConfirmation()
                 ->modalHeading('Create New Form')

--- a/app-modules/form/src/Filament/Resources/Forms/Pages/ManageFormSubmissions.php
+++ b/app-modules/form/src/Filament/Resources/Forms/Pages/ManageFormSubmissions.php
@@ -162,7 +162,8 @@ class ManageFormSubmissions extends ManageRelatedRecords
 
                             return Excel::download(new FormSubmissionExport($records), $filename);
                         }),
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/form/src/Filament/Resources/Forms/Pages/ManageFormWorkflows.php
+++ b/app-modules/form/src/Filament/Resources/Forms/Pages/ManageFormWorkflows.php
@@ -90,6 +90,7 @@ class ManageFormWorkflows extends ManageRelatedRecords
     {
         return [
             Action::make('create')
+                ->authorize(fn (): bool => auth()->user()->can('update', $this->getOwnerRecord()))
                 ->label('Create New Workflow')
                 ->action(function () {
                     try {

--- a/app-modules/form/src/Policies/FormPolicy.php
+++ b/app-modules/form/src/Policies/FormPolicy.php
@@ -87,6 +87,14 @@ class FormPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function replicate(Authenticatable $authenticatable, Form $form): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'form.create',
+            denyResponse: 'You do not have permission to duplicate this form.'
+        );
+    }
+
     public function update(Authenticatable $authenticatable, Form $form): Response
     {
         return $authenticatable->canOrElse(
@@ -103,6 +111,14 @@ class FormPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['form.*.delete'],
+            denyResponse: 'You do not have permission to delete any form.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Form $form): Response
     {
         return $authenticatable->canOrElse(
@@ -111,11 +127,27 @@ class FormPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['form.*.restore'],
+            denyResponse: 'You do not have permission to restore any form.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Form $form): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['form.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this form.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['form.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any form.'
         );
     }
 

--- a/app-modules/form/src/Policies/FormSubmissionPolicy.php
+++ b/app-modules/form/src/Policies/FormSubmissionPolicy.php
@@ -34,51 +34,35 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Prospect\Filament\Resources\Prospects\Actions;
+namespace AdvisingApp\Form\Policies;
 
-use AdvisingApp\Prospect\Enums\SystemProspectClassification;
-use AdvisingApp\Prospect\Models\Prospect;
-use AdvisingApp\Prospect\Models\ProspectStatus;
-use Filament\Actions\Action;
-use Filament\Notifications\Notification;
+use AdvisingApp\Form\Models\FormSubmission;
+use App\Models\Authenticatable;
+use Illuminate\Auth\Access\Response;
 
-class DisassociateStudent extends Action
+class FormSubmissionPolicy
 {
-    protected function setUp(): void
+    public function update(Authenticatable $authenticatable, FormSubmission $formSubmission): Response
     {
-        parent::setUp();
-
-        $this
-            ->authorize(fn (): bool => auth()->user()->can('prospect.*.update'))
-            ->modalHeading('Disassociate Prospect from Student?')
-            ->requiresConfirmation()
-            ->color('danger')
-            ->modalSubmitActionLabel('Yes')
-            ->action(function (Prospect $record) {
-                /** @var Prospect $record */
-                $record->student()->dissociate();
-
-                $record->status()->associate(
-                    ProspectStatus::query()
-                        ->where('classification', SystemProspectClassification::New)
-                        ->where('name', 'New')
-                        ->where('is_system_protected', true)
-                        ->firstOrFail()
-                );
-
-                $record->save();
-
-                $this->dispatch('reload-prospect');
-
-                Notification::make()
-                    ->title('Prospect disassociated from Student')
-                    ->success()
-                    ->send();
-            });
+        return $authenticatable->canOrElse(
+            abilities: ['form.*.update'],
+            denyResponse: 'You do not have permission to update this form submission.'
+        );
     }
 
-    public static function getDefaultName(): ?string
+    public function delete(Authenticatable $authenticatable, FormSubmission $formSubmission): Response
     {
-        return 'disassociate';
+        return $authenticatable->canOrElse(
+            abilities: ['form.*.update'],
+            denyResponse: 'You do not have permission to delete this form submission.'
+        );
+    }
+
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['form.*.update'],
+            denyResponse: 'You do not have permission to delete form submissions.'
+        );
     }
 }

--- a/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/ListFormsTest.php
+++ b/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/ListFormsTest.php
@@ -34,12 +34,73 @@
 </COPYRIGHT>
 */
 
+use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Form\Filament\Resources\Forms\Pages\ListForms;
 use AdvisingApp\Form\Models\Form;
 use AdvisingApp\Form\Models\FormSubmission;
+use App\Models\User;
+use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
+
+function listFormsTestUser(): User
+{
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->onlineForms = true;
+    $settings->save();
+
+    return User::factory()->licensed(LicenseType::cases())->create();
+}
+
+it('the delete bulk action is gated by the delete permission', function () {
+    $user = listFormsTestUser();
+    $user->givePermissionTo('form.view-any');
+
+    actingAs($user);
+
+    livewire(ListForms::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('form.*.delete');
+
+    livewire(ListForms::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});
+
+it('the create action is gated by the create permission', function () {
+    $user = listFormsTestUser();
+    $user->givePermissionTo('form.view-any');
+
+    actingAs($user);
+
+    livewire(ListForms::class)
+        ->assertActionHidden('create');
+
+    $user->givePermissionTo('form.create');
+
+    livewire(ListForms::class)
+        ->assertActionVisible('create');
+});
+
+it('the duplicate action is gated by the create permission', function () {
+    $user = listFormsTestUser();
+    $user->givePermissionTo('form.view-any');
+
+    actingAs($user);
+
+    $form = Form::factory()->create();
+
+    livewire(ListForms::class)
+        ->assertTableActionHidden('Duplicate', $form);
+
+    $user->givePermissionTo('form.create');
+
+    livewire(ListForms::class)
+        ->assertTableActionVisible('Duplicate', $form);
+});
 
 it('can duplicate a form its steps and its fields', function () {
     asSuperAdmin();

--- a/app-modules/group/src/Policies/GroupPolicy.php
+++ b/app-modules/group/src/Policies/GroupPolicy.php
@@ -121,6 +121,14 @@ class GroupPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['group.*.delete'],
+            denyResponse: 'You do not have permission to delete any group.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Group $group): Response
     {
         if (! $authenticatable->hasLicense($group->model->class()::getLicenseType())) {
@@ -130,6 +138,14 @@ class GroupPolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: ['group.*.restore'],
             denyResponse: 'You do not have permission to restore this group.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['group.*.restore'],
+            denyResponse: 'You do not have permission to restore any group.'
         );
     }
 
@@ -146,6 +162,14 @@ class GroupPolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: ['group.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this group.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['group.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any group.'
         );
     }
 }

--- a/app-modules/interaction/src/Filament/Resources/InteractionDrivers/Pages/ListInteractionDrivers.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionDrivers/Pages/ListInteractionDrivers.php
@@ -170,7 +170,8 @@ class ListInteractionDrivers extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultGroup('interactable_type');

--- a/app-modules/interaction/src/Filament/Resources/InteractionDrivers/Pages/ListInteractionDrivers.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionDrivers/Pages/ListInteractionDrivers.php
@@ -104,6 +104,7 @@ class ListInteractionDrivers extends ListRecords
                                     ->label('Enabled')
                                     ->live()
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_driver_enabled = $state;
                                         $settings->save();
@@ -123,6 +124,7 @@ class ListInteractionDrivers extends ListRecords
                                     ->live()
                                     ->visible(fn (Get $get) => $get('is_driver_enabled'))
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_driver_required = $state;
                                         $settings->save();
@@ -140,6 +142,7 @@ class ListInteractionDrivers extends ListRecords
                             ]),
                     ]),
             ])
+            ->disabled(! auth()->user()->can('settings.*.update'))
             ->statePath('data');
     }
 

--- a/app-modules/interaction/src/Filament/Resources/InteractionInitiatives/Pages/ListInteractionInitiatives.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionInitiatives/Pages/ListInteractionInitiatives.php
@@ -170,7 +170,8 @@ class ListInteractionInitiatives extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultGroup('interactable_type');

--- a/app-modules/interaction/src/Filament/Resources/InteractionInitiatives/Pages/ListInteractionInitiatives.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionInitiatives/Pages/ListInteractionInitiatives.php
@@ -104,6 +104,7 @@ class ListInteractionInitiatives extends ListRecords
                                     ->label('Enabled')
                                     ->live()
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_initiative_enabled = $state;
                                         $settings->save();
@@ -123,6 +124,7 @@ class ListInteractionInitiatives extends ListRecords
                                     ->live()
                                     ->visible(fn (Get $get) => $get('is_initiative_enabled'))
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_initiative_required = $state;
                                         $settings->save();
@@ -140,6 +142,7 @@ class ListInteractionInitiatives extends ListRecords
                             ]),
                     ]),
             ])
+            ->disabled(! auth()->user()->can('settings.*.update'))
             ->statePath('data');
     }
 

--- a/app-modules/interaction/src/Filament/Resources/InteractionOutcomes/Pages/ListInteractionOutcomes.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionOutcomes/Pages/ListInteractionOutcomes.php
@@ -104,6 +104,7 @@ class ListInteractionOutcomes extends ListRecords
                                     ->label('Enabled')
                                     ->live()
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_outcome_enabled = $state;
                                         $settings->save();
@@ -123,6 +124,7 @@ class ListInteractionOutcomes extends ListRecords
                                     ->live()
                                     ->visible(fn (Get $get) => $get('is_outcome_enabled'))
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_outcome_required = $state;
                                         $settings->save();
@@ -140,6 +142,7 @@ class ListInteractionOutcomes extends ListRecords
                             ]),
                     ]),
             ])
+            ->disabled(! auth()->user()->can('settings.*.update'))
             ->statePath('data');
     }
 

--- a/app-modules/interaction/src/Filament/Resources/InteractionOutcomes/Pages/ListInteractionOutcomes.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionOutcomes/Pages/ListInteractionOutcomes.php
@@ -170,7 +170,8 @@ class ListInteractionOutcomes extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultGroup('interactable_type');

--- a/app-modules/interaction/src/Filament/Resources/InteractionRelations/Pages/ListInteractionRelations.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionRelations/Pages/ListInteractionRelations.php
@@ -170,7 +170,8 @@ class ListInteractionRelations extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultGroup('interactable_type');

--- a/app-modules/interaction/src/Filament/Resources/InteractionRelations/Pages/ListInteractionRelations.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionRelations/Pages/ListInteractionRelations.php
@@ -104,6 +104,7 @@ class ListInteractionRelations extends ListRecords
                                     ->label('Enabled')
                                     ->live()
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_relation_enabled = $state;
                                         $settings->save();
@@ -123,6 +124,7 @@ class ListInteractionRelations extends ListRecords
                                     ->live()
                                     ->visible(fn (Get $get) => $get('is_relation_enabled'))
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_relation_required = $state;
                                         $settings->save();
@@ -140,6 +142,7 @@ class ListInteractionRelations extends ListRecords
                             ]),
                     ]),
             ])
+            ->disabled(! auth()->user()->can('settings.*.update'))
             ->statePath('data');
     }
 

--- a/app-modules/interaction/src/Filament/Resources/InteractionStatuses/Pages/ListInteractionStatuses.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionStatuses/Pages/ListInteractionStatuses.php
@@ -107,6 +107,7 @@ class ListInteractionStatuses extends ListRecords
                                     ->label('Enabled')
                                     ->live()
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_status_enabled = $state;
                                         $settings->save();
@@ -132,6 +133,7 @@ class ListInteractionStatuses extends ListRecords
                                     ->live()
                                     ->visible(fn (Get $get) => $get('is_status_enabled'))
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_status_required = $state;
                                         $settings->save();
@@ -148,6 +150,7 @@ class ListInteractionStatuses extends ListRecords
                             ]),
                     ]),
             ])
+            ->disabled(! auth()->user()->can('settings.*.update'))
             ->statePath('data');
     }
 

--- a/app-modules/interaction/src/Filament/Resources/InteractionStatuses/Pages/ListInteractionStatuses.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionStatuses/Pages/ListInteractionStatuses.php
@@ -180,7 +180,8 @@ class ListInteractionStatuses extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultGroup('interactable_type');

--- a/app-modules/interaction/src/Filament/Resources/InteractionTypes/Pages/ListInteractionTypes.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionTypes/Pages/ListInteractionTypes.php
@@ -170,7 +170,8 @@ class ListInteractionTypes extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultGroup('interactable_type');

--- a/app-modules/interaction/src/Filament/Resources/InteractionTypes/Pages/ListInteractionTypes.php
+++ b/app-modules/interaction/src/Filament/Resources/InteractionTypes/Pages/ListInteractionTypes.php
@@ -104,6 +104,7 @@ class ListInteractionTypes extends ListRecords
                                     ->label('Enabled')
                                     ->live()
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_type_enabled = $state;
                                         $settings->save();
@@ -123,6 +124,7 @@ class ListInteractionTypes extends ListRecords
                                     ->live()
                                     ->visible(fn (Get $get) => $get('is_type_enabled'))
                                     ->afterStateUpdated(function (bool $state): void {
+                                        abort_unless(auth()->user()?->can('settings.*.update') ?? false, 403);
                                         $settings = $this->getSettings();
                                         $settings->is_type_required = $state;
                                         $settings->save();
@@ -140,6 +142,7 @@ class ListInteractionTypes extends ListRecords
                             ]),
                     ]),
             ])
+            ->disabled(! auth()->user()->can('settings.*.update'))
             ->statePath('data');
     }
 

--- a/app-modules/interaction/src/Filament/Resources/Interactions/Pages/ListInteractions.php
+++ b/app-modules/interaction/src/Filament/Resources/Interactions/Pages/ListInteractions.php
@@ -92,7 +92,8 @@ class ListInteractions extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/interaction/src/Policies/InteractionDriverPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionDriverPolicy.php
@@ -97,6 +97,14 @@ class InteractionDriverPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any interaction driver.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
         return $authenticatable->canOrElse(
@@ -105,11 +113,27 @@ class InteractionDriverPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any interaction driver.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, InteractionDriver $driver): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this interaction driver.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any interaction driver.'
         );
     }
 }

--- a/app-modules/interaction/src/Policies/InteractionInitiativePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionInitiativePolicy.php
@@ -97,6 +97,14 @@ class InteractionInitiativePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any interaction initiative.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
         return $authenticatable->canOrElse(
@@ -105,11 +113,27 @@ class InteractionInitiativePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any interaction initiative.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, InteractionInitiative $initiative): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this interaction initiative.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any interaction initiative.'
         );
     }
 }

--- a/app-modules/interaction/src/Policies/InteractionOutcomePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionOutcomePolicy.php
@@ -97,6 +97,14 @@ class InteractionOutcomePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any interaction outcome.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
         return $authenticatable->canOrElse(
@@ -105,11 +113,27 @@ class InteractionOutcomePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any interaction outcome.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, InteractionOutcome $outcome): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this interaction outcome.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any interaction outcome.'
         );
     }
 }

--- a/app-modules/interaction/src/Policies/InteractionPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionPolicy.php
@@ -117,6 +117,14 @@ class InteractionPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['interaction.*.delete'],
+            denyResponse: 'You do not have permission to delete any interaction.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Interaction $interaction): Response
     {
         if (! $authenticatable->can('view', $interaction->interactable)) {
@@ -129,6 +137,14 @@ class InteractionPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['interaction.*.restore'],
+            denyResponse: 'You do not have permission to restore any interaction.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Interaction $interaction): Response
     {
         if (! $authenticatable->can('view', $interaction->interactable)) {
@@ -138,6 +154,14 @@ class InteractionPolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: ['interaction.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this interaction.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['interaction.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any interaction.'
         );
     }
 }

--- a/app-modules/interaction/src/Policies/InteractionPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionPolicy.php
@@ -89,6 +89,14 @@ class InteractionPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function import(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'interaction.import',
+            denyResponse: 'You do not have permission to import interactions.',
+        );
+    }
+
     public function update(Authenticatable $authenticatable, Interaction $interaction): Response
     {
         if ($interaction->interactable_type === (new Prospect())->getMorphClass() && filled($interaction->interactable->student_id)) {

--- a/app-modules/interaction/src/Policies/InteractionRelationPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionRelationPolicy.php
@@ -97,6 +97,14 @@ class InteractionRelationPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any interaction relation.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
         return $authenticatable->canOrElse(
@@ -105,11 +113,27 @@ class InteractionRelationPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any interaction relation.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, InteractionRelation $relation): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this interaction relation.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any interaction relation.'
         );
     }
 }

--- a/app-modules/interaction/src/Policies/InteractionStatusPolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionStatusPolicy.php
@@ -97,6 +97,14 @@ class InteractionStatusPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any interaction status.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
         return $authenticatable->canOrElse(
@@ -105,11 +113,27 @@ class InteractionStatusPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any interaction status.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, InteractionStatus $status): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this interaction status.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any interaction status.'
         );
     }
 }

--- a/app-modules/interaction/src/Policies/InteractionTypePolicy.php
+++ b/app-modules/interaction/src/Policies/InteractionTypePolicy.php
@@ -97,6 +97,14 @@ class InteractionTypePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any interaction type.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, InteractionType $type): Response
     {
         return $authenticatable->canOrElse(
@@ -105,11 +113,27 @@ class InteractionTypePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any interaction type.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, InteractionType $type): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this interaction type.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any interaction type.'
         );
     }
 }

--- a/app-modules/interaction/tests/Tenant/Feature/InteractionManagementSettingsTest.php
+++ b/app-modules/interaction/tests/Tenant/Feature/InteractionManagementSettingsTest.php
@@ -68,6 +68,7 @@ it('disables initiative setting from the initiatives list page', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
     $user->givePermissionTo([
         'settings.view-any',
+        'settings.*.update',
     ]);
 
     actingAs($user);
@@ -89,6 +90,7 @@ it('makes driver optional from the drivers list page', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
     $user->givePermissionTo([
         'settings.view-any',
+        'settings.*.update',
     ]);
 
     actingAs($user);
@@ -106,6 +108,7 @@ it('persists settings across different list pages', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
     $user->givePermissionTo([
         'settings.view-any',
+        'settings.*.update',
     ]);
 
     actingAs($user);

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionDrivers/ListInteractionDriversTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionDrivers/ListInteractionDriversTest.php
@@ -40,6 +40,7 @@ use AdvisingApp\Interaction\Filament\Resources\InteractionDrivers\InteractionDri
 use AdvisingApp\Interaction\Filament\Resources\InteractionDrivers\Pages\ListInteractionDrivers;
 use AdvisingApp\Interaction\Models\InteractionDriver;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -75,4 +76,18 @@ test('it can filter by interactable type', function () {
         ->filterTable('interactable_type', InteractableType::Prospect->value)
         ->assertCanSeeTableRecords($prospectDrivers)
         ->assertCanNotSeeTableRecords($studentDrivers);
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ListInteractionDrivers::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListInteractionDrivers::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionInitiatives/ListInteractionInitiativesTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionInitiatives/ListInteractionInitiativesTest.php
@@ -40,6 +40,7 @@ use AdvisingApp\Interaction\Filament\Resources\InteractionInitiatives\Interactio
 use AdvisingApp\Interaction\Filament\Resources\InteractionInitiatives\Pages\ListInteractionInitiatives;
 use AdvisingApp\Interaction\Models\InteractionInitiative;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -75,4 +76,18 @@ test('it can filter by interactable type', function () {
         ->filterTable('interactable_type', InteractableType::Prospect->value)
         ->assertCanSeeTableRecords($prospectInitiatives)
         ->assertCanNotSeeTableRecords($studentInitiatives);
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ListInteractionInitiatives::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListInteractionInitiatives::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionOutcomes/ListInteractionOutcomesTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionOutcomes/ListInteractionOutcomesTest.php
@@ -40,6 +40,7 @@ use AdvisingApp\Interaction\Filament\Resources\InteractionOutcomes\InteractionOu
 use AdvisingApp\Interaction\Filament\Resources\InteractionOutcomes\Pages\ListInteractionOutcomes;
 use AdvisingApp\Interaction\Models\InteractionOutcome;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -75,4 +76,18 @@ test('it can filter by interactable type', function () {
         ->filterTable('interactable_type', InteractableType::Prospect->value)
         ->assertCanSeeTableRecords($prospectOutcomes)
         ->assertCanNotSeeTableRecords($studentOutcomes);
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ListInteractionOutcomes::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListInteractionOutcomes::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionRelations/ListInteractionRelationsTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionRelations/ListInteractionRelationsTest.php
@@ -40,6 +40,7 @@ use AdvisingApp\Interaction\Filament\Resources\InteractionRelations\InteractionR
 use AdvisingApp\Interaction\Filament\Resources\InteractionRelations\Pages\ListInteractionRelations;
 use AdvisingApp\Interaction\Models\InteractionRelation;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -75,4 +76,18 @@ test('it can filter by interactable type', function () {
         ->filterTable('interactable_type', InteractableType::Prospect->value)
         ->assertCanSeeTableRecords($prospectRelations)
         ->assertCanNotSeeTableRecords($studentRelations);
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ListInteractionRelations::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListInteractionRelations::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionStatuses/ListInteractionStatusesTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionStatuses/ListInteractionStatusesTest.php
@@ -40,6 +40,7 @@ use AdvisingApp\Interaction\Filament\Resources\InteractionStatuses\InteractionSt
 use AdvisingApp\Interaction\Filament\Resources\InteractionStatuses\Pages\ListInteractionStatuses;
 use AdvisingApp\Interaction\Models\InteractionStatus;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -75,4 +76,18 @@ test('it can filter by interactable type', function () {
         ->filterTable('interactable_type', InteractableType::Prospect->value)
         ->assertCanSeeTableRecords($prospectStatuses)
         ->assertCanNotSeeTableRecords($studentStatuses);
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ListInteractionStatuses::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListInteractionStatuses::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/interaction/tests/Tenant/Filament/InteractionTypes/ListInteractionTypesTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/InteractionTypes/ListInteractionTypesTest.php
@@ -40,6 +40,7 @@ use AdvisingApp\Interaction\Filament\Resources\InteractionTypes\InteractionTypeR
 use AdvisingApp\Interaction\Filament\Resources\InteractionTypes\Pages\ListInteractionTypes;
 use AdvisingApp\Interaction\Models\InteractionType;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -75,4 +76,18 @@ test('it can filter by interactable type', function () {
         ->filterTable('interactable_type', InteractableType::Prospect->value)
         ->assertCanSeeTableRecords($prospectTypes)
         ->assertCanNotSeeTableRecords($studentTypes);
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ListInteractionTypes::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListInteractionTypes::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/interaction/tests/Tenant/Filament/Interactions/ListInteractionsTest.php
+++ b/app-modules/interaction/tests/Tenant/Filament/Interactions/ListInteractionsTest.php
@@ -36,9 +36,12 @@
 
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Interaction\Filament\Resources\Interactions\InteractionResource;
+use AdvisingApp\Interaction\Filament\Resources\Interactions\Pages\ListInteractions;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 
 test('ListInteractions is gated with proper access control', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
@@ -54,4 +57,18 @@ test('ListInteractions is gated with proper access control', function () {
         ->get(
             InteractionResource::getUrl('index')
         )->assertSuccessful();
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('interaction.view-any');
+    actingAs($user);
+
+    livewire(ListInteractions::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('interaction.*.delete');
+
+    livewire(ListInteractions::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/meeting-center/src/Filament/Resources/CalendarEvents/Pages/ListCalendarEvents.php
+++ b/app-modules/meeting-center/src/Filament/Resources/CalendarEvents/Pages/ListCalendarEvents.php
@@ -184,7 +184,8 @@ class ListCalendarEvents extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->modifyQueryUsing(function (Builder $query): Builder {

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/ListEvents.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/ListEvents.php
@@ -129,7 +129,8 @@ class ListEvents extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultSort('starts_at');

--- a/app-modules/meeting-center/src/Policies/BookingGroupPolicy.php
+++ b/app-modules/meeting-center/src/Policies/BookingGroupPolicy.php
@@ -95,6 +95,14 @@ class BookingGroupPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['group_appointment.*.delete'],
+            denyResponse: 'You do not have permissions to delete any booking group.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, BookingGroup $bookingGroup): Response
     {
         return $authenticatable->canOrElse(
@@ -103,11 +111,27 @@ class BookingGroupPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['group_appointment.*.restore'],
+            denyResponse: 'You do not have permissions to restore any booking group.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, BookingGroup $bookingGroup): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['group_appointment.*.force-delete'],
             denyResponse: 'You do not have permissions to force delete this booking group.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['group_appointment.*.force-delete'],
+            denyResponse: 'You do not have permissions to force delete any booking group.'
         );
     }
 

--- a/app-modules/meeting-center/src/Policies/CalendarEventPolicy.php
+++ b/app-modules/meeting-center/src/Policies/CalendarEventPolicy.php
@@ -79,7 +79,7 @@ class CalendarEventPolicy implements PerformsChecksBeforeAuthorization
     {
         return $authenticatable->canOrElse(
             abilities: ['calendar_event.*.view'],
-            denyResponse: 'You do not have permission to view this engagement response.'
+            denyResponse: 'You do not have permission to view this calendar event.'
         );
     }
 
@@ -95,7 +95,7 @@ class CalendarEventPolicy implements PerformsChecksBeforeAuthorization
     {
         return $authenticatable->canOrElse(
             abilities: ['calendar_event.*.update'],
-            denyResponse: 'You do not have permission to update this engagement response.'
+            denyResponse: 'You do not have permission to update this calendar event.'
         );
     }
 
@@ -103,7 +103,15 @@ class CalendarEventPolicy implements PerformsChecksBeforeAuthorization
     {
         return $authenticatable->canOrElse(
             abilities: ['calendar_event.*.delete'],
-            denyResponse: 'You do not have permission to delete this engagement response.'
+            denyResponse: 'You do not have permission to delete this calendar event.'
+        );
+    }
+
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['calendar_event.*.delete'],
+            denyResponse: 'You do not have permission to delete any calendar event.'
         );
     }
 
@@ -111,7 +119,15 @@ class CalendarEventPolicy implements PerformsChecksBeforeAuthorization
     {
         return $authenticatable->canOrElse(
             abilities: ['calendar_event.*.restore'],
-            denyResponse: 'You do not have permission to restore this engagement response.'
+            denyResponse: 'You do not have permission to restore this calendar event.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['calendar_event.*.restore'],
+            denyResponse: 'You do not have permission to restore any calendar event.'
         );
     }
 
@@ -119,7 +135,15 @@ class CalendarEventPolicy implements PerformsChecksBeforeAuthorization
     {
         return $authenticatable->canOrElse(
             abilities: ['calendar_event.*.force-delete'],
-            denyResponse: 'You do not have permission to permanently delete this engagement response.'
+            denyResponse: 'You do not have permission to permanently delete this calendar event.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['calendar_event.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any calendar event.'
         );
     }
 

--- a/app-modules/meeting-center/src/Policies/EventAttendeePolicy.php
+++ b/app-modules/meeting-center/src/Policies/EventAttendeePolicy.php
@@ -103,6 +103,14 @@ class EventAttendeePolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['event_attendee.*.delete'],
+            denyResponse: 'You do not have permissions to delete any event attendee.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, EventAttendee $eventAttendee): Response
     {
         return $authenticatable->canOrElse(
@@ -111,11 +119,27 @@ class EventAttendeePolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['event_attendee.*.restore'],
+            denyResponse: 'You do not have permissions to restore any event attendee.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, EventAttendee $eventAttendee): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['event_attendee.*.force-delete'],
             denyResponse: 'You do not have permissions to permanently delete this event attendee.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['event_attendee.*.force-delete'],
+            denyResponse: 'You do not have permissions to permanently delete any event attendee.'
         );
     }
 

--- a/app-modules/meeting-center/src/Policies/EventPolicy.php
+++ b/app-modules/meeting-center/src/Policies/EventPolicy.php
@@ -87,6 +87,14 @@ class EventPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function replicate(Authenticatable $authenticatable, Event $event): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'event.create',
+            denyResponse: 'You do not have permission to duplicate this event.'
+        );
+    }
+
     public function update(Authenticatable $authenticatable, Event $event): Response
     {
         return $authenticatable->canOrElse(
@@ -103,6 +111,14 @@ class EventPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['event.*.delete'],
+            denyResponse: 'You do not have permissions to delete any event.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Event $event): Response
     {
         return $authenticatable->canOrElse(
@@ -111,11 +127,27 @@ class EventPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['event.*.restore'],
+            denyResponse: 'You do not have permissions to restore any event.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Event $event): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['event.*.force-delete'],
             denyResponse: 'You do not have permissions to permanently delete this event.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['event.*.force-delete'],
+            denyResponse: 'You do not have permissions to permanently delete any event.'
         );
     }
 

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/CalendarEvents/Pages/ListCalendarEventsTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/CalendarEvents/Pages/ListCalendarEventsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\MeetingCenter\Filament\Resources\CalendarEvents\Pages\ListCalendarEvents;
+use App\Models\User;
+use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+function listCalendarEventsTestUser(): User
+{
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->scheduleAndAppointments = true;
+    $settings->save();
+
+    return User::factory()->licensed(LicenseType::cases())->create();
+}
+
+it('the delete bulk action is gated by the delete permission', function () {
+    $user = listCalendarEventsTestUser();
+    $user->givePermissionTo('calendar_event.view-any');
+
+    actingAs($user);
+
+    livewire(ListCalendarEvents::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('calendar_event.*.delete');
+
+    livewire(ListCalendarEvents::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/ListEventsTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/ListEventsTest.php
@@ -34,13 +34,61 @@
 </COPYRIGHT>
 */
 
+use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\MeetingCenter\Filament\Resources\Events\Pages\ListEvents;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationForm;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationFormSubmission;
+use App\Models\User;
+use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
+
+function listEventsTestUser(): User
+{
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->eventManagement = true;
+    $settings->save();
+
+    return User::factory()->licensed(LicenseType::cases())->create();
+}
+
+it('the delete bulk action is gated by the delete permission', function () {
+    $user = listEventsTestUser();
+    $user->givePermissionTo('event.view-any');
+
+    actingAs($user);
+
+    livewire(ListEvents::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('event.*.delete');
+
+    livewire(ListEvents::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});
+
+it('the duplicate action is gated by the create permission', function () {
+    $user = listEventsTestUser();
+    $user->givePermissionTo('event.view-any');
+
+    actingAs($user);
+
+    $event = Event::factory()->create(['starts_at' => now()->addWeek()]);
+
+    livewire(ListEvents::class)
+        ->removeTableFilter('pastEvents')
+        ->assertTableActionHidden('Duplicate', $event);
+
+    $user->givePermissionTo('event.create');
+
+    livewire(ListEvents::class)
+        ->removeTableFilter('pastEvents')
+        ->assertTableActionVisible('Duplicate', $event);
+});
 
 it('can duplicate a event its registration form its steps and its fields', function () {
     asSuperAdmin();

--- a/app-modules/notification/src/Policies/SubscriptionPolicy.php
+++ b/app-modules/notification/src/Policies/SubscriptionPolicy.php
@@ -102,6 +102,14 @@ class SubscriptionPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['subscription.*.delete'],
+            denyResponse: 'You do not have permission to delete any subscription.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Subscription $subscription): Response
     {
         $licenseType = $this->getSubscribableLicenseType($subscription);
@@ -116,6 +124,14 @@ class SubscriptionPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['subscription.*.restore'],
+            denyResponse: 'You do not have permission to restore any subscription.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Subscription $subscription): Response
     {
         $licenseType = $this->getSubscribableLicenseType($subscription);
@@ -127,6 +143,14 @@ class SubscriptionPolicy
         return $authenticatable->canOrElse(
             abilities: ['subscription.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this subscription.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['subscription.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any subscription.'
         );
     }
 

--- a/app-modules/pipeline/src/Policies/PipelinePolicy.php
+++ b/app-modules/pipeline/src/Policies/PipelinePolicy.php
@@ -105,6 +105,14 @@ class PipelinePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['pipeline.*.delete'],
+            denyResponse: 'You do not have permission to delete any pipeline.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Pipeline $pipeline): Response
     {
         if ($pipeline->project && (! $authenticatable->can('update', $pipeline->project))) {
@@ -117,6 +125,14 @@ class PipelinePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['pipeline.*.restore'],
+            denyResponse: 'You do not have permission to restore any pipeline.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Pipeline $pipeline): Response
     {
         if ($pipeline->project && (! $authenticatable->can('update', $pipeline->project))) {
@@ -126,6 +142,14 @@ class PipelinePolicy
         return $authenticatable->canOrElse(
             abilities: ['pipeline.*.force-delete'],
             denyResponse: 'You do not have permission to force delete this pipeline.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['pipeline.*.force-delete'],
+            denyResponse: 'You do not have permission to force delete any pipeline.'
         );
     }
 }

--- a/app-modules/project/src/Filament/Resources/Projects/Pages/ListProjects.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Pages/ListProjects.php
@@ -66,7 +66,8 @@ class ListProjects extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/project/src/Filament/Resources/Projects/Pages/ManageFiles.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Pages/ManageFiles.php
@@ -194,7 +194,8 @@ class ManageFiles extends ManageRelatedRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/project/src/Filament/Resources/Projects/Pages/ManageTasks.php
+++ b/app-modules/project/src/Filament/Resources/Projects/Pages/ManageTasks.php
@@ -283,6 +283,7 @@ class ManageTasks extends ManageRelatedRecords
             ->toolbarActions([
                 BulkActionGroup::make([
                     DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete')
                         ->authorize(fn () => auth()->user()->can('update', $this->getOwnerRecord())),
                 ]),
             ]);

--- a/app-modules/project/src/Policies/ProjectFilePolicy.php
+++ b/app-modules/project/src/Policies/ProjectFilePolicy.php
@@ -87,4 +87,9 @@ class ProjectFilePolicy
 
         return Response::allow();
     }
+
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return Response::allow();
+    }
 }

--- a/app-modules/project/src/Policies/ProjectMilestonePolicy.php
+++ b/app-modules/project/src/Policies/ProjectMilestonePolicy.php
@@ -87,4 +87,9 @@ class ProjectMilestonePolicy
 
         return Response::allow();
     }
+
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return Response::allow();
+    }
 }

--- a/app-modules/project/src/Policies/ProjectMilestoneStatusPolicy.php
+++ b/app-modules/project/src/Policies/ProjectMilestoneStatusPolicy.php
@@ -104,11 +104,27 @@ class ProjectMilestoneStatusPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permissions to delete any project milestone status.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, ProjectMilestoneStatus $projectMilestoneStatus): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.restore',
             denyResponse: 'You do not have permissions to restore this project milestone status.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permissions to restore any project milestone status.'
         );
     }
 
@@ -121,6 +137,14 @@ class ProjectMilestoneStatusPolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permissions to force delete this project milestone status.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permissions to force delete any project milestone status.'
         );
     }
 

--- a/app-modules/project/src/Policies/ProjectPolicy.php
+++ b/app-modules/project/src/Policies/ProjectPolicy.php
@@ -117,6 +117,14 @@ class ProjectPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'project.*.delete',
+            denyResponse: 'You do not have permission to delete any project.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Project $project): Response
     {
         if (! auth()->user()->isSuperAdmin()) {
@@ -136,6 +144,14 @@ class ProjectPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'project.*.restore',
+            denyResponse: 'You do not have permission to restore any project.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Project $project): Response
     {
         if (! auth()->user()->isSuperAdmin()) {
@@ -152,6 +168,14 @@ class ProjectPolicy
         return $authenticatable->canOrElse(
             abilities: 'project.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this project.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'project.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any project.'
         );
     }
 

--- a/app-modules/project/tests/Tenant/Filament/Resources/ProjectMilestoneStatuses/Pages/ListProjectMilestoneStatusesTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/ProjectMilestoneStatuses/Pages/ListProjectMilestoneStatusesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Project\Filament\Resources\ProjectMilestoneStatuses\Pages\ListProjectMilestoneStatuses;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+it('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListProjectMilestoneStatuses::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListProjectMilestoneStatuses::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});

--- a/app-modules/project/tests/Tenant/Filament/Resources/Projects/Pages/ListProjectsTest.php
+++ b/app-modules/project/tests/Tenant/Filament/Resources/Projects/Pages/ListProjectsTest.php
@@ -40,8 +40,11 @@ use AdvisingApp\Project\Models\Project;
 use AdvisingApp\Team\Models\Team;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertNotSoftDeleted;
+use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Laravel\get;
 use function Pest\Livewire\livewire;
 
@@ -199,6 +202,51 @@ it('does not list projects to unauthorized auditor users', function () {
         ->assertCountTableRecords(5)
         ->assertCanSeeTableRecords($authorizedProjects)
         ->assertCanNotSeeTableRecords($unauthorizedProjects);
+});
+
+it('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('project.view-any');
+    $user->givePermissionTo('project.*.view');
+
+    actingAs($user);
+
+    livewire(ListProjects::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('project.*.delete');
+
+    livewire(ListProjects::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});
+
+it('the delete bulk action only deletes the records the user is authorized to delete', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('project.view-any');
+    $user->givePermissionTo('project.*.view');
+    $user->givePermissionTo('project.*.delete');
+
+    actingAs($user);
+
+    // The user is a manager of this project, so they can both view and delete it.
+    $deletable = Project::factory()->for(User::factory(), 'createdBy')->create();
+    $deletable->managerUsers()->attach($user);
+
+    // The user is only an auditor of this project, so they can view it but the
+    // delete() policy denies them — authorizeIndividualRecords('delete') must skip it.
+    $protected = Project::factory()->for(User::factory(), 'createdBy')->create();
+    $protected->auditorUsers()->attach($user);
+
+    livewire(ListProjects::class)
+        ->assertCanSeeTableRecords([$deletable, $protected])
+        ->callTableBulkAction(DeleteBulkAction::class, [$deletable, $protected]);
+
+    assertSoftDeleted($deletable);
+    assertNotSoftDeleted($protected);
 });
 
 it('does not list projects to unauthorized auditor teams', function () {

--- a/app-modules/prospect/src/Filament/Resources/ProspectSources/Pages/ListProspectSources.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectSources/Pages/ListProspectSources.php
@@ -71,7 +71,8 @@ class ListProspectSources extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/prospect/src/Filament/Resources/ProspectStatuses/Pages/ListProspectStatuses.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectStatuses/Pages/ListProspectStatuses.php
@@ -80,6 +80,7 @@ class ListProspectStatuses extends ListRecords
             ])
             ->defaultSort('sort')
             ->reorderable('sort')
+            ->authorizeReorder(fn (): bool => auth()->user()->can('settings.*.update'))
             ->recordActions([
                 ViewAction::make(),
                 EditAction::make(),

--- a/app-modules/prospect/src/Filament/Resources/Prospects/Actions/ConvertToStudent.php
+++ b/app-modules/prospect/src/Filament/Resources/Prospects/Actions/ConvertToStudent.php
@@ -54,6 +54,7 @@ class ConvertToStudent extends Action
         parent::setUp();
 
         $this
+            ->authorize(fn (): bool => auth()->user()->can('prospect.*.update'))
             ->modalHeading('Convert Prospect to Student')
             ->modalWidth(Width::ExtraLarge)
             ->modalSubmitActionLabel('Convert')

--- a/app-modules/prospect/src/Filament/Resources/Prospects/Pages/ListProspects.php
+++ b/app-modules/prospect/src/Filament/Resources/Prospects/Pages/ListProspects.php
@@ -268,7 +268,9 @@ class ListProspects extends ListRecords
                         BulkGroupAction::make(groupModel: GroupModel::Prospect),
                     ])->dropdown(false),
                     ActionGroup::make([
-                        DeleteBulkAction::make()->label('Delete'),
+                        DeleteBulkAction::make()
+                            ->authorizeIndividualRecords('delete')
+                            ->label('Delete'),
                     ])->dropdown(false),
                 ]),
             ]);

--- a/app-modules/prospect/src/Filament/Resources/Prospects/Pages/ManageProspectCareTeam.php
+++ b/app-modules/prospect/src/Filament/Resources/Prospects/Pages/ManageProspectCareTeam.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\Prospect\Filament\Resources\Prospects\Pages;
 
 use AdvisingApp\CareTeam\Filament\Actions\AddCareTeamMemberToEducatableAttachAction;
+use AdvisingApp\CareTeam\Models\CareTeam;
 use AdvisingApp\CareTeam\Models\CareTeamRole;
 use AdvisingApp\Prospect\Concerns\ProspectHolisticViewPage;
 use AdvisingApp\Prospect\Filament\Resources\Prospects\Pages\Concerns\HasProspectHeader;
@@ -94,6 +95,7 @@ class ManageProspectCareTeam extends ManageRelatedRecords
             ])
             ->recordActions([
                 DetachAction::make()
+                    ->authorize(fn (): bool => auth()->user()->can('deleteAny', CareTeam::class))
                     ->label('Remove')
                     ->modalHeading(function (User $record) {
                         /** @var Prospect $prospect */
@@ -112,6 +114,7 @@ class ManageProspectCareTeam extends ManageRelatedRecords
             ->toolbarActions([
                 BulkActionGroup::make([
                     DetachBulkAction::make()
+                        ->authorize(fn (): bool => auth()->user()->can('deleteAny', CareTeam::class))
                         ->label('Remove selected')
                         ->modalHeading(function () {
                             /** @var Prospect $prospect */

--- a/app-modules/prospect/src/Filament/Resources/Prospects/Pages/ManageProspectConcerns.php
+++ b/app-modules/prospect/src/Filament/Resources/Prospects/Pages/ManageProspectConcerns.php
@@ -180,7 +180,8 @@ class ManageProspectConcerns extends ManageRelatedRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/prospect/src/Filament/Resources/Prospects/Pages/ManageProspectSubscriptions.php
+++ b/app-modules/prospect/src/Filament/Resources/Prospects/Pages/ManageProspectSubscriptions.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Prospect\Filament\Resources\Prospects\Pages;
 
+use AdvisingApp\Notification\Models\Subscription;
 use AdvisingApp\Prospect\Concerns\ProspectHolisticViewPage;
 use AdvisingApp\Prospect\Filament\Resources\Prospects\ProspectResource;
 use AdvisingApp\Prospect\Models\Prospect;
@@ -88,6 +89,7 @@ class ManageProspectSubscriptions extends ManageRelatedRecords
             ])
             ->headerActions([
                 AttachAction::make()
+                    ->authorize(fn (): bool => auth()->user()->can('create', Subscription::class))
                     ->label('New')
                     ->modalHeading(function () {
                         /** @var Prospect $prospect */
@@ -115,6 +117,7 @@ class ManageProspectSubscriptions extends ManageRelatedRecords
             ])
             ->recordActions([
                 DetachAction::make()
+                    ->authorize(fn (): bool => auth()->user()->can('deleteAny', Subscription::class))
                     ->label('Unsubscribe')
                     ->modalHeading(function (User $record) {
                         /** @var Prospect $prospect */
@@ -133,6 +136,7 @@ class ManageProspectSubscriptions extends ManageRelatedRecords
             ->toolbarActions([
                 BulkActionGroup::make([
                     DetachBulkAction::make()
+                        ->authorize(fn (): bool => auth()->user()->can('deleteAny', Subscription::class))
                         ->label('Unsubscribe selected')
                         ->modalHeading(function () {
                             /** @var Prospect $prospect */

--- a/app-modules/prospect/src/Policies/ProspectPolicy.php
+++ b/app-modules/prospect/src/Policies/ProspectPolicy.php
@@ -103,6 +103,14 @@ class ProspectPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['prospect.*.delete'],
+            denyResponse: 'You do not have permission to delete any prospect.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Prospect $prospect): Response
     {
         return $authenticatable->canOrElse(
@@ -111,11 +119,27 @@ class ProspectPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['prospect.*.restore'],
+            denyResponse: 'You do not have permission to restore any prospect.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Prospect $prospect): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['prospect.*.force-delete'],
             denyResponse: 'You do not have permission to force delete this prospect.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['prospect.*.force-delete'],
+            denyResponse: 'You do not have permission to force delete any prospect.'
         );
     }
 }

--- a/app-modules/prospect/src/Policies/ProspectSourcePolicy.php
+++ b/app-modules/prospect/src/Policies/ProspectSourcePolicy.php
@@ -92,6 +92,14 @@ class ProspectSourcePolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any prospect source.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, ProspectSource $prospectSource): Response
     {
         return $authenticatable->canOrElse(
@@ -100,11 +108,27 @@ class ProspectSourcePolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any prospect source.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, ProspectSource $prospectSource): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to force delete this prospect source.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to force delete any prospect source.'
         );
     }
 }

--- a/app-modules/prospect/src/Policies/ProspectStatusPolicy.php
+++ b/app-modules/prospect/src/Policies/ProspectStatusPolicy.php
@@ -100,11 +100,27 @@ class ProspectStatusPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.delete'],
+            denyResponse: 'You do not have permission to delete any prospect status.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, ProspectStatus $prospectStatus): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['settings.*.restore'],
             denyResponse: 'You do not have permission to restore prospect status.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.restore'],
+            denyResponse: 'You do not have permission to restore any prospect status.'
         );
     }
 
@@ -117,6 +133,14 @@ class ProspectStatusPolicy
         return $authenticatable->canOrElse(
             abilities: ['settings.*.force-delete'],
             denyResponse: 'You do not have permission to force delete prospect status.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.force-delete'],
+            denyResponse: 'You do not have permission to force delete any prospect status.'
         );
     }
 }

--- a/app-modules/prospect/tests/Tenant/Prospect/ListProspectTest.php
+++ b/app-modules/prospect/tests/Tenant/Prospect/ListProspectTest.php
@@ -49,6 +49,7 @@ use AdvisingApp\Prospect\Models\ProspectSource;
 use AdvisingApp\Prospect\Models\ProspectStatus;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -381,4 +382,22 @@ it('renders the bulk create case action based on proper access', function () {
     livewire(ListProspects::class)
         ->assertOk()
         ->assertTableBulkActionVisible('createCase');
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(Prospect::getLicenseType())->create();
+
+    $user->givePermissionTo('prospect.view-any');
+
+    actingAs($user);
+
+    livewire(ListProspects::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('prospect.*.delete');
+
+    livewire(ListProspects::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/prospect/tests/Tenant/Prospect/ViewProspectTest.php
+++ b/app-modules/prospect/tests/Tenant/Prospect/ViewProspectTest.php
@@ -87,6 +87,7 @@ test('convert action visible when prospect is not converted to student', functio
 
     $user->givePermissionTo('prospect.view-any');
     $user->givePermissionTo('prospect.*.view');
+    $user->givePermissionTo('prospect.*.update');
 
     actingAs($user);
 
@@ -107,6 +108,7 @@ test('disassociate student action visible when prospect is converted to student'
 
     $user->givePermissionTo('prospect.view-any');
     $user->givePermissionTo('prospect.*.view');
+    $user->givePermissionTo('prospect.*.update');
 
     actingAs($user);
 
@@ -123,6 +125,7 @@ test('convert prospect to student', function () {
 
     $user->givePermissionTo('prospect.view-any');
     $user->givePermissionTo('prospect.*.view');
+    $user->givePermissionTo('prospect.*.update');
 
     actingAs($user);
 
@@ -166,6 +169,7 @@ test('disassociate student from prospect', function () {
 
     $user->givePermissionTo('prospect.view-any');
     $user->givePermissionTo('prospect.*.view');
+    $user->givePermissionTo('prospect.*.update');
 
     actingAs($user);
 

--- a/app-modules/prospect/tests/Tenant/ProspectSource/ListProspectSourcesTest.php
+++ b/app-modules/prospect/tests/Tenant/ProspectSource/ListProspectSourcesTest.php
@@ -39,6 +39,7 @@ use AdvisingApp\Prospect\Filament\Resources\ProspectSources\ProspectSourceResour
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\Prospect\Models\ProspectSource;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -96,4 +97,22 @@ test('ListProspectSources is gated with proper access control', function () {
         ->get(
             ProspectSourceResource::getUrl('index')
         )->assertSuccessful();
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(Prospect::getLicenseType())->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListProspectSources::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListProspectSources::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/prospect/tests/Tenant/ProspectStatus/ListProspectStatusesTest.php
+++ b/app-modules/prospect/tests/Tenant/ProspectStatus/ListProspectStatusesTest.php
@@ -39,6 +39,7 @@ use AdvisingApp\Prospect\Filament\Resources\ProspectStatuses\ProspectStatusResou
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\Prospect\Models\ProspectStatus;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -106,4 +107,22 @@ test('ListProspectStatuses is gated with proper access control', function () {
         ->get(
             ProspectStatusResource::getUrl('index')
         )->assertSuccessful();
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(Prospect::getLicenseType())->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListProspectStatuses::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ListProspectStatuses::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/report/src/Policies/ReportPolicy.php
+++ b/app-modules/report/src/Policies/ReportPolicy.php
@@ -112,6 +112,14 @@ class ReportPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['report.*.delete'],
+            denyResponse: 'You do not have permission to delete any report.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Report $report): Response
     {
         if (! $report->model->canBeAccessed($authenticatable)) {
@@ -124,6 +132,14 @@ class ReportPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['report.*.restore'],
+            denyResponse: 'You do not have permission to restore any report.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Report $report): Response
     {
         if (! $report->model->canBeAccessed($authenticatable)) {
@@ -133,6 +149,14 @@ class ReportPolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: ['report.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this report.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['report.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any report.'
         );
     }
 }

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/ListResourceHubArticles.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/ListResourceHubArticles.php
@@ -223,7 +223,8 @@ class ListResourceHubArticles extends ListRecords
             ->toolbarActions([
                 BulkActionGroup::make([
                     AssignManagerBulkAction::make(),
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ])
             ->defaultSort('updated_at', 'desc');

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategories/Pages/ListResourceHubCategories.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategories/Pages/ListResourceHubCategories.php
@@ -75,7 +75,8 @@ class ListResourceHubCategories extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/ListResourceHubQualities.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/ListResourceHubQualities.php
@@ -71,7 +71,8 @@ class ListResourceHubQualities extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/ListResourceHubStatuses.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/ListResourceHubStatuses.php
@@ -71,7 +71,8 @@ class ListResourceHubStatuses extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/resource-hub/src/Policies/ResourceHubArticlePolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubArticlePolicy.php
@@ -87,6 +87,14 @@ class ResourceHubArticlePolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function replicate(Authenticatable $authenticatable, ResourceHubArticle $resourceHubArticle): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'resource_hub_article.create',
+            denyResponse: 'You do not have permission to duplicate this resource hub article.'
+        );
+    }
+
     public function update(Authenticatable $authenticatable, ResourceHubArticle $resourceHubArticle): Response
     {
         return $authenticatable->canOrElse(
@@ -103,6 +111,14 @@ class ResourceHubArticlePolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['resource_hub_article.*.delete'],
+            denyResponse: 'You do not have permissions to delete any resource hub article.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, ResourceHubArticle $resourceHubArticle): Response
     {
         return $authenticatable->canOrElse(
@@ -111,11 +127,27 @@ class ResourceHubArticlePolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['resource_hub_article.*.restore'],
+            denyResponse: 'You do not have permissions to restore any resource hub article.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, ResourceHubArticle $resourceHubArticle): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['resource_hub_article.*.force-delete'],
             denyResponse: 'You do not have permissions to force delete this resource hub article.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['resource_hub_article.*.force-delete'],
+            denyResponse: 'You do not have permissions to force delete any resource hub article.'
         );
     }
 

--- a/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubCategoryPolicy.php
@@ -107,11 +107,27 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permissions to delete any resource hub category.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, ResourceHubCategory $resourceHubCategory): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.restore',
             denyResponse: 'You do not have permission to restore this resource hub category.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any resource hub category.'
         );
     }
 
@@ -124,6 +140,14 @@ class ResourceHubCategoryPolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this resource hub category.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any resource hub category.'
         );
     }
 

--- a/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubQualityPolicy.php
@@ -107,11 +107,27 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any resource hub quality.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, ResourceHubQuality $resourceHubQuality): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.restore',
             denyResponse: 'You do not have permission to restore this resource hub quality.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any resource hub quality.'
         );
     }
 
@@ -124,6 +140,14 @@ class ResourceHubQualityPolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this resource hub quality.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any resource hub quality.'
         );
     }
 

--- a/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
+++ b/app-modules/resource-hub/src/Policies/ResourceHubStatusPolicy.php
@@ -107,11 +107,27 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any resource hub status.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, ResourceHubStatus $resourceHubStatus): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.restore',
             denyResponse: 'You do not have permission to restore this resource hub status.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any resource hub status.'
         );
     }
 
@@ -124,6 +140,14 @@ class ResourceHubStatusPolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this resource hub status.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any resource hub status.'
         );
     }
 

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/ListResourceHubArticlesTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/ListResourceHubArticlesTest.php
@@ -35,12 +35,17 @@
 */
 
 use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubArticles\Pages\ListResourceHubArticles;
 use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubArticles\ResourceHubArticleResource;
+use AdvisingApp\ResourceHub\Models\ResourceHubArticle;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\ReplicateAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
 use function Tests\Helpers\testResourceRequiresPermissionForAccess;
 
 // TODO: Write ListResourceHubArticles tests
@@ -110,4 +115,42 @@ test('ListResourceHubArticles is gated with proper license access control', func
     get(
         ResourceHubArticleResource::getUrl('index')
     )->assertSuccessful();
+});
+
+test('The DeleteBulkAction is hidden without the delete permission and visible with it', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    $user->givePermissionTo('resource_hub_article.view-any');
+
+    actingAs($user);
+
+    livewire(ListResourceHubArticles::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('resource_hub_article.*.delete');
+
+    actingAs($user);
+
+    livewire(ListResourceHubArticles::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});
+
+test('The Duplicate (ReplicateAction) row action is hidden without the create permission and visible with it', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    $user->givePermissionTo('resource_hub_article.view-any');
+
+    actingAs($user);
+
+    $record = ResourceHubArticle::factory()->create();
+
+    livewire(ListResourceHubArticles::class)
+        ->assertTableActionHidden(ReplicateAction::class, $record);
+
+    $user->givePermissionTo('resource_hub_article.create');
+
+    actingAs($user);
+
+    livewire(ListResourceHubArticles::class)
+        ->assertTableActionVisible(ReplicateAction::class, $record);
 });

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/ListResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/ListResourceHubCategoryTest.php
@@ -35,11 +35,14 @@
 */
 
 use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubCategories\Pages\ListResourceHubCategories;
 use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubCategories\ResourceHubCategoryResource;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 
 // TODO: Write ListResourceHubCategory tests
 //test('The correct details are displayed on the ListResourceHubCategory page', function () {});
@@ -118,4 +121,22 @@ test('ListResourceHubCategory is gated with proper license access control', func
         ->get(
             ResourceHubCategoryResource::getUrl('index')
         )->assertSuccessful();
+});
+
+test('The DeleteBulkAction is hidden without the delete permission and visible with it', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListResourceHubCategories::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    actingAs($user);
+
+    livewire(ListResourceHubCategories::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/ListResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/ListResourceHubQualityTest.php
@@ -35,11 +35,14 @@
 */
 
 use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubQualities\Pages\ListResourceHubQualities;
 use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubQualities\ResourceHubQualityResource;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 
 // TODO: Write ListResourceHubQuality tests
 //test('The correct details are displayed on the ListResourceHubQuality page', function () {});
@@ -118,4 +121,22 @@ test('ListResourceHubQuality is gated with proper license access control', funct
         ->get(
             ResourceHubQualityResource::getUrl('index')
         )->assertSuccessful();
+});
+
+test('The DeleteBulkAction is hidden without the delete permission and visible with it', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListResourceHubQualities::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    actingAs($user);
+
+    livewire(ListResourceHubQualities::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/ListResourceHubStatusesTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/ListResourceHubStatusesTest.php
@@ -35,11 +35,14 @@
 */
 
 use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubStatuses\Pages\ListResourceHubStatuses;
 use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubStatuses\ResourceHubStatusResource;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 
 // TODO: Write ListResourceHubStatuses tests
 //test('The correct details are displayed on the ListResourceHubStatuses page', function () {});
@@ -118,4 +121,22 @@ test('ListResourceHubStatus is gated with proper license access control', functi
         ->get(
             ResourceHubStatusResource::getUrl('index')
         )->assertSuccessful();
+});
+
+test('The DeleteBulkAction is hidden without the delete permission and visible with it', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ListResourceHubStatuses::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    actingAs($user);
+
+    livewire(ListResourceHubStatuses::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/student-data-model/src/Filament/Resources/Educatables/Pages/Concerns/CanManageEducatableCareTeam.php
+++ b/app-modules/student-data-model/src/Filament/Resources/Educatables/Pages/Concerns/CanManageEducatableCareTeam.php
@@ -82,6 +82,7 @@ trait CanManageEducatableCareTeam
             ])
             ->recordActions([
                 DetachAction::make()
+                    ->authorize(fn (): bool => auth()->user()->can('deleteAny', CareTeam::class))
                     ->label('Remove')
                     ->modalHeading(function (User $record) {
                         /** @var Student $student */
@@ -100,6 +101,7 @@ trait CanManageEducatableCareTeam
             ->toolbarActions([
                 BulkActionGroup::make([
                     DetachBulkAction::make()
+                        ->authorize(fn (): bool => auth()->user()->can('deleteAny', CareTeam::class))
                         ->label('Remove selected')
                         ->modalHeading(function () {
                             /** @var Student $student */

--- a/app-modules/student-data-model/src/Filament/Resources/Educatables/Pages/Concerns/CanManageEducatableConcerns.php
+++ b/app-modules/student-data-model/src/Filament/Resources/Educatables/Pages/Concerns/CanManageEducatableConcerns.php
@@ -149,7 +149,8 @@ trait CanManageEducatableConcerns
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/student-data-model/src/Filament/Resources/Educatables/Pages/Concerns/CanManageEducatableSubscriptions.php
+++ b/app-modules/student-data-model/src/Filament/Resources/Educatables/Pages/Concerns/CanManageEducatableSubscriptions.php
@@ -78,6 +78,7 @@ trait CanManageEducatableSubscriptions
             ])
             ->headerActions([
                 AttachAction::make()
+                    ->authorize(fn (): bool => auth()->user()->can('create', Subscription::class))
                     ->label('New')
                     ->modalHeading(function () {
                         /** @var Student $student */
@@ -105,6 +106,7 @@ trait CanManageEducatableSubscriptions
             ])
             ->recordActions([
                 DetachAction::make()
+                    ->authorize(fn (): bool => auth()->user()->can('deleteAny', Subscription::class))
                     ->label('Unsubscribe')
                     ->modalHeading(function (User $record) {
                         /** @var Student $student */
@@ -123,6 +125,7 @@ trait CanManageEducatableSubscriptions
             ->toolbarActions([
                 BulkActionGroup::make([
                     DetachBulkAction::make()
+                        ->authorize(fn (): bool => auth()->user()->can('deleteAny', Subscription::class))
                         ->label('Unsubscribe selected')
                         ->modalHeading(function () {
                             /** @var Student $student */

--- a/app-modules/student-data-model/src/Filament/Resources/Educatables/Pages/Concerns/CanManageEducatableTasks.php
+++ b/app-modules/student-data-model/src/Filament/Resources/Educatables/Pages/Concerns/CanManageEducatableTasks.php
@@ -218,12 +218,22 @@ trait CanManageEducatableTasks
                 TaskViewAction::make(),
                 EditAction::make(),
                 DissociateAction::make()
+                    ->authorize(function (): bool {
+                        $ownerRecord = $this->getRecord();
+
+                        return auth()->user()->can('create', [Task::class, $ownerRecord instanceof Prospect ? $ownerRecord : null]);
+                    })
                     ->using(fn (Task $task) => $task->concern()->dissociate()->save()),
             ])
             ->recordUrl(null)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DissociateBulkAction::make()
+                        ->authorize(function (): bool {
+                            $ownerRecord = $this->getRecord();
+
+                            return auth()->user()->can('create', [Task::class, $ownerRecord instanceof Prospect ? $ownerRecord : null]);
+                        })
                         ->using(function (Collection $selectedRecords) {
                             $selectedRecords->each(
                                 fn (Task $selectedRecord) => $selectedRecord->concern()->dissociate()->save()

--- a/app-modules/student-data-model/src/Filament/Resources/EnrollmentSemesters/EnrollmentSemesterResource.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EnrollmentSemesters/EnrollmentSemesterResource.php
@@ -116,7 +116,8 @@ class EnrollmentSemesterResource extends Resource
             ->paginated([50, 100, 500, 1000])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/student-data-model/src/Filament/Resources/EnrollmentSemesters/Pages/ManageEnrollmentSemesters.php
+++ b/app-modules/student-data-model/src/Filament/Resources/EnrollmentSemesters/Pages/ManageEnrollmentSemesters.php
@@ -60,6 +60,7 @@ class ManageEnrollmentSemesters extends ManageRecords
 
         return [
             Action::make('syncAll')
+                ->authorize(fn (): bool => auth()->user()->can('create', EnrollmentSemester::class))
                 ->label('Sync')
                 ->disabled(fn () => ! $unsyncedEnrollments->exists())
                 ->tooltip(fn () => $unsyncedEnrollments->exists() ? '' : 'No additional semesters to sync.')

--- a/app-modules/student-data-model/src/Filament/Resources/Students/RelationManagers/ApplicationSubmissionsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/Students/RelationManagers/ApplicationSubmissionsRelationManager.php
@@ -123,7 +123,8 @@ class ApplicationSubmissionsRelationManager extends RelationManager
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/student-data-model/src/Filament/Resources/Students/RelationManagers/FormSubmissionsRelationManager.php
+++ b/app-modules/student-data-model/src/Filament/Resources/Students/RelationManagers/FormSubmissionsRelationManager.php
@@ -101,7 +101,8 @@ class FormSubmissionsRelationManager extends RelationManager
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/student-data-model/src/Policies/EnrollmentPolicy.php
+++ b/app-modules/student-data-model/src/Policies/EnrollmentPolicy.php
@@ -105,6 +105,18 @@ class EnrollmentPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'enrollment.*.delete',
+            denyResponse: 'You do not have permission to delete any enrollment.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Enrollment $enrollment): Response
     {
         if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
@@ -117,6 +129,18 @@ class EnrollmentPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'enrollment.*.update',
+            denyResponse: 'You do not have permission to restore any enrollment.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Enrollment $enrollment): Response
     {
         if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
@@ -126,6 +150,18 @@ class EnrollmentPolicy
         return $authenticatable->canOrElse(
             abilities: 'enrollment.*.force-delete',
             denyResponse: 'You do not have permission to force delete this enrollment.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'enrollment.*.force-delete',
+            denyResponse: 'You do not have permission to force delete any enrollment.'
         );
     }
 

--- a/app-modules/student-data-model/src/Policies/EnrollmentSemesterPolicy.php
+++ b/app-modules/student-data-model/src/Policies/EnrollmentSemesterPolicy.php
@@ -82,6 +82,14 @@ class EnrollmentSemesterPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.delete'],
+            denyResponse: 'You do not have permission to delete any enrollment semester.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, EnrollmentSemester $enrollmentSemester): Response
     {
         return $authenticatable->canOrElse(
@@ -90,11 +98,27 @@ class EnrollmentSemesterPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.restore'],
+            denyResponse: 'You do not have permission to restore any enrollment semester.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, EnrollmentSemester $enrollmentSemester): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['settings.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this enrollment semester.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['settings.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any enrollment semester.'
         );
     }
 }

--- a/app-modules/student-data-model/src/Policies/HoldPolicy.php
+++ b/app-modules/student-data-model/src/Policies/HoldPolicy.php
@@ -105,6 +105,18 @@ class HoldPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'hold.*.delete',
+            denyResponse: 'You do not have permission to delete any hold.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Hold $hold): Response
     {
         if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
@@ -117,6 +129,18 @@ class HoldPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'hold.*.restore',
+            denyResponse: 'You do not have permission to restore any hold.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Hold $hold): Response
     {
         if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
@@ -126,6 +150,18 @@ class HoldPolicy
         return $authenticatable->canOrElse(
             abilities: 'hold.*.force-delete',
             denyResponse: 'You do not have permission to force delete this hold.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'hold.*.force-delete',
+            denyResponse: 'You do not have permission to force delete any hold.'
         );
     }
 

--- a/app-modules/student-data-model/src/Policies/ProgramPolicy.php
+++ b/app-modules/student-data-model/src/Policies/ProgramPolicy.php
@@ -105,6 +105,18 @@ class ProgramPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'program.*.delete',
+            denyResponse: 'You do not have permission to delete any program.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Program $program): Response
     {
         if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
@@ -117,6 +129,18 @@ class ProgramPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'program.*.restore',
+            denyResponse: 'You do not have permission to restore any program.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Program $program): Response
     {
         if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
@@ -125,7 +149,19 @@ class ProgramPolicy
 
         return $authenticatable->canOrElse(
             abilities: 'program.*.force-delete',
-            denyResponse: 'You do not have permission to force delete this student.'
+            denyResponse: 'You do not have permission to force delete this program.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'program.*.force-delete',
+            denyResponse: 'You do not have permission to force delete any program.'
         );
     }
 

--- a/app-modules/student-data-model/src/Policies/StudentPolicy.php
+++ b/app-modules/student-data-model/src/Policies/StudentPolicy.php
@@ -104,6 +104,18 @@ class StudentPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'student.*.delete',
+            denyResponse: 'You do not have permission to delete any student.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Student $student): Response
     {
         if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
@@ -116,6 +128,18 @@ class StudentPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'student.*.restore',
+            denyResponse: 'You do not have permission to restore any student.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Student $student): Response
     {
         if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
@@ -125,6 +149,18 @@ class StudentPolicy
         return $authenticatable->canOrElse(
             abilities: 'student.*.force-delete',
             denyResponse: 'You do not have permission to force delete this student.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        if (! app(ManageStudentConfigurationSettings::class)->is_enabled) {
+            return Response::deny('Student data configuration is not enabled.');
+        }
+
+        return $authenticatable->canOrElse(
+            abilities: 'student.*.force-delete',
+            denyResponse: 'You do not have permission to force delete any student.'
         );
     }
 

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/EnrollmentSemesters/Pages/ManageEnrollmentSemestersTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/EnrollmentSemesters/Pages/ManageEnrollmentSemestersTest.php
@@ -39,6 +39,7 @@ use AdvisingApp\StudentDataModel\Filament\Resources\EnrollmentSemesters\Pages\Ma
 use AdvisingApp\StudentDataModel\Models\Enrollment;
 use AdvisingApp\StudentDataModel\Models\EnrollmentSemester;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 use Illuminate\Database\Eloquent\Factories\Sequence;
 
 use function Pest\Laravel\actingAs;
@@ -61,6 +62,22 @@ test('the page is gated with proper access control', function () {
         ->get(
             EnrollmentSemesterResource::getUrl('index')
         )->assertSuccessful();
+});
+
+test('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+
+    actingAs($user);
+
+    livewire(ManageEnrollmentSemesters::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('settings.*.delete');
+
+    livewire(ManageEnrollmentSemesters::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });
 
 test('it enables the sync button when appropriate', function () {

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/Students/Pages/ListStudentsTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/Students/Pages/ListStudentsTest.php
@@ -42,6 +42,7 @@ use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\StudentDataModel\Settings\ManageStudentConfigurationSettings;
 use App\Models\User;
 use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -100,6 +101,28 @@ it('renders the CreateAction based on proper access', function () {
     livewire(ListStudents::class)
         ->assertOk()
         ->assertActionVisible(CreateAction::class);
+});
+
+it('the delete bulk action is gated by the delete permission', function () {
+    $user = User::factory()->licensed(Student::getLicenseType())->create();
+
+    $user->givePermissionTo('student.view-any');
+
+    $studentSettings = app(ManageStudentConfigurationSettings::class);
+    $studentSettings->is_enabled = true;
+    $studentSettings->save();
+
+    actingAs($user);
+
+    livewire(ListStudents::class)
+        ->assertOk()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('student.*.delete');
+
+    livewire(ListStudents::class)
+        ->assertOk()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });
 
 it('can filter students by concerns', function () {

--- a/app-modules/survey/src/Filament/Resources/Surveys/Pages/ListSurveys.php
+++ b/app-modules/survey/src/Filament/Resources/Surveys/Pages/ListSurveys.php
@@ -95,7 +95,8 @@ class ListSurveys extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/survey/src/Filament/Resources/Surveys/Pages/ManageSurveySubmissions.php
+++ b/app-modules/survey/src/Filament/Resources/Surveys/Pages/ManageSurveySubmissions.php
@@ -142,7 +142,8 @@ class ManageSurveySubmissions extends ManageRelatedRecords
 
                             return Excel::download(new FormSubmissionExport($records), $filename);
                         }),
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/survey/src/Policies/SurveyPolicy.php
+++ b/app-modules/survey/src/Policies/SurveyPolicy.php
@@ -87,6 +87,14 @@ class SurveyPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function replicate(Authenticatable $authenticatable, Survey $survey): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'survey.create',
+            denyResponse: 'You do not have permission to duplicate this survey.'
+        );
+    }
+
     public function update(Authenticatable $authenticatable, Survey $survey): Response
     {
         return $authenticatable->canOrElse(
@@ -103,6 +111,14 @@ class SurveyPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['survey.*.delete'],
+            denyResponse: 'You do not have permission to delete any survey.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Survey $survey): Response
     {
         return $authenticatable->canOrElse(
@@ -111,11 +127,27 @@ class SurveyPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['survey.*.restore'],
+            denyResponse: 'You do not have permission to restore any survey.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Survey $survey): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['survey.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this survey.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['survey.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any survey.'
         );
     }
 

--- a/app-modules/survey/tests/Tenant/Filament/Resources/Surveys/Pages/ListSurveysTest.php
+++ b/app-modules/survey/tests/Tenant/Filament/Resources/Surveys/Pages/ListSurveysTest.php
@@ -34,12 +34,58 @@
 </COPYRIGHT>
 */
 
+use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Survey\Filament\Resources\Surveys\Pages\ListSurveys;
 use AdvisingApp\Survey\Models\Survey;
 use AdvisingApp\Survey\Models\SurveySubmission;
+use App\Models\User;
+use App\Settings\LicenseSettings;
+use Filament\Actions\DeleteBulkAction;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
+
+function listSurveysTestUser(): User
+{
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->onlineSurveys = true;
+    $settings->save();
+
+    return User::factory()->licensed(LicenseType::cases())->create();
+}
+
+it('the delete bulk action is gated by the delete permission', function () {
+    $user = listSurveysTestUser();
+    $user->givePermissionTo('survey.view-any');
+
+    actingAs($user);
+
+    livewire(ListSurveys::class)
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+
+    $user->givePermissionTo('survey.*.delete');
+
+    livewire(ListSurveys::class)
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});
+
+it('the duplicate action is gated by the create permission', function () {
+    $user = listSurveysTestUser();
+    $user->givePermissionTo('survey.view-any');
+
+    actingAs($user);
+
+    $survey = Survey::factory()->create();
+
+    livewire(ListSurveys::class)
+        ->assertTableActionHidden('Duplicate', $survey);
+
+    $user->givePermissionTo('survey.create');
+
+    livewire(ListSurveys::class)
+        ->assertTableActionVisible('Duplicate', $survey);
+});
 
 it('can duplicate a survey its steps and its fields', function () {
     asSuperAdmin();

--- a/app-modules/task/src/Filament/RelationManagers/BaseTaskRelationManager.php
+++ b/app-modules/task/src/Filament/RelationManagers/BaseTaskRelationManager.php
@@ -223,12 +223,22 @@ abstract class BaseTaskRelationManager extends ManageRelatedRecords
                 TaskViewAction::make(),
                 EditAction::make(),
                 DissociateAction::make()
+                    ->authorize(function (): bool {
+                        $ownerRecord = $this->getOwnerRecord();
+
+                        return auth()->user()->can('create', [Task::class, $ownerRecord instanceof Prospect ? $ownerRecord : null]);
+                    })
                     ->using(fn (Task $task) => $task->concern()->dissociate()->save()),
             ])
             ->recordUrl(null)
             ->toolbarActions([
                 BulkActionGroup::make([
                     DissociateBulkAction::make()
+                        ->authorize(function (): bool {
+                            $ownerRecord = $this->getOwnerRecord();
+
+                            return auth()->user()->can('create', [Task::class, $ownerRecord instanceof Prospect ? $ownerRecord : null]);
+                        })
                         ->using(function (Collection $selectedRecords) {
                             $selectedRecords->each(
                                 fn (Task $selectedRecord) => $selectedRecord->concern()->dissociate()->save()

--- a/app-modules/task/src/Policies/TaskPolicy.php
+++ b/app-modules/task/src/Policies/TaskPolicy.php
@@ -121,6 +121,14 @@ class TaskPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['task.*.delete'],
+            denyResponse: 'You do not have permission to delete any task.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Task $task): Response
     {
         if (! $authenticatable->hasLicense($task->concern?->getLicenseType())) {
@@ -133,6 +141,14 @@ class TaskPolicy implements PerformsChecksBeforeAuthorization
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['task.*.restore'],
+            denyResponse: 'You do not have permission to restore any task.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Task $task): Response
     {
         if (! $authenticatable->hasLicense($task->concern?->getLicenseType())) {
@@ -142,6 +158,14 @@ class TaskPolicy implements PerformsChecksBeforeAuthorization
         return $authenticatable->canOrElse(
             abilities: ['task.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this task.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['task.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any task.'
         );
     }
 }

--- a/app-modules/team/src/Filament/Resources/Teams/Pages/ListTeams.php
+++ b/app-modules/team/src/Filament/Resources/Teams/Pages/ListTeams.php
@@ -71,7 +71,8 @@ class ListTeams extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app-modules/team/src/Policies/TeamPolicy.php
+++ b/app-modules/team/src/Policies/TeamPolicy.php
@@ -82,6 +82,14 @@ class TeamPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['team.*.delete'],
+            denyResponse: 'You do not have permission to delete any team.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Team $team): Response
     {
         return $authenticatable->canOrElse(
@@ -90,11 +98,27 @@ class TeamPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['team.*.restore'],
+            denyResponse: 'You do not have permission to restore any team.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Team $team): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['team.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this team.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['team.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any team.'
         );
     }
 }

--- a/app-modules/team/tests/Tenant/Teams/EditTeamTest.php
+++ b/app-modules/team/tests/Tenant/Teams/EditTeamTest.php
@@ -35,6 +35,7 @@
 */
 
 use AdvisingApp\Team\Filament\Resources\Teams\Pages\EditTeam;
+use AdvisingApp\Team\Filament\Resources\Teams\Pages\ViewTeam;
 use AdvisingApp\Team\Filament\Resources\Teams\RelationManagers\UsersRelationManager;
 use AdvisingApp\Team\Filament\Resources\Teams\TeamResource;
 use AdvisingApp\Team\Models\Team;
@@ -183,4 +184,30 @@ test('Super Admin Users do not show up in UsersRelationManager for Teams search 
 
             return empty($options) ? true : false;
         })->assertSuccessful();
+});
+
+// The associate/dissociate/attach/detach actions on relation managers are gated by the
+// "update" ability of the owner record (see FilamentServiceProvider). On the read-only-able
+// view page, a user who can only view the team must not see the associate action.
+test('the associate action in the team users relation manager is gated by the team update permission', function () {
+    $team = Team::factory()->create();
+
+    $user = User::factory()->create();
+    $user->givePermissionTo('team.view-any');
+    $user->givePermissionTo('team.*.view');
+    $user->givePermissionTo('user.view-any');
+
+    actingAs($user);
+
+    livewire(UsersRelationManager::class, [
+        'ownerRecord' => $team,
+        'pageClass' => ViewTeam::class,
+    ])->assertTableActionHidden(AssociateAction::class);
+
+    $user->givePermissionTo('team.*.update');
+
+    livewire(UsersRelationManager::class, [
+        'ownerRecord' => $team,
+        'pageClass' => ViewTeam::class,
+    ])->assertTableActionVisible(AssociateAction::class);
 });

--- a/app-modules/team/tests/Tenant/Teams/ListTeamsTest.php
+++ b/app-modules/team/tests/Tenant/Teams/ListTeamsTest.php
@@ -34,10 +34,14 @@
 </COPYRIGHT>
 */
 
+use AdvisingApp\Team\Filament\Resources\Teams\Pages\ListTeams;
 use AdvisingApp\Team\Filament\Resources\Teams\TeamResource;
+use AdvisingApp\Team\Models\Team;
 use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
 
 use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 
 // Permission Tests
 
@@ -55,4 +59,28 @@ test('ListTeams is gated with proper access control', function () {
         ->get(
             TeamResource::getUrl('index')
         )->assertSuccessful();
+});
+
+test('hides the bulk delete action from a user without the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('team.view-any');
+    actingAs($user);
+
+    Team::factory()->count(2)->create();
+
+    livewire(ListTeams::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+test('shows the bulk delete action to a user with the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('team.view-any', 'team.*.delete');
+    actingAs($user);
+
+    Team::factory()->count(2)->create();
+
+    livewire(ListTeams::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
 });

--- a/app-modules/webhook/src/Policies/InboundWebhookPolicy.php
+++ b/app-modules/webhook/src/Policies/InboundWebhookPolicy.php
@@ -75,12 +75,27 @@ class InboundWebhookPolicy
         return Response::deny('Inbound webhooks cannot be deleted.');
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('Inbound webhooks cannot be deleted.');
+    }
+
     public function restore(Authenticatable $authenticatable, InboundWebhook $inboundWebhook): Response
     {
         return Response::deny('Inbound webhooks cannot be restored.');
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return Response::deny('Inbound webhooks cannot be restored.');
+    }
+
     public function forceDelete(Authenticatable $authenticatable, InboundWebhook $inboundWebhook): Response
+    {
+        return Response::deny('Inbound webhooks cannot be force deleted.');
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
     {
         return Response::deny('Inbound webhooks cannot be force deleted.');
     }

--- a/app-modules/workflow/src/Filament/Resources/Workflows/RelationManagers/WorkflowStepsRelationManager.php
+++ b/app-modules/workflow/src/Filament/Resources/Workflows/RelationManagers/WorkflowStepsRelationManager.php
@@ -107,6 +107,7 @@ class WorkflowStepsRelationManager extends RelationManager
             ])
             ->headerActions([
                 Action::make('create')
+                    ->authorize(fn (): bool => auth()->user()->can('update', $workflow->workflowTrigger->related))
                     ->label('New Step')
                     ->slideOver()
                     ->modalHeading('Create Workflow Steps')
@@ -214,7 +215,8 @@ class WorkflowStepsRelationManager extends RelationManager
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app/Filament/Pages/ManageInstitutionDetailsSettings.php
+++ b/app/Filament/Pages/ManageInstitutionDetailsSettings.php
@@ -96,6 +96,25 @@ class ManageInstitutionDetailsSettings extends SettingsPage
                         InstitutionDetailsSettings::getSettingsPropertyModel('institution.light_logo'),
                     )
                     ->columnSpanFull(),
-            ]);
+            ])
+            ->disabled(! auth()->user()->can('product_admin.*.update'));
+    }
+
+    public function save(): void
+    {
+        if (! auth()->user()->can('product_admin.*.update')) {
+            return;
+        }
+
+        parent::save();
+    }
+
+    public function getFormActions(): array
+    {
+        if (! auth()->user()->can('product_admin.*.update')) {
+            return [];
+        }
+
+        return parent::getFormActions();
     }
 }

--- a/app/Filament/Resources/NotificationSettings/Pages/ListNotificationSettings.php
+++ b/app/Filament/Resources/NotificationSettings/Pages/ListNotificationSettings.php
@@ -61,7 +61,8 @@ class ListNotificationSettings extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/Pronouns/PronounsResource.php
+++ b/app/Filament/Resources/Pronouns/PronounsResource.php
@@ -86,7 +86,8 @@ class PronounsResource extends Resource
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/SystemUsers/Pages/ListSystemUsers.php
+++ b/app/Filament/Resources/SystemUsers/Pages/ListSystemUsers.php
@@ -66,7 +66,8 @@ class ListSystemUsers extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
                 ]),
             ]);
     }

--- a/app/Filament/Resources/Users/Pages/ListUsers.php
+++ b/app/Filament/Resources/Users/Pages/ListUsers.php
@@ -133,8 +133,10 @@ class ListUsers extends ListRecords
             ])
             ->toolbarActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
-                    RestoreBulkAction::make(),
+                    DeleteBulkAction::make()
+                        ->authorizeIndividualRecords('delete'),
+                    RestoreBulkAction::make()
+                        ->authorizeIndividualRecords('restore'),
                     AssignLicensesBulkAction::make()
                         ->visible(fn () => auth()->user()->can('create', License::class)),
                     AssignRolesBulkAction::make()

--- a/app/Livewire/ProspectPipelineKanban.php
+++ b/app/Livewire/ProspectPipelineKanban.php
@@ -116,6 +116,13 @@ class ProspectPipelineKanban extends Component implements HasForms, HasActions
 
     public function moveProspect(Pipeline $pipeline, string $educatableId, string $fromStage = '', string $toStage = ''): JsonResponse
     {
+        if (! auth()->user()?->can('update', $pipeline)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'You do not have permission to move records in this pipeline.',
+            ], ResponseAlias::HTTP_FORBIDDEN);
+        }
+
         try {
             $educatableType = $pipeline->group->model;
 

--- a/app/Policies/ExportPolicy.php
+++ b/app/Policies/ExportPolicy.php
@@ -82,11 +82,27 @@ class ExportPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'export_hub.delete',
+            denyResponse: 'You do not have permission to delete any export.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Export $export): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'export_hub.restore',
             denyResponse: 'You do not have permission to restore this export.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'export_hub.restore',
+            denyResponse: 'You do not have permission to restore any export.'
         );
     }
 

--- a/app/Policies/NotificationSettingPolicy.php
+++ b/app/Policies/NotificationSettingPolicy.php
@@ -82,6 +82,14 @@ class NotificationSettingPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any notification setting.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
         return $authenticatable->canOrElse(
@@ -90,11 +98,27 @@ class NotificationSettingPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any notification setting.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, NotificationSetting $notificationSetting): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this notification setting.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any notification setting.'
         );
     }
 }

--- a/app/Policies/PronounsPolicy.php
+++ b/app/Policies/PronounsPolicy.php
@@ -82,6 +82,14 @@ class PronounsPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete these pronoun.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Pronouns $model): Response
     {
         return $authenticatable->canOrElse(
@@ -90,7 +98,23 @@ class PronounsPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore these pronoun.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, Pronouns $model): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete these pronoun.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',

--- a/app/Policies/SystemUserPolicy.php
+++ b/app/Policies/SystemUserPolicy.php
@@ -82,6 +82,14 @@ class SystemUserPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['system_user.*.delete'],
+            denyResponse: 'You do not have permission to delete any user.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, SystemUser $model): Response
     {
         return $authenticatable->canOrElse(
@@ -90,11 +98,27 @@ class SystemUserPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['system_user.*.restore'],
+            denyResponse: 'You do not have permission to restore any user.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, SystemUser $model): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['system_user.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this user.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['system_user.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any user.'
         );
     }
 }

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -92,11 +92,27 @@ class TagPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.delete',
+            denyResponse: 'You do not have permission to delete any tag.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, Tag $tag): Response
     {
         return $authenticatable->canOrElse(
             abilities: 'settings.*.restore',
             denyResponse: 'You do not have permission to restore this tag.'
+        );
+    }
+
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.restore',
+            denyResponse: 'You do not have permission to restore any tag.'
         );
     }
 
@@ -113,6 +129,14 @@ class TagPolicy
         return $authenticatable->canOrElse(
             abilities: 'settings.*.force-delete',
             denyResponse: 'You do not have permission to permanently delete this tag.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: 'settings.*.force-delete',
+            denyResponse: 'You do not have permission to permanently delete any tag.'
         );
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -90,6 +90,14 @@ class UserPolicy
         );
     }
 
+    public function deleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['user.*.delete'],
+            denyResponse: 'You do not have permission to delete any user.'
+        );
+    }
+
     public function restore(Authenticatable $authenticatable, User $model): Response
     {
         return $authenticatable->canOrElse(
@@ -98,11 +106,27 @@ class UserPolicy
         );
     }
 
+    public function restoreAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['user.*.restore'],
+            denyResponse: 'You do not have permission to restore any user.'
+        );
+    }
+
     public function forceDelete(Authenticatable $authenticatable, User $model): Response
     {
         return $authenticatable->canOrElse(
             abilities: ['user.*.force-delete'],
             denyResponse: 'You do not have permission to permanently delete this user.'
+        );
+    }
+
+    public function forceDeleteAny(Authenticatable $authenticatable): Response
+    {
+        return $authenticatable->canOrElse(
+            abilities: ['user.*.force-delete'],
+            denyResponse: 'You do not have permission to permanently delete any user.'
         );
     }
 

--- a/app/Providers/FilamentServiceProvider.php
+++ b/app/Providers/FilamentServiceProvider.php
@@ -41,6 +41,12 @@ use App\Models\FailedImportRow;
 use App\Models\Import;
 use App\Models\User;
 use App\Settings\DisplaySettings;
+use Filament\Actions\AssociateAction;
+use Filament\Actions\AttachAction;
+use Filament\Actions\DetachAction;
+use Filament\Actions\DetachBulkAction;
+use Filament\Actions\DissociateAction;
+use Filament\Actions\DissociateBulkAction;
 use Filament\Actions\Exports\Models\Export as BaseExport;
 use Filament\Actions\Imports\Models\FailedImportRow as BaseFailedImportRow;
 use Filament\Actions\Imports\Models\Import as BaseImport;
@@ -52,6 +58,8 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\Toggle;
 use Filament\Infolists\Components\TextEntry;
+use Filament\Resources\Pages\ManageRelatedRecords;
+use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
@@ -342,5 +350,24 @@ class FilamentServiceProvider extends ServiceProvider
             ->label('Duplicate')
             ->modalSubmitActionLabel('Duplicate')
             ->modalHeading('Duplicate'));
+
+        // Relation manager associate/dissociate/attach/detach actions are not authorized by
+        // Filament out of the box. Because read-only relation managers on resource view pages
+        // are disabled for this panel, these actions would otherwise be available to anyone who
+        // can view the owner record. Gate them behind the "update" ability of the owner record.
+        // Typing $livewire as ManageRelatedRecords|RelationManager also guards against these
+        // actions ever being used outside of a relation manager (it would throw).
+        $authorizeRelationManagerOwnerUpdate = function (AssociateAction | AttachAction | DetachAction | DissociateAction | DetachBulkAction | DissociateBulkAction $action): void {
+            $action->authorize(
+                fn (ManageRelatedRecords | RelationManager $livewire): bool => auth()->user()->can('update', $livewire->getOwnerRecord()),
+            );
+        };
+
+        AssociateAction::configureUsing($authorizeRelationManagerOwnerUpdate);
+        AttachAction::configureUsing($authorizeRelationManagerOwnerUpdate);
+        DetachAction::configureUsing($authorizeRelationManagerOwnerUpdate);
+        DissociateAction::configureUsing($authorizeRelationManagerOwnerUpdate);
+        DetachBulkAction::configureUsing($authorizeRelationManagerOwnerUpdate);
+        DissociateBulkAction::configureUsing($authorizeRelationManagerOwnerUpdate);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "canyon-gbs/research": "*",
         "canyon-gbs/stock-media": "*",
         "canyon-gbs/workflow": "*",
-        "canyongbs/common": "^2.18.0",
+        "canyongbs/common": "^2.21.0",
         "canyongbs/model-state-machine": "^2.0.8",
         "cknow/laravel-money": "^8.1",
         "composer/composer": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4cc46f2383f47ef2ef02179a8d33b9c3",
+    "content-hash": "54e079bb9dc162f79e823a58a0f4bd2c",
     "packages": [
         {
             "name": "ably/ably-php",
@@ -2144,16 +2144,16 @@
         },
         {
             "name": "canyongbs/common",
-            "version": "2.19.0",
+            "version": "2.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/canyongbs/common.git",
-                "reference": "59387eacdf2daa7d5808a46b17ae0b58dcedb00d"
+                "reference": "803578c7534656d4b017a1f72a57db797236fe4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/canyongbs/common/zipball/59387eacdf2daa7d5808a46b17ae0b58dcedb00d",
-                "reference": "59387eacdf2daa7d5808a46b17ae0b58dcedb00d",
+                "url": "https://api.github.com/repos/canyongbs/common/zipball/803578c7534656d4b017a1f72a57db797236fe4a",
+                "reference": "803578c7534656d4b017a1f72a57db797236fe4a",
                 "shasum": ""
             },
             "require": {
@@ -2204,9 +2204,9 @@
             ],
             "support": {
                 "issues": "https://github.com/canyongbs/common/issues",
-                "source": "https://github.com/canyongbs/common/tree/2.19.0"
+                "source": "https://github.com/canyongbs/common/tree/2.21.0"
             },
-            "time": "2026-06-11T13:11:25+00:00"
+            "time": "2026-06-22T14:00:38+00:00"
         },
         {
             "name": "canyongbs/model-state-machine",

--- a/tests/Tenant/Feature/Filament/NotificationSettings/ListNotificationSettingsTest.php
+++ b/tests/Tenant/Feature/Filament/NotificationSettings/ListNotificationSettingsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use App\Filament\Resources\NotificationSettings\Pages\ListNotificationSettings;
+use App\Models\NotificationSetting;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+it('hides the bulk delete action from a user without the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    NotificationSetting::create(['name' => 'Setting One']);
+    NotificationSetting::create(['name' => 'Setting Two']);
+
+    livewire(ListNotificationSettings::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the bulk delete action to a user with the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('settings.view-any', 'settings.*.delete');
+    actingAs($user);
+
+    NotificationSetting::create(['name' => 'Setting One']);
+    NotificationSetting::create(['name' => 'Setting Two']);
+
+    livewire(ListNotificationSettings::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});

--- a/tests/Tenant/Feature/Filament/Pronouns/ManagePronounsTest.php
+++ b/tests/Tenant/Feature/Filament/Pronouns/ManagePronounsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use App\Filament\Resources\Pronouns\Pages\ManagePronouns;
+use App\Models\Pronouns;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+it('hides the bulk delete action from a user without the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    Pronouns::factory(2)->create();
+
+    livewire(ManagePronouns::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the bulk delete action to a user with the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('settings.view-any', 'settings.*.delete');
+    actingAs($user);
+
+    Pronouns::factory(2)->create();
+
+    livewire(ManagePronouns::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});

--- a/tests/Tenant/Feature/Filament/SystemUsers/ListSystemUsersTest.php
+++ b/tests/Tenant/Feature/Filament/SystemUsers/ListSystemUsersTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use App\Filament\Resources\SystemUsers\Pages\ListSystemUsers;
+use App\Models\SystemUser;
+use App\Models\User;
+use Filament\Actions\DeleteBulkAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+it('hides the bulk delete action from a user without the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('system_user.view-any');
+    actingAs($user);
+
+    SystemUser::factory(2)->create();
+
+    livewire(ListSystemUsers::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionHidden(DeleteBulkAction::class);
+});
+
+it('shows the bulk delete action to a user with the delete permission', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('system_user.view-any', 'system_user.*.delete');
+    actingAs($user);
+
+    SystemUser::factory(2)->create();
+
+    livewire(ListSystemUsers::class)
+        ->assertSuccessful()
+        ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2715

### Technical Description

> Gate write actions behind permissions: bulk delete/restore (deleteAny/restoreAny/forceDeleteAny + `authorizeIndividualRecords`), duplicate (replicate policy), custom create buttons, and relation-manager attach/detach (owner update, with care-team/subscriptions/tasks using their own permissions). Adds permission tests across the affected resources.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
