### PR TITLE
[ADVAPP-2742]: There are error reports related to Customer Advisors having a null model

### DIFF
--- a/app-modules/ai/src/Actions/GenerateCustomerAdvisorIntroductoryMessage.php
+++ b/app-modules/ai/src/Actions/GenerateCustomerAdvisorIntroductoryMessage.php
@@ -49,7 +49,13 @@ class GenerateCustomerAdvisorIntroductoryMessage
             return $advisor->introductory_message ?? null;
         }
 
-        $aiService = $advisor->getAiServiceModel()->getService();
+        $aiModel = $advisor->getAiServiceModel();
+
+        if (! $aiModel) {
+            return null;
+        }
+
+        $aiService = $aiModel->getService();
 
         return $aiService->complete(
             prompt: $this->buildContext($advisor, $author),

--- a/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/ListCustomerAdvisors.php
+++ b/app-modules/ai/src/Filament/Resources/CustomerAdvisors/Pages/ListCustomerAdvisors.php
@@ -85,7 +85,8 @@ class ListCustomerAdvisors extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
-            CreateAction::make(),
+            CreateAction::make()
+                ->authorizationTooltip(),
         ];
     }
 }

--- a/app-modules/ai/src/Http/Controllers/CustomerAdvisors/SendAdvisorMessageController.php
+++ b/app-modules/ai/src/Http/Controllers/CustomerAdvisors/SendAdvisorMessageController.php
@@ -57,7 +57,15 @@ class SendAdvisorMessageController
         ]);
 
         if ($request->query('preview')) {
-            $aiService = $advisor->getAiServiceModel()->getService();
+            $aiModel = $advisor->getAiServiceModel();
+
+            if (! $aiModel) {
+                return response()->json([
+                    'message' => 'No AI model is configured for this advisor.',
+                ], 422);
+            }
+
+            $aiService = $aiModel->getService();
 
             try {
                 return response()->stream(

--- a/app-modules/ai/src/Jobs/CustomerAdvisors/RetryCustomerAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/CustomerAdvisors/RetryCustomerAdvisorMessage.php
@@ -95,8 +95,22 @@ class RetryCustomerAdvisorMessage implements ShouldQueue
         $message->request = $this->request;
         $message->save();
 
+        $aiModel = $this->advisor->getAiServiceModel();
+
+        if (! $aiModel) {
+            event(new CustomerAdvisorMessageChunk(
+                $this->advisor,
+                $this->thread,
+                content: '',
+                isComplete: false,
+                error: 'No AI model is configured for this advisor.',
+            ));
+
+            return;
+        }
+
         try {
-            $aiService = $this->advisor->getAiServiceModel()->getService();
+            $aiService = $aiModel->getService();
 
             $files = [
                 ...$this->advisor->files()->whereNotNull('parsing_results')->get()->all(),

--- a/app-modules/ai/src/Jobs/CustomerAdvisors/SendCustomerAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/CustomerAdvisors/SendCustomerAdvisorMessage.php
@@ -86,8 +86,22 @@ class SendCustomerAdvisorMessage implements ShouldQueue
         $message->is_advisor = false;
         $message->save();
 
+        $aiModel = $this->advisor->getAiServiceModel();
+
+        if (! $aiModel) {
+            event(new CustomerAdvisorMessageChunk(
+                $this->advisor,
+                $this->thread,
+                content: '',
+                isComplete: false,
+                error: 'No AI model is configured for this advisor.',
+            ));
+
+            return;
+        }
+
         try {
-            $aiService = $this->advisor->getAiServiceModel()->getService();
+            $aiService = $aiModel->getService();
 
             $files = [
                 ...$this->advisor->files()->whereNotNull('parsing_results')->get()->all(),

--- a/app-modules/ai/src/Models/CustomerAdvisor.php
+++ b/app-modules/ai/src/Models/CustomerAdvisor.php
@@ -194,7 +194,7 @@ class CustomerAdvisor extends BaseModel implements HasMedia, Auditable
             ->all();
     }
 
-    public function getAiServiceModel(): AiModel
+    public function getAiServiceModel(): ?AiModel
     {
         $settings = app(AiCustomerAdvisorSettings::class);
 

--- a/app-modules/ai/src/Policies/CustomerAdvisorPolicy.php
+++ b/app-modules/ai/src/Policies/CustomerAdvisorPolicy.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Ai\Policies;
 
+use AdvisingApp\Ai\Enums\AiModelApplicabilityFeature;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use App\Concerns\PerformsLicenseChecks;
 use App\Enums\Feature;
@@ -78,6 +79,10 @@ class CustomerAdvisorPolicy
 
     public function create(Authenticatable $authenticatable): Response
     {
+        if (empty(AiModelApplicabilityFeature::CustomerAdvisor->getModels())) {
+            return Response::deny('No AI models are configured for Customer Advisors.');
+        }
+
         return $authenticatable->canOrElse(
             abilities: 'customer_advisor.create',
             denyResponse: 'You do not have permission to create Customer Advisors.'

--- a/app-modules/integration-open-ai/src/Jobs/UploadCustomerAdvisorFilesToVectorStore.php
+++ b/app-modules/integration-open-ai/src/Jobs/UploadCustomerAdvisorFilesToVectorStore.php
@@ -69,7 +69,13 @@ class UploadCustomerAdvisorFilesToVectorStore implements ShouldQueue, TenantAwar
 
     public function handle(): void
     {
-        $service = $this->advisor->getAiServiceModel()->getService();
+        $aiModel = $this->advisor->getAiServiceModel();
+
+        if (! $aiModel) {
+            return;
+        }
+
+        $service = $aiModel->getService();
 
         if (! ($service instanceof BaseOpenAiService)) {
             return;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2742

### Technical Description

Prevents errors from advisor usage with missing model configuration. Presents user-friendly notices about the fact that no model is configured when sending a message or creating an advisor.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
