### PR TITLE
[ADVAPP-2741]: Some users have reported failures when uploading large files during AI chat

### DIFF
--- a/app-modules/ai/src/Http/Controllers/Advisors/RetryMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/Advisors/RetryMessageController.php
@@ -72,7 +72,7 @@ class RetryMessageController
                     ),
                     'ip' => request()->ip(),
                 ],
-                files: AiMessageFile::query()->whereKey($request->validated('files'))->get()->all(),
+                files: AiMessageFile::query()->whereKey($request->validated('files'))->get(),
                 hasImageGeneration: $request->validated('has_image_generation') ?? false,
             ))->onConnection('background');
 

--- a/app-modules/ai/src/Http/Controllers/Advisors/SendMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/Advisors/SendMessageController.php
@@ -73,7 +73,7 @@ class SendMessageController
                     ),
                     'ip' => request()->ip(),
                 ],
-                files: AiMessageFile::query()->whereKey($request->validated('files'))->get()->all(),
+                files: AiMessageFile::query()->whereKey($request->validated('files'))->get(),
                 hasImageGeneration: $request->validated('has_image_generation') ?? false,
             ))->onConnection('background');
 

--- a/app-modules/ai/src/Jobs/Advisors/RetryAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/RetryAdvisorMessage.php
@@ -49,6 +49,7 @@ use AdvisingApp\Ai\Support\StreamingChunks\Text;
 use AdvisingApp\Ai\Support\StreamingChunks\Thinking;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
@@ -66,13 +67,13 @@ class RetryAdvisorMessage implements ShouldQueue
 
     /**
      * @param array<string, mixed> $request
-     * @param array<AiMessageFile> $files
+     * @param Collection<int, AiMessageFile> $files
      */
     public function __construct(
         protected AiThread $thread,
         protected string $content,
         protected array $request = [],
-        protected array $files = [],
+        protected Collection $files = new Collection(),
         protected bool $hasImageGeneration = false,
     ) {}
 
@@ -102,7 +103,7 @@ class RetryAdvisorMessage implements ShouldQueue
         try {
             $stream = $aiService->retryMessage(
                 message: $message,
-                files: $this->files,
+                files: $this->files->all(),
                 hasImageGeneration: $this->hasImageGeneration,
             );
         } catch (Throwable $exception) {

--- a/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
@@ -50,6 +50,7 @@ use AdvisingApp\Ai\Support\StreamingChunks\Text;
 use AdvisingApp\Ai\Support\StreamingChunks\Thinking;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
@@ -68,13 +69,13 @@ class SendAdvisorMessage implements ShouldQueue
 
     /**
      * @param array<string, mixed> $request
-     * @param array<AiMessageFile> $files
+     * @param Collection<int, AiMessageFile> $files
      */
     public function __construct(
         protected AiThread $thread,
         protected string | Prompt $content,
         protected array $request = [],
-        protected array $files = [],
+        protected Collection $files = new Collection(),
         protected bool $hasImageGeneration = false,
     ) {}
 
@@ -124,7 +125,7 @@ class SendAdvisorMessage implements ShouldQueue
         try {
             $stream = $aiService->sendMessage(
                 message: $message,
-                files: $this->files,
+                files: $this->files->all(),
                 hasImageGeneration: $this->hasImageGeneration,
             );
         } catch (Throwable $exception) {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2741

### Technical Description

When a user sends a message to an AI advisor with too large a file, like a PDF attachment (parsed by LlamaParse), the request fails with:

```
proc_open(): posix_spawn() failed: Argument list too long
```

**Root cause:** The `SendAdvisorMessage` and `RetryAdvisorMessage` jobs accept `$files` as a plain PHP `array<AiMessageFile>`. Because `SerializesModels` only converts top-level properties that implement `QueueableCollection` or `QueueableEntity` — and does **not** recurse into plain arrays — the full Eloquent model instances (including the `parsing_results` longText column containing the entire parsed document) are serialized verbatim.

The `background` queue connection uses `TenantAwareBackgroundQueue`, which passes the serialized job inside a closure to `Concurrency::driver('process')->defer()`. The process driver encodes this into an environment variable for a child PHP process. When `parsing_results` contains a large document, the combined argv + envp exceeds the OS limit (~2MB on Linux), causing `posix_spawn()` to fail.

### Fix

Changed the `$files` property on both jobs from `array` to `Illuminate\Database\Eloquent\Collection`. Since Eloquent Collection implements `QueueableCollection`, the `SerializesModels` trait now properly replaces it with a lightweight `ModelIdentifier` (class name + primary keys, ~50 bytes) during serialization. The models are re-fetched from the database when the job deserializes and executes.

Further details of the error can be found in the Sentry report linked to the ticket.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
