### PR TITLE
[ADVAPP-2771]: Kanban boards throw an error when you drag an empty column's placeholder onto another column

### DIFF
--- a/app-modules/pipeline/resources/js/kanban.js
+++ b/app-modules/pipeline/resources/js/kanban.js
@@ -40,6 +40,7 @@ document.addEventListener('alpine:init', () => {
                 window.Sortable.create(kanbanList, {
                     group: 'kanban',
                     animation: 100,
+                    draggable: '[data-pipeline]',
                     forceFallback: true,
                     dragClass: 'drag-card',
                     ghostClass: 'ghost-card',

--- a/app-modules/task/resources/js/kanban.js
+++ b/app-modules/task/resources/js/kanban.js
@@ -40,6 +40,7 @@ document.addEventListener('alpine:init', () => {
                 window.Sortable.create(kanbanList, {
                     group: 'kanban',
                     animation: 100,
+                    draggable: '[data-task]',
                     forceFallback: true,
                     dragClass: 'drag-card',
                     ghostClass: 'ghost-card',


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2771

### Technical Description

- Added draggable option in JS file so empty sate placeholder will not drag and drop.

### Any deployment steps required?

No

### Cleanup Tasks

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
