### PR TITLE
[ADVAPP-2814]: Introduce event registration form versioning

### DIFF
--- a/.cleanup-tasks/2026_07_13_event_versioning_feature.md
+++ b/.cleanup-tasks/2026_07_13_event_versioning_feature.md
@@ -10,3 +10,5 @@ created: 2026-07-13
 ## Temporary Migrations
 
 ## Additional Cleanup
+
+- Search for `TODO: Cleanup Task - EventVersioningFeature` in the codebase for inline cleanup instructions (migration backfill comments)

--- a/.cleanup-tasks/2026_07_13_event_versioning_feature.md
+++ b/.cleanup-tasks/2026_07_13_event_versioning_feature.md
@@ -17,6 +17,7 @@ created: 2026-07-13
         // TODO: Cleanup Task - EventVersioningFeature - This backfill can be removed once all environments have run this migration
         DB::update('UPDATE event_registration_forms SET root_id = id WHERE root_id IS NULL');
         ```
+    2. Remove the feature flag activate and deactivate from `up()` and `down()` method respectively.
 
 - In `app-modules/meeting-center/src/Models/Event.php`:
     1. Replace the guarded `eventRegistrationForm()` relationship with an unconditional version — keep `->whereNull('archived_at')` but remove the `if (EventVersioningFeature::active())` wrapper:
@@ -36,11 +37,11 @@ created: 2026-07-13
 
 - In `app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php`:
     1. In `saveRelationshipsBeforeChildrenUsing`, remove the `if (EventVersioningFeature::active()) { ... } else { $record->fill($data); $record->save(); }` branching — keep only the versioning branch (the `if` body) and un-indent it.
-    2. Remove the three `->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists())` modifiers on the `is_wizard` Toggle, the `Form Fields` Section, and the `steps` Repeater — versioning is always active, so this condition is permanently false and the `->disabled()` call serves no purpose.
+    2. Remove the `! EventVersioningFeature::active()` part form the three disabled modifiers.
     3. Remove the `use App\Features\EventVersioningFeature;` import.
 
 - In `app-modules/meeting-center/src/Filament/Resources/Events/Pages/Concerns/HasSharedEventFormConfiguration.php`:
-    1. Remove the three `->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists())` modifiers on the `is_wizard` Toggle, the `Fields` Section, and the `steps` Repeater — same reasoning as above.
+    1. Remove the `! EventVersioningFeature::active()` part form the three disabled modifiers.
     2. Remove the `use App\Features\EventVersioningFeature;` import.
 
 - Delete the feature flag class itself: `app/Features/EventVersioningFeature.php`.

--- a/.cleanup-tasks/2026_07_13_event_versioning_feature.md
+++ b/.cleanup-tasks/2026_07_13_event_versioning_feature.md
@@ -44,4 +44,7 @@ created: 2026-07-13
     1. Remove the `! EventVersioningFeature::active()` part form the three disabled modifiers.
     2. Remove the `use App\Features\EventVersioningFeature;` import.
 
+- In `app-modules/meeting-center/src/Actions/DuplicateEvent.php`
+    1. Remove the condition `if (EventVersioningFeature::active())` and the code inside it should run unconditionally. 
+
 - Delete the feature flag class itself: `app/Features/EventVersioningFeature.php`.

--- a/.cleanup-tasks/2026_07_13_event_versioning_feature.md
+++ b/.cleanup-tasks/2026_07_13_event_versioning_feature.md
@@ -45,6 +45,6 @@ created: 2026-07-13
     2. Remove the `use App\Features\EventVersioningFeature;` import.
 
 - In `app-modules/meeting-center/src/Actions/DuplicateEvent.php`
-    1. Remove the condition `if (EventVersioningFeature::active())` and the code inside it should run unconditionally. 
+    1. Remove the condition `if (EventVersioningFeature::active())` and the code inside it should run unconditionally.
 
 - Delete the feature flag class itself: `app/Features/EventVersioningFeature.php`.

--- a/.cleanup-tasks/2026_07_13_event_versioning_feature.md
+++ b/.cleanup-tasks/2026_07_13_event_versioning_feature.md
@@ -11,4 +11,36 @@ created: 2026-07-13
 
 ## Additional Cleanup
 
-- Search for `TODO: Cleanup Task - EventVersioningFeature` in the codebase for inline cleanup instructions (migration backfill comments)
+- In `app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php`:
+    1. Remove the backfill statement and its TODO comment:
+       ```php
+       // TODO: Cleanup Task - EventVersioningFeature - This backfill can be removed once all environments have run this migration
+       DB::update('UPDATE event_registration_forms SET root_id = id WHERE root_id IS NULL');
+       ```
+
+- In `app-modules/meeting-center/src/Models/Event.php`:
+    1. Replace the guarded `eventRegistrationForm()` relationship with an unconditional version — keep `->whereNull('archived_at')` but remove the `if (EventVersioningFeature::active())` wrapper:
+       ```php
+       // Before
+       if (EventVersioningFeature::active()) {
+           $relationship->whereNull('archived_at');
+       }
+       // After — remove the if, keep the whereNull
+       $relationship->whereNull('archived_at');
+       ```
+    2. Remove the `use App\Features\EventVersioningFeature;` import.
+
+- In `app-modules/meeting-center/src/Observers/EventRegistrationFormObserver.php`:
+    1. Remove the `if (! EventVersioningFeature::active()) { return; }` early-return guard — let `$form->root_id = $form->id` run unconditionally.
+    2. Remove the `use App\Features\EventVersioningFeature;` import.
+
+- In `app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php`:
+    1. In `saveRelationshipsBeforeChildrenUsing`, remove the `if (EventVersioningFeature::active()) { ... } else { $record->fill($data); $record->save(); }` branching — keep only the versioning branch (the `if` body) and un-indent it.
+    2. Remove the three `->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists())` modifiers on the `is_wizard` Toggle, the `Form Fields` Section, and the `steps` Repeater — versioning is always active, so this condition is permanently false and the `->disabled()` call serves no purpose.
+    3. Remove the `use App\Features\EventVersioningFeature;` import.
+
+- In `app-modules/meeting-center/src/Filament/Resources/Events/Pages/Concerns/HasSharedEventFormConfiguration.php`:
+    1. Remove the three `->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists())` modifiers on the `is_wizard` Toggle, the `Fields` Section, and the `steps` Repeater — same reasoning as above.
+    2. Remove the `use App\Features\EventVersioningFeature;` import.
+
+- Delete the feature flag class itself: `app/Features/EventVersioningFeature.php`.

--- a/.cleanup-tasks/2026_07_13_event_versioning_feature.md
+++ b/.cleanup-tasks/2026_07_13_event_versioning_feature.md
@@ -13,21 +13,21 @@ created: 2026-07-13
 
 - In `app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php`:
     1. Remove the backfill statement and its TODO comment:
-       ```php
-       // TODO: Cleanup Task - EventVersioningFeature - This backfill can be removed once all environments have run this migration
-       DB::update('UPDATE event_registration_forms SET root_id = id WHERE root_id IS NULL');
-       ```
+        ```php
+        // TODO: Cleanup Task - EventVersioningFeature - This backfill can be removed once all environments have run this migration
+        DB::update('UPDATE event_registration_forms SET root_id = id WHERE root_id IS NULL');
+        ```
 
 - In `app-modules/meeting-center/src/Models/Event.php`:
     1. Replace the guarded `eventRegistrationForm()` relationship with an unconditional version — keep `->whereNull('archived_at')` but remove the `if (EventVersioningFeature::active())` wrapper:
-       ```php
-       // Before
-       if (EventVersioningFeature::active()) {
-           $relationship->whereNull('archived_at');
-       }
-       // After — remove the if, keep the whereNull
-       $relationship->whereNull('archived_at');
-       ```
+        ```php
+        // Before
+        if (EventVersioningFeature::active()) {
+            $relationship->whereNull('archived_at');
+        }
+        // After — remove the if, keep the whereNull
+        $relationship->whereNull('archived_at');
+        ```
     2. Remove the `use App\Features\EventVersioningFeature;` import.
 
 - In `app-modules/meeting-center/src/Observers/EventRegistrationFormObserver.php`:

--- a/.cleanup-tasks/2026_07_13_event_versioning_feature.md
+++ b/.cleanup-tasks/2026_07_13_event_versioning_feature.md
@@ -1,0 +1,12 @@
+---
+title: Event Versioning Feature
+created: 2026-07-13
+---
+
+## Feature Flags
+
+- App\Features\EventVersioningFeature
+
+## Temporary Migrations
+
+## Additional Cleanup

--- a/app-modules/application/src/Models/ApplicationSubmissionState.php
+++ b/app-modules/application/src/Models/ApplicationSubmissionState.php
@@ -53,6 +53,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use OwenIt\Auditing\Contracts\Auditable;
 
 /**
+ * @property bool $is_default
+ *
  * @mixin IdeHelperApplicationSubmissionState
  */
 #[ObservedBy([ApplicationSubmissionStateObserver::class])]

--- a/app-modules/form/src/Filament/Blocks/FormFieldBlock.php
+++ b/app-modules/form/src/Filament/Blocks/FormFieldBlock.php
@@ -96,7 +96,7 @@ abstract class FormFieldBlock extends RichContentCustomBlock
         // (e.g. dragging a new block in). getPreviewLabel() supplies the block default.
         $config['label'] ??= static::getPreviewLabel($config);
         $config['isRequired'] ??= false;
- 
+
         return view(static::previewView(), $config)->render();
     }
 

--- a/app-modules/form/src/Filament/Blocks/FormFieldBlock.php
+++ b/app-modules/form/src/Filament/Blocks/FormFieldBlock.php
@@ -91,6 +91,12 @@ abstract class FormFieldBlock extends RichContentCustomBlock
 
     public static function toPreviewHtml(array $config): ?string
     {
+        // Preview blades reference $label and $isRequired directly, so guarantee they
+        // exist even when the block is previewed before its config has been filled
+        // (e.g. dragging a new block in). getPreviewLabel() supplies the block default.
+        $config['label'] ??= static::getPreviewLabel($config);
+        $config['isRequired'] ??= false;
+ 
         return view(static::previewView(), $config)->render();
     }
 

--- a/app-modules/form/src/Filament/Resources/Forms/Pages/ListForms.php
+++ b/app-modules/form/src/Filament/Resources/Forms/Pages/ListForms.php
@@ -55,7 +55,6 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 
 class ListForms extends ListRecords
 {
@@ -102,8 +101,10 @@ class ListForms extends ListRecords
                                 ->required(),
                         ]);
                     })
-                    ->beforeReplicaSaved(function (Model $replica, array $data): void {
+                    ->beforeReplicaSaved(function (Form $replica, array $data): void {
                         $replica->name = $data['name'];
+                        $replica->setAttribute('root_id', null);
+                        $replica->archived_at = null;
                     })
                     ->after(function (Form $replica, Form $record): void {
                         resolve(DuplicateForm::class, ['original' => $record, 'replica' => $replica])();

--- a/app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php
+++ b/app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of

--- a/app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php
+++ b/app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php
@@ -48,7 +48,8 @@ return new class () extends Migration {
                 $table->uuid('root_id')->nullable();
                 $table->timestamp('archived_at')->nullable();
             });
-
+            
+            // TODO: Cleanup Task - EventVersioningFeature - This backfill can be removed once all environments have run this migration
             DB::update('UPDATE event_registration_forms SET root_id = id WHERE root_id IS NULL');
 
             Schema::table('event_registration_forms', function (Blueprint $table) {

--- a/app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php
+++ b/app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php
@@ -48,7 +48,7 @@ return new class () extends Migration {
                 $table->uuid('root_id')->nullable();
                 $table->timestamp('archived_at')->nullable();
             });
-            
+
             // TODO: Cleanup Task - EventVersioningFeature - This backfill can be removed once all environments have run this migration
             DB::update('UPDATE event_registration_forms SET root_id = id WHERE root_id IS NULL');
 

--- a/app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php
+++ b/app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use App\Features\EventVersioningFeature;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::transaction(function () {
+            Schema::table('event_registration_forms', function (Blueprint $table) {
+                $table->uuid('root_id')->nullable();
+                $table->timestamp('archived_at')->nullable();
+            });
+
+            DB::update('UPDATE event_registration_forms SET root_id = id WHERE root_id IS NULL');
+
+            Schema::table('event_registration_forms', function (Blueprint $table) {
+                $table->uuid('root_id')->nullable(false)->change();
+                $table->foreign('root_id')->references('id')->on('event_registration_forms');
+                $table->index('root_id');
+            });
+
+            EventVersioningFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            EventVersioningFeature::deactivate();
+
+            Schema::table('event_registration_forms', function (Blueprint $table) {
+                $table->dropForeign(['root_id']);
+                $table->dropIndex(['root_id']);
+                $table->dropColumn(['root_id', 'archived_at']);
+            });
+        });
+    }
+};

--- a/app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php
+++ b/app-modules/meeting-center/database/migrations/2026_07_13_115355_add_versioning_to_event_registration_forms_table.php
@@ -36,6 +36,7 @@
 
 use App\Features\EventVersioningFeature;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
@@ -58,6 +59,24 @@ return new class () extends Migration {
                 $table->index('root_id');
             });
 
+            // Archive all but the most recently created active form per event
+            // so the partial unique index can be created cleanly on existing data.
+            DB::statement(
+                'UPDATE event_registration_forms
+                 SET archived_at = NOW()
+                 WHERE archived_at IS NULL
+                   AND id NOT IN (
+                       SELECT DISTINCT ON (event_id) id
+                       FROM event_registration_forms
+                       WHERE archived_at IS NULL
+                       ORDER BY event_id, created_at DESC
+                   )'
+            );
+
+            Schema::table('event_registration_forms', function (Blueprint $table) {
+                $table->uniqueIndex(['event_id'])->where(fn (Builder $condition) => $condition->whereNull('archived_at'));
+            });
+
             EventVersioningFeature::activate();
         });
     }
@@ -66,6 +85,10 @@ return new class () extends Migration {
     {
         DB::transaction(function () {
             EventVersioningFeature::deactivate();
+
+            Schema::table('event_registration_forms', function (Blueprint $table) {
+                $table->dropIndex('event_registration_forms_event_id_unique');
+            });
 
             Schema::table('event_registration_forms', function (Blueprint $table) {
                 $table->dropForeign(['root_id']);

--- a/app-modules/meeting-center/src/Actions/CreateEventRegistrationFormVersion.php
+++ b/app-modules/meeting-center/src/Actions/CreateEventRegistrationFormVersion.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of

--- a/app-modules/meeting-center/src/Actions/CreateEventRegistrationFormVersion.php
+++ b/app-modules/meeting-center/src/Actions/CreateEventRegistrationFormVersion.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\MeetingCenter\Actions;
+
+use AdvisingApp\MeetingCenter\Models\EventRegistrationForm;
+use Illuminate\Support\Facades\DB;
+
+class CreateEventRegistrationFormVersion
+{
+    /** @param array<string, mixed> $newData */
+    public function execute(EventRegistrationForm $oldVersion, array $newData): EventRegistrationForm
+    {
+        return DB::transaction(function () use ($oldVersion, $newData) {
+            $oldVersion->archive();
+
+            $newVersion = new EventRegistrationForm();
+            $newVersion->embed_enabled = $oldVersion->embed_enabled;
+            $newVersion->allowed_domains = $oldVersion->allowed_domains;
+            $newVersion->primary_color = $oldVersion->primary_color;
+            $newVersion->rounding = $oldVersion->rounding;
+            $newVersion->recaptcha_enabled = $oldVersion->recaptcha_enabled;
+            $newVersion->is_wizard = $oldVersion->is_wizard;
+            $newVersion->fill($newData);
+            $newVersion->root_id = $oldVersion->root_id;
+            $newVersion->event_id = $oldVersion->event_id;
+            $newVersion->save();
+
+            return $newVersion;
+        });
+    }
+}

--- a/app-modules/meeting-center/src/Actions/DuplicateEvent.php
+++ b/app-modules/meeting-center/src/Actions/DuplicateEvent.php
@@ -39,6 +39,7 @@ namespace AdvisingApp\MeetingCenter\Actions;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationFormField;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationFormStep;
+use App\Features\EventVersioningFeature;
 
 class DuplicateEvent
 {
@@ -59,6 +60,13 @@ class DuplicateEvent
     {
         $duplicatedEventRegistrationForm = $this->original->eventRegistrationForm->replicate();
         $duplicatedEventRegistrationForm->event_id = $this->replica->id;
+        if (EventVersioningFeature::active()) {
+            // replicate() copies root_id/archived_at, which would place the duplicated
+            // form in the original event's version tree. Reset them so the observer
+            // assigns a fresh, self-referential root for the new event.
+            $duplicatedEventRegistrationForm->root_id = null;
+            $duplicatedEventRegistrationForm->archived_at = null;
+        }
         $duplicatedEventRegistrationForm->save();
     }
 

--- a/app-modules/meeting-center/src/Actions/DuplicateEvent.php
+++ b/app-modules/meeting-center/src/Actions/DuplicateEvent.php
@@ -60,6 +60,7 @@ class DuplicateEvent
     {
         $duplicatedEventRegistrationForm = $this->original->eventRegistrationForm->replicate();
         $duplicatedEventRegistrationForm->event_id = $this->replica->id;
+
         if (EventVersioningFeature::active()) {
             // replicate() copies root_id/archived_at, which would place the duplicated
             // form in the original event's version tree. Reset them so the observer

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/Concerns/HasSharedEventFormConfiguration.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/Concerns/HasSharedEventFormConfiguration.php
@@ -43,6 +43,7 @@ use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationForm;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationFormField;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationFormStep;
+use App\Features\EventVersioningFeature;
 use CanyonGBS\Common\Filament\Forms\Components\ColorSelect;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Repeater;
@@ -125,13 +126,13 @@ trait HasSharedEventFormConfiguration
                     Toggle::make('is_wizard')
                         ->label('Multi-step form')
                         ->live()
-                        ->disabled(fn (?EventRegistrationForm $record) => $record?->submissions()->exists()),
+                        ->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists()),
                     Section::make('Fields')
                         ->schema([
                             $this->fieldBuilder(),
                         ])
                         ->hidden(fn (Get $get) => $get('is_wizard'))
-                        ->disabled(fn (?EventRegistrationForm $record) => $record?->submissions()->exists()),
+                        ->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists()),
                     Repeater::make('steps')
                         ->schema([
                             TextInput::make('label')
@@ -146,7 +147,7 @@ trait HasSharedEventFormConfiguration
                         ->addActionLabel('New step')
                         ->itemLabel(fn (array $state): ?string => $state['label'] ?? null)
                         ->visible(fn (Get $get) => $get('is_wizard'))
-                        ->disabled(fn (?EventRegistrationForm $record) => $record?->submissions()->exists())
+                        ->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists())
                         ->relationship()
                         ->orderColumn('sort')
                         ->columnSpanFull(),

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
@@ -88,11 +88,7 @@ class EditEventRegistration extends EditRecord
                                 if ($newVersion->is_wizard) {
                                     $sort = 1;
                                     $wizardStepVersionMap = [];
-
-                                    // $data['steps'] is always null because Repeater::relationship()
-                                    // internally calls ->dehydrated(false), excluding it from $data.
-                                    // Instead, read steps directly from the Repeater component's raw
-                                    // Livewire state, which includes unsaved new items from the UI.
+                                    
                                     $repeaterState = collect($component->getChildComponentContainer()->getComponents(withHidden: true, withActions: false))
                                         ->first(fn ($component) => $component instanceof Repeater && $component->getName() === 'steps')
                                         ?->getRawState();
@@ -108,16 +104,10 @@ class EditEventRegistration extends EditRecord
                                             'label' => $stepData['label'] ?? 'Untitled Step',
                                             'sort' => $sort++,
                                         ]);
-                                        // The Repeater prefixes existing-record keys with 'record-'.
-                                        // Strip it so the key matches $record->id in the RichEditor callback.
+                                        
                                         $mapKey = str_starts_with((string) $key, 'record-') ? substr((string) $key, 7) : (string) $key;
                                         $wizardStepVersionMap[$mapKey] = $newStep;
 
-                                        // For newly added steps (temp key, not yet in DB), save their blocks here.
-                                        // The RichEditor's saveRelationships callback cannot run for new items
-                                        // because getRecord() returns null (model is a class string, not an
-                                        // instance) → Component::saveRelationships() returns early before
-                                        // the callback is ever invoked.
                                         if (! str_starts_with((string) $key, 'record-')) {
                                             $stepContent = $stepData['content'] ?? null;
 

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
@@ -88,7 +88,7 @@ class EditEventRegistration extends EditRecord
                                 if ($newVersion->is_wizard) {
                                     $sort = 1;
                                     $wizardStepVersionMap = [];
-                                    
+
                                     $repeaterState = collect($component->getChildComponentContainer()->getComponents(withHidden: true, withActions: false))
                                         ->first(fn ($component) => $component instanceof Repeater && $component->getName() === 'steps')
                                         ?->getRawState();
@@ -104,7 +104,7 @@ class EditEventRegistration extends EditRecord
                                             'label' => $stepData['label'] ?? 'Untitled Step',
                                             'sort' => $sort++,
                                         ]);
-                                        
+
                                         $mapKey = str_starts_with((string) $key, 'record-') ? substr((string) $key, 7) : (string) $key;
                                         $wizardStepVersionMap[$mapKey] = $newStep;
 

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
@@ -37,11 +37,13 @@
 namespace AdvisingApp\MeetingCenter\Filament\Resources\Events\Pages;
 
 use AdvisingApp\Form\Filament\Blocks\FormFieldBlockRegistry;
+use AdvisingApp\MeetingCenter\Actions\CreateEventRegistrationFormVersion;
 use AdvisingApp\MeetingCenter\Filament\Resources\Events\EventResource;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationForm;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationFormField;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationFormStep;
+use App\Features\EventVersioningFeature;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\RichEditor\ToolbarButtonGroup;
@@ -67,14 +69,19 @@ class EditEventRegistration extends EditRecord
         return $schema->components([
             Fieldset::make('Registration Form')
                 ->relationship('eventRegistrationForm')
-                ->saveRelationshipsBeforeChildrenUsing(static function (Component | CanEntangleWithSingularRelationships $component): void {
+                ->saveRelationshipsBeforeChildrenUsing(function (Component | CanEntangleWithSingularRelationships $component): void {
                     $relationship = $component->getRelationship();
                     $record = $component->getCachedExistingRecord();
                     $data = $component->getChildComponentContainer()->getState(shouldCallHooksBefore: false);
 
-                    if ($record) {
-                        $record->fill($data);
-                        $record->save();
+                    if ($record instanceof EventRegistrationForm) {
+                        if (EventVersioningFeature::active()) {
+                            $newVersion = app(CreateEventRegistrationFormVersion::class)->execute($record, $data);
+                            $component->cachedExistingRecord($newVersion);
+                        } else {
+                            $record->fill($data);
+                            $record->save();
+                        }
                     } else {
                         $data = $component->mutateRelationshipDataBeforeCreate($data);
 
@@ -84,23 +91,23 @@ class EditEventRegistration extends EditRecord
                         $record->fill($data);
 
                         $relationship->save($record);
-                    }
 
-                    $component->cachedExistingRecord($record);
+                        $component->cachedExistingRecord($record);
+                    }
                 })
                 ->saveRelationshipsUsing(null)
                 ->schema([
                     Toggle::make('is_wizard')
                         ->label('Multi-step form')
                         ->live()
-                        ->disabled(fn (?EventRegistrationForm $record) => $record?->submissions()->exists()),
+                        ->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists()),
 
                     Section::make('Form Fields')
                         ->schema([
                             $this->fieldBuilder(),
                         ])
                         ->hidden(fn (Get $get) => $get('is_wizard'))
-                        ->disabled(fn (?EventRegistrationForm $record) => $record?->submissions()->exists()),
+                        ->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists()),
 
                     Repeater::make('steps')
                         ->schema([
@@ -116,7 +123,7 @@ class EditEventRegistration extends EditRecord
                         ->addActionLabel('New step')
                         ->itemLabel(fn (array $state): ?string => $state['label'] ?? null)
                         ->visible(fn (Get $get) => $get('is_wizard'))
-                        ->disabled(fn (?EventRegistrationForm $record) => $record?->submissions()->exists())
+                        ->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists())
                         ->relationship()
                         ->reorderable()
                         ->columnSpanFull(),

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\MeetingCenter\Filament\Resources\Events\Pages;
 
+use AdvisingApp\Form\Actions\SaveSubmissibleFieldsFromContent;
 use AdvisingApp\Form\Filament\Blocks\FormFieldBlockRegistry;
 use AdvisingApp\MeetingCenter\Actions\CreateEventRegistrationFormVersion;
 use AdvisingApp\MeetingCenter\Filament\Resources\Events\EventResource;
@@ -57,12 +58,15 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Support\Facades\DB;
 
 class EditEventRegistration extends EditRecord
 {
     protected static string $resource = EventResource::class;
 
     protected static ?string $navigationLabel = 'Registration Form';
+
+    protected bool $registrationFormVersionedInCurrentSave = false;
 
     public function form(Schema $schema): Schema
     {
@@ -76,8 +80,38 @@ class EditEventRegistration extends EditRecord
 
                     if ($record instanceof EventRegistrationForm) {
                         if (EventVersioningFeature::active()) {
-                            $newVersion = app(CreateEventRegistrationFormVersion::class)->execute($record, $data);
-                            $component->cachedExistingRecord($newVersion);
+                            $newVersion = DB::transaction(function () use ($component, $record, $data): EventRegistrationForm {
+                                $newVersion = app(CreateEventRegistrationFormVersion::class)->execute($record, $data);
+
+                                if ($newVersion->is_wizard) {
+                                    // The Repeater state inside a nested Fieldset relationship is not
+                                    // reliably dehydrated, so we source step data directly from the
+                                    // old version and let SaveSubmissibleFieldsFromContent recreate
+                                    // the steps and their fields on the new version.
+                                    $stepsData = ! empty($data['steps'])
+                                        ? array_values($data['steps'])
+                                        : $record->steps()->orderBy('sort')->get()
+                                            ->map(fn (EventRegistrationFormStep $step) => [
+                                                'label' => $step->label,
+                                                'content' => $step->content,
+                                            ])
+                                            ->all();
+
+                                    app(SaveSubmissibleFieldsFromContent::class)->execute(
+                                        $newVersion,
+                                        ['steps' => $stepsData],
+                                    );
+                                }
+
+                                $component->cachedExistingRecord($newVersion);
+
+                                return $newVersion;
+                            });
+
+                            // Only skip the Repeater and RichEditor saves for wizard forms,
+                            // since SaveSubmissibleFieldsFromContent already handled them.
+                            // For non-wizard, the RichEditor saveRelationshipsUsing still runs.
+                            $this->registrationFormVersionedInCurrentSave = $newVersion->is_wizard;
                         } else {
                             $record->fill($data);
                             $record->save();
@@ -125,6 +159,13 @@ class EditEventRegistration extends EditRecord
                         ->visible(fn (Get $get) => $get('is_wizard'))
                         ->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists())
                         ->relationship()
+                        ->saveRelationshipsUsing(function (Repeater $component): void {
+                            if ($this->registrationFormVersionedInCurrentSave) {
+                                return;
+                            }
+
+                            $component->saveToRelationship();
+                        })
                         ->reorderable()
                         ->columnSpanFull(),
                 ]),
@@ -146,6 +187,10 @@ class EditEventRegistration extends EditRecord
             ->placeholder('Drag blocks here to build your form')
             ->hiddenLabel()
             ->saveRelationshipsUsing(function (RichEditor $component, EventRegistrationForm | EventRegistrationFormStep $record) {
+                if ($this->registrationFormVersionedInCurrentSave) {
+                    return;
+                }
+
                 if ($component->isDisabled()) {
                     return;
                 }
@@ -233,6 +278,7 @@ class EditEventRegistration extends EditRecord
     protected function afterSave(): void
     {
         $this->clearFormContentForWizard();
+        $this->registrationFormVersionedInCurrentSave = false;
     }
 
     protected function clearFormContentForWizard(): void

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
@@ -36,7 +36,6 @@
 
 namespace AdvisingApp\MeetingCenter\Filament\Resources\Events\Pages;
 
-use AdvisingApp\Form\Actions\SaveSubmissibleFieldsFromContent;
 use AdvisingApp\Form\Filament\Blocks\FormFieldBlockRegistry;
 use AdvisingApp\MeetingCenter\Actions\CreateEventRegistrationFormVersion;
 use AdvisingApp\MeetingCenter\Filament\Resources\Events\EventResource;
@@ -68,6 +67,9 @@ class EditEventRegistration extends EditRecord
 
     protected bool $registrationFormVersionedInCurrentSave = false;
 
+    /** @var array<array-key, EventRegistrationFormStep> */
+    protected array $wizardStepVersionMap = [];
+
     public function form(Schema $schema): Schema
     {
         return $schema->components([
@@ -80,38 +82,34 @@ class EditEventRegistration extends EditRecord
 
                     if ($record instanceof EventRegistrationForm) {
                         if (EventVersioningFeature::active()) {
-                            $newVersion = DB::transaction(function () use ($component, $record, $data): EventRegistrationForm {
+                            DB::transaction(function () use ($component, $record, $data): void {
                                 $newVersion = app(CreateEventRegistrationFormVersion::class)->execute($record, $data);
 
                                 if ($newVersion->is_wizard) {
-                                    // The Repeater state inside a nested Fieldset relationship is not
-                                    // reliably dehydrated, so we source step data directly from the
-                                    // old version and let SaveSubmissibleFieldsFromContent recreate
-                                    // the steps and their fields on the new version.
-                                    $stepsData = ! empty($data['steps'])
-                                        ? array_values($data['steps'])
+                                    $sort = 1;
+                                    $wizardStepVersionMap = [];
+
+                                    $steps = ! empty($data['steps'])
+                                        ? $data['steps']
                                         : $record->steps()->orderBy('sort')->get()
-                                            ->map(fn (EventRegistrationFormStep $step) => [
-                                                'label' => $step->label,
-                                                'content' => $step->content,
-                                            ])
+                                            ->mapWithKeys(fn (EventRegistrationFormStep $step) => [$step->id => ['label' => $step->label]])
                                             ->all();
 
-                                    app(SaveSubmissibleFieldsFromContent::class)->execute(
-                                        $newVersion,
-                                        ['steps' => $stepsData],
-                                    );
+                                    foreach ($steps as $key => $stepData) {
+                                        $newStep = $newVersion->steps()->create([
+                                            'label' => $stepData['label'] ?? 'Untitled Step',
+                                            'sort' => $sort++,
+                                        ]);
+                                        $wizardStepVersionMap[$key] = $newStep;
+                                    }
+
+                                    $this->wizardStepVersionMap = $wizardStepVersionMap;
                                 }
 
                                 $component->cachedExistingRecord($newVersion);
-
-                                return $newVersion;
                             });
 
-                            // Only skip the Repeater and RichEditor saves for wizard forms,
-                            // since SaveSubmissibleFieldsFromContent already handled them.
-                            // For non-wizard, the RichEditor saveRelationshipsUsing still runs.
-                            $this->registrationFormVersionedInCurrentSave = $newVersion->is_wizard;
+                            $this->registrationFormVersionedInCurrentSave = ! empty($this->wizardStepVersionMap);
                         } else {
                             $record->fill($data);
                             $record->save();
@@ -159,6 +157,7 @@ class EditEventRegistration extends EditRecord
                         ->visible(fn (Get $get) => $get('is_wizard'))
                         ->disabled(fn (?EventRegistrationForm $record) => ! EventVersioningFeature::active() && $record?->submissions()->exists())
                         ->relationship()
+                        ->orderColumn('sort')
                         ->saveRelationshipsUsing(function (Repeater $component): void {
                             if ($this->registrationFormVersionedInCurrentSave) {
                                 return;
@@ -188,6 +187,21 @@ class EditEventRegistration extends EditRecord
             ->hiddenLabel()
             ->saveRelationshipsUsing(function (RichEditor $component, EventRegistrationForm | EventRegistrationFormStep $record) {
                 if ($this->registrationFormVersionedInCurrentSave) {
+                    if ($record instanceof EventRegistrationFormStep) {
+                        $newStep = $this->wizardStepVersionMap[(string) $record->id] ?? null;
+
+                        if ($newStep !== null) {
+                            if ($component->isDisabled()) {
+                                return;
+                            }
+
+                            $form = $newStep->submissible;
+                            assert($form instanceof EventRegistrationForm);
+
+                            $this->saveFieldContentToRecord($component, $form, $newStep, $newStep, $record->content);
+                        }
+                    }
+
                     return;
                 }
 
@@ -199,31 +213,7 @@ class EditEventRegistration extends EditRecord
                 assert($form instanceof EventRegistrationForm);
                 $formStep = $record instanceof EventRegistrationFormStep ? $record : null;
 
-                EventRegistrationFormField::query()
-                    ->whereBelongsTo($form, 'submissible')
-                    ->when($formStep, fn (EloquentBuilder $query) => $query->whereBelongsTo($formStep, 'step'))
-                    ->delete();
-
-                $content = $component->getState();
-
-                if (is_string($content)) {
-                    $content = json_decode($content, true);
-                }
-
-                if (! is_array($content)) {
-                    $content = [];
-                }
-
-                $content['content'] = $this->saveFieldsFromComponents(
-                    $form,
-                    $content['content'] ?? [],
-                    $formStep,
-                );
-
-                $record->content = $content;
-                $record->save();
-
-                $component->state($content);
+                $this->saveFieldContentToRecord($component, $form, $formStep, $record);
             })
             ->dehydrated(false)
             ->columnSpanFull()
@@ -275,10 +265,44 @@ class EditEventRegistration extends EditRecord
         return $components;
     }
 
+    /**
+     * @param  array<array-key, mixed>|null  $fallbackContent
+     */
+    protected function saveFieldContentToRecord(
+        RichEditor $component,
+        EventRegistrationForm $form,
+        ?EventRegistrationFormStep $step,
+        EventRegistrationForm|EventRegistrationFormStep $target,
+        array|null $fallbackContent = null,
+    ): void {
+        EventRegistrationFormField::query()
+            ->whereBelongsTo($form, 'submissible')
+            ->when($step, fn (EloquentBuilder $query) => $query->whereBelongsTo($step, 'step'))
+            ->delete();
+
+        $content = $component->getState();
+
+        if (is_string($content)) {
+            $content = json_decode($content, true);
+        }
+
+        if (! is_array($content) || empty($content)) {
+            $content = $fallbackContent ?? [];
+        }
+
+        $content['content'] = $this->saveFieldsFromComponents($form, $content['content'] ?? [], $step);
+
+        $target->content = $content;
+        $target->save();
+
+        $component->state($content);
+    }
+
     protected function afterSave(): void
     {
         $this->clearFormContentForWizard();
         $this->registrationFormVersionedInCurrentSave = false;
+        $this->wizardStepVersionMap = [];
     }
 
     protected function clearFormContentForWizard(): void

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
@@ -89,8 +89,16 @@ class EditEventRegistration extends EditRecord
                                     $sort = 1;
                                     $wizardStepVersionMap = [];
 
-                                    $steps = ! empty($data['steps'])
-                                        ? $data['steps']
+                                    // $data['steps'] is always null because Repeater::relationship()
+                                    // internally calls ->dehydrated(false), excluding it from $data.
+                                    // Instead, read steps directly from the Repeater component's raw
+                                    // Livewire state, which includes unsaved new items from the UI.
+                                    $repeaterState = collect($component->getChildComponentContainer()->getComponents(withHidden: true, withActions: false))
+                                        ->first(fn ($c) => $c instanceof Repeater && $c->getName() === 'steps')
+                                        ?->getRawState();
+
+                                    $steps = ! empty($repeaterState)
+                                        ? $repeaterState
                                         : $record->steps()->orderBy('sort')->get()
                                             ->mapWithKeys(fn (EventRegistrationFormStep $step) => [$step->id => ['label' => $step->label]])
                                             ->all();
@@ -100,7 +108,29 @@ class EditEventRegistration extends EditRecord
                                             'label' => $stepData['label'] ?? 'Untitled Step',
                                             'sort' => $sort++,
                                         ]);
-                                        $wizardStepVersionMap[$key] = $newStep;
+                                        // The Repeater prefixes existing-record keys with 'record-'.
+                                        // Strip it so the key matches $record->id in the RichEditor callback.
+                                        $mapKey = str_starts_with((string) $key, 'record-') ? substr((string) $key, 7) : (string) $key;
+                                        $wizardStepVersionMap[$mapKey] = $newStep;
+
+                                        // For newly added steps (temp key, not yet in DB), save their blocks here.
+                                        // The RichEditor's saveRelationships callback cannot run for new items
+                                        // because getRecord() returns null (model is a class string, not an
+                                        // instance) → Component::saveRelationships() returns early before
+                                        // the callback is ever invoked.
+                                        if (! str_starts_with((string) $key, 'record-')) {
+                                            $stepContent = $stepData['content'] ?? null;
+
+                                            if (is_string($stepContent)) {
+                                                $stepContent = json_decode($stepContent, true);
+                                            }
+
+                                            if (is_array($stepContent) && ! empty($stepContent)) {
+                                                $stepContent['content'] = $this->saveFieldsFromComponents($newVersion, $stepContent['content'] ?? [], $newStep);
+                                                $newStep->content = $stepContent;
+                                                $newStep->save();
+                                            }
+                                        }
                                     }
 
                                     $this->wizardStepVersionMap = $wizardStepVersionMap;

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventRegistration.php
@@ -94,7 +94,7 @@ class EditEventRegistration extends EditRecord
                                     // Instead, read steps directly from the Repeater component's raw
                                     // Livewire state, which includes unsaved new items from the UI.
                                     $repeaterState = collect($component->getChildComponentContainer()->getComponents(withHidden: true, withActions: false))
-                                        ->first(fn ($c) => $c instanceof Repeater && $c->getName() === 'steps')
+                                        ->first(fn ($component) => $component instanceof Repeater && $component->getName() === 'steps')
                                         ?->getRawState();
 
                                     $steps = ! empty($repeaterState)

--- a/app-modules/meeting-center/src/Models/Event.php
+++ b/app-modules/meeting-center/src/Models/Event.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\MeetingCenter\Models;
 
+use App\Features\EventVersioningFeature;
 use App\Models\BaseModel;
 use App\Models\Media;
 use CanyonGBS\Common\Models\Concerns\HasUserSaveTracking;
@@ -102,7 +103,13 @@ class Event extends BaseModel implements HasMedia, HasRichContent
      */
     public function eventRegistrationForm(): HasOne
     {
-        return $this->hasOne(EventRegistrationForm::class, 'event_id');
+        $relationship = $this->hasOne(EventRegistrationForm::class, 'event_id');
+
+        if (EventVersioningFeature::active()) {
+            $relationship->whereNull('archived_at');
+        }
+
+        return $relationship;
     }
 
     /**

--- a/app-modules/meeting-center/src/Models/EventRegistrationForm.php
+++ b/app-modules/meeting-center/src/Models/EventRegistrationForm.php
@@ -46,6 +46,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
+ * @property string|null $root_id
+ *
  * @mixin IdeHelperEventRegistrationForm
  */
 #[ObservedBy([EventRegistrationFormObserver::class])]

--- a/app-modules/meeting-center/src/Models/EventRegistrationForm.php
+++ b/app-modules/meeting-center/src/Models/EventRegistrationForm.php
@@ -38,6 +38,9 @@ namespace AdvisingApp\MeetingCenter\Models;
 
 use AdvisingApp\Form\Enums\Rounding;
 use AdvisingApp\Form\Models\Submissible;
+use AdvisingApp\MeetingCenter\Observers\EventRegistrationFormObserver;
+use CanyonGBS\Common\Models\Concerns\CanBeArchived;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -45,8 +48,10 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 /**
  * @mixin IdeHelperEventRegistrationForm
  */
+#[ObservedBy([EventRegistrationFormObserver::class])]
 class EventRegistrationForm extends Submissible
 {
+    use CanBeArchived;
     use SoftDeletes;
 
     protected $fillable = [
@@ -58,6 +63,7 @@ class EventRegistrationForm extends Submissible
         'primary_color',
         'rounding',
         'content',
+        'root_id',
     ];
 
     protected $casts = [
@@ -100,5 +106,28 @@ class EventRegistrationForm extends Submissible
     public function submissions(): HasMany
     {
         return $this->hasMany(EventRegistrationFormSubmission::class, 'form_id');
+    }
+
+    /**
+     * @return BelongsTo<EventRegistrationForm, $this>
+     */
+    public function rootForm(): BelongsTo
+    {
+        return $this->belongsTo(EventRegistrationForm::class, 'root_id');
+    }
+
+    /**
+     * @return HasMany<EventRegistrationForm, $this>
+     */
+    public function versions(): HasMany
+    {
+        return $this->hasMany(EventRegistrationForm::class, 'root_id', 'root_id');
+    }
+
+    public function latestVersion(): ?EventRegistrationForm
+    {
+        return EventRegistrationForm::query()->where('root_id', $this->root_id)
+            ->whereNull('archived_at')
+            ->first();
     }
 }

--- a/app-modules/meeting-center/src/Models/EventRegistrationForm.php
+++ b/app-modules/meeting-center/src/Models/EventRegistrationForm.php
@@ -109,27 +109,4 @@ class EventRegistrationForm extends Submissible
     {
         return $this->hasMany(EventRegistrationFormSubmission::class, 'form_id');
     }
-
-    /**
-     * @return BelongsTo<EventRegistrationForm, $this>
-     */
-    public function rootForm(): BelongsTo
-    {
-        return $this->belongsTo(EventRegistrationForm::class, 'root_id');
-    }
-
-    /**
-     * @return HasMany<EventRegistrationForm, $this>
-     */
-    public function versions(): HasMany
-    {
-        return $this->hasMany(EventRegistrationForm::class, 'root_id', 'root_id');
-    }
-
-    public function latestVersion(): ?EventRegistrationForm
-    {
-        return EventRegistrationForm::query()->where('root_id', $this->root_id)
-            ->whereNull('archived_at')
-            ->first();
-    }
 }

--- a/app-modules/meeting-center/src/Observers/EventRegistrationFormObserver.php
+++ b/app-modules/meeting-center/src/Observers/EventRegistrationFormObserver.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of

--- a/app-modules/meeting-center/src/Observers/EventRegistrationFormObserver.php
+++ b/app-modules/meeting-center/src/Observers/EventRegistrationFormObserver.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\MeetingCenter\Observers;
+
+use AdvisingApp\MeetingCenter\Models\EventRegistrationForm;
+use App\Features\EventVersioningFeature;
+
+class EventRegistrationFormObserver
+{
+    public function creating(EventRegistrationForm $form): void
+    {
+        if (! EventVersioningFeature::active()) {
+            return;
+        }
+
+        if ($form->getAttribute('root_id') === null) {
+            $form->root_id = $form->id;
+        }
+    }
+}

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/EditEventRegistrationTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/EditEventRegistrationTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/EditEventRegistrationTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/EditEventRegistrationTest.php
@@ -37,6 +37,7 @@
 use AdvisingApp\MeetingCenter\Filament\Resources\Events\Pages\EditEventRegistration;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationForm;
+use AdvisingApp\MeetingCenter\Models\EventRegistrationFormStep;
 use App\Settings\LicenseSettings;
 
 use function Pest\Livewire\livewire;
@@ -140,4 +141,77 @@ it('sets root_id to its own id when a registration form is first created', funct
     $form = $event->eventRegistrationForm;
 
     expect($form->root_id)->toBe($form->id);
+});
+
+it('when saving a wizard registration form, the new version retains the same number of steps', function () {
+    editEventRegistrationTestSetup();
+
+    asSuperAdmin();
+
+    $event = Event::factory()->create();
+    $form = $event->eventRegistrationForm;
+
+    // Ensure the form is in wizard mode with a known set of steps
+    $form->steps()->delete();
+    $form->is_wizard = true;
+    $form->content = null;
+    $form->save();
+
+    EventRegistrationFormStep::factory()->count(2)->create(['form_id' => $form->getKey()]);
+
+    $originalStepCount = $form->steps()->count();
+    $originalRootId = $form->root_id;
+    $originalId = $form->id;
+
+    livewire(EditEventRegistration::class, ['record' => $event->getKey()])
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $newVersion = EventRegistrationForm::withoutGlobalScopes()
+        ->where('root_id', $originalRootId)
+        ->whereNull('archived_at')
+        ->first();
+
+    expect($newVersion)->not->toBeNull();
+    expect($newVersion->id)->not->toBe($originalId);
+    expect($newVersion->is_wizard)->toBeTrue();
+    expect($newVersion->steps()->count())->toBe($originalStepCount);
+
+    // Archived version retains its original steps
+    $archivedVersion = EventRegistrationForm::withoutGlobalScopes()
+        ->where('id', $originalId)
+        ->first();
+
+    expect($archivedVersion->archived_at)->not->toBeNull();
+    expect($archivedVersion->steps()->count())->toBe($originalStepCount);
+});
+
+it('when saving a wizard registration form, the archived version still has its original steps', function () {
+    editEventRegistrationTestSetup();
+
+    asSuperAdmin();
+
+    $event = Event::factory()->create();
+    $form = $event->eventRegistrationForm;
+
+    $form->steps()->delete();
+    $form->is_wizard = true;
+    $form->content = null;
+    $form->save();
+
+    EventRegistrationFormStep::factory()->count(3)->create(['form_id' => $form->getKey()]);
+
+    $originalStepCount = $form->steps()->count();
+    $originalId = $form->id;
+
+    livewire(EditEventRegistration::class, ['record' => $event->getKey()])
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $archivedVersion = EventRegistrationForm::withoutGlobalScopes()
+        ->where('id', $originalId)
+        ->first();
+
+    expect($archivedVersion->archived_at)->not->toBeNull();
+    expect($archivedVersion->steps()->count())->toBe($originalStepCount);
 });

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/EditEventRegistrationTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/EditEventRegistrationTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\MeetingCenter\Filament\Resources\Events\Pages\EditEventRegistration;
+use AdvisingApp\MeetingCenter\Models\Event;
+use AdvisingApp\MeetingCenter\Models\EventRegistrationForm;
+use App\Settings\LicenseSettings;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+function editEventRegistrationTestSetup(): void
+{
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->eventManagement = true;
+    $settings->save();
+}
+
+it('creates a new version and archives the old one when saving the registration form', function () {
+    editEventRegistrationTestSetup();
+
+    asSuperAdmin();
+
+    $event = Event::factory()->create();
+    $form = $event->eventRegistrationForm;
+
+    $originalId = $form->id;
+    $originalRootId = $form->root_id;
+
+    expect($form->archived_at)->toBeNull();
+    expect(EventRegistrationForm::withoutGlobalScopes()->where('root_id', $originalRootId)->count())->toBe(1);
+
+    livewire(EditEventRegistration::class, ['record' => $event->getKey()])
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect(EventRegistrationForm::withoutGlobalScopes()->where('root_id', $originalRootId)->count())->toBe(2);
+
+    $archivedForm = EventRegistrationForm::withoutGlobalScopes()
+        ->where('id', $originalId)
+        ->first();
+
+    expect($archivedForm->archived_at)->not->toBeNull();
+
+    $newForm = EventRegistrationForm::withoutGlobalScopes()
+        ->where('root_id', $originalRootId)
+        ->whereNull('archived_at')
+        ->first();
+
+    expect($newForm)->not->toBeNull();
+    expect($newForm->id)->not->toBe($originalId);
+    expect($newForm->event_id)->toBe($event->getKey());
+    expect($newForm->root_id)->toBe($originalRootId);
+});
+
+it('the new version inherits embed settings from the old version', function () {
+    editEventRegistrationTestSetup();
+
+    asSuperAdmin();
+
+    $event = Event::factory()->create();
+    $form = $event->eventRegistrationForm;
+    $form->embed_enabled = true;
+    $form->allowed_domains = ['example.com'];
+    $form->save();
+
+    $originalRootId = $form->root_id;
+
+    livewire(EditEventRegistration::class, ['record' => $event->getKey()])
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $newForm = EventRegistrationForm::withoutGlobalScopes()
+        ->where('root_id', $originalRootId)
+        ->whereNull('archived_at')
+        ->first();
+
+    expect($newForm->embed_enabled)->toBeTrue();
+    expect($newForm->allowed_domains)->toBe(['example.com']);
+});
+
+it('the event registration form relationship resolves to the latest non-archived version', function () {
+    editEventRegistrationTestSetup();
+
+    asSuperAdmin();
+
+    $event = Event::factory()->create();
+    $form = $event->eventRegistrationForm;
+    $originalId = $form->id;
+
+    livewire(EditEventRegistration::class, ['record' => $event->getKey()])
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $event->refresh();
+    $currentForm = $event->eventRegistrationForm;
+
+    expect($currentForm)->not->toBeNull();
+    expect($currentForm->id)->not->toBe($originalId);
+    expect($currentForm->archived_at)->toBeNull();
+});
+
+it('sets root_id to its own id when a registration form is first created', function () {
+    editEventRegistrationTestSetup();
+
+    $event = Event::factory()->create();
+    $form = $event->eventRegistrationForm;
+
+    expect($form->root_id)->toBe($form->id);
+});

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/EditEventRegistrationTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/EditEventRegistrationTest.php
@@ -37,6 +37,7 @@
 use AdvisingApp\MeetingCenter\Filament\Resources\Events\Pages\EditEventRegistration;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationForm;
+use AdvisingApp\MeetingCenter\Models\EventRegistrationFormField;
 use AdvisingApp\MeetingCenter\Models\EventRegistrationFormStep;
 use App\Settings\LicenseSettings;
 
@@ -214,4 +215,115 @@ it('when saving a wizard registration form, the archived version still has its o
 
     expect($archivedVersion->archived_at)->not->toBeNull();
     expect($archivedVersion->steps()->count())->toBe($originalStepCount);
+});
+
+it('carries each wizard step its own fields onto the new version when saving', function () {
+    editEventRegistrationTestSetup();
+
+    asSuperAdmin();
+
+    $event = Event::factory()->create();
+    $form = $event->eventRegistrationForm;
+
+    $form->steps()->delete();
+    $form->fields()->delete();
+    $form->is_wizard = true;
+    $form->content = null;
+    $form->save();
+
+    foreach ([0, 1] as $index) {
+        $step = $form->steps()->create(['label' => "Step {$index}", 'sort' => $index]);
+        $field = EventRegistrationFormField::factory()->create([
+            'form_id' => $form->getKey(),
+            'step_id' => $step->getKey(),
+        ]);
+        $step->content = [
+            'type' => 'doc',
+            'content' => [[
+                'type' => 'customBlock',
+                'attrs' => ['id' => $field->type, 'config' => [
+                    'fieldId' => $field->getKey(),
+                    'label' => $field->label,
+                    'isRequired' => $field->is_required,
+                ]],
+            ]],
+        ];
+        $step->save();
+    }
+
+    $originalRootId = $form->root_id;
+    $originalFieldIds = $form->fields()->pluck('id');
+
+    livewire(EditEventRegistration::class, ['record' => $event->getKey()])
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $newVersion = EventRegistrationForm::withoutGlobalScopes()
+        ->where('root_id', $originalRootId)
+        ->whereNull('archived_at')
+        ->first();
+
+    expect($newVersion->fields()->count())->toBe(2);
+    expect($newVersion->fields()->whereIn('id', $originalFieldIds)->count())->toBe(0);
+
+    $newVersion->steps()->orderBy('sort')->get()->each(function (EventRegistrationFormStep $step) use ($newVersion) {
+        expect($newVersion->fields()->where('step_id', $step->getKey())->count())->toBe(1);
+
+        $fieldId = data_get($step->content, 'content.0.attrs.config.fieldId');
+        expect($newVersion->fields()->whereKey($fieldId)->exists())->toBeTrue();
+    });
+});
+
+it('persists a newly added wizard step and its fields to the new version', function () {
+    editEventRegistrationTestSetup();
+
+    asSuperAdmin();
+
+    $event = Event::factory()->create();
+    $form = $event->eventRegistrationForm;
+
+    $form->steps()->delete();
+    $form->fields()->delete();
+    $form->is_wizard = true;
+    $form->content = null;
+    $form->save();
+
+    EventRegistrationFormStep::factory()
+        ->count(2)
+        ->sequence(fn ($sequence) => ['sort' => $sequence->index, 'label' => "Existing {$sequence->index}"])
+        ->create(['form_id' => $form->getKey()]);
+
+    $originalRootId = $form->root_id;
+
+    $component = livewire(EditEventRegistration::class, ['record' => $event->getKey()]);
+
+    $steps = data_get($component->instance()->form->getRawState(), 'eventRegistrationForm.steps', []);
+    $steps['newStepKey'] = [
+        'label' => 'Brand New Step',
+        'content' => [
+            'type' => 'doc',
+            'content' => [[
+                'type' => 'customBlock',
+                'attrs' => ['id' => 'text_input', 'config' => ['label' => 'New Field', 'isRequired' => false]],
+            ]],
+        ],
+    ];
+
+    $component
+        ->fillForm(['eventRegistrationForm' => ['steps' => $steps]])
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $newVersion = EventRegistrationForm::withoutGlobalScopes()
+        ->where('root_id', $originalRootId)
+        ->whereNull('archived_at')
+        ->first();
+
+    expect($newVersion->steps()->count())->toBe(3);
+    expect($newVersion->steps()->pluck('label'))->toContain('Brand New Step');
+
+    $newStep = $newVersion->steps()->where('label', 'Brand New Step')->first();
+
+    expect($newStep)->not->toBeNull();
+    expect($newVersion->fields()->where('step_id', $newStep->getKey())->count())->toBe(1);
 });

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/ListEventsTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/ListEventsTest.php
@@ -140,16 +140,16 @@ it('will not duplicate event registration form submissions if they exist', funct
 
 it('gives a duplicated event registration form its own version tree rather than sharing the original', function () {
     asSuperAdmin();
- 
+
     $event = Event::factory()->create();
- 
+
     livewire(ListEvents::class)
         ->assertStatus(200)
         ->removeTableFilter('pastEvents')
         ->callTableAction('Duplicate', $event);
- 
+
     $duplicatedForm = Event::where('id', '<>', $event->id)->first()->eventRegistrationForm;
- 
+
     // The duplicated form must root to itself, not the original event's version tree.
     expect($duplicatedForm->root_id)->toBe($duplicatedForm->id);
     expect($duplicatedForm->root_id)->not->toBe($event->eventRegistrationForm->root_id);

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/ListEventsTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/ListEventsTest.php
@@ -137,3 +137,21 @@ it('will not duplicate event registration form submissions if they exist', funct
 
     expect($duplicatedEvent->eventRegistrationForm->submissions()->count())->toBe(0);
 });
+
+it('gives a duplicated event registration form its own version tree rather than sharing the original', function () {
+    asSuperAdmin();
+ 
+    $event = Event::factory()->create();
+ 
+    livewire(ListEvents::class)
+        ->assertStatus(200)
+        ->removeTableFilter('pastEvents')
+        ->callTableAction('Duplicate', $event);
+ 
+    $duplicatedForm = Event::where('id', '<>', $event->id)->first()->eventRegistrationForm;
+ 
+    // The duplicated form must root to itself, not the original event's version tree.
+    expect($duplicatedForm->root_id)->toBe($duplicatedForm->id);
+    expect($duplicatedForm->root_id)->not->toBe($event->eventRegistrationForm->root_id);
+    expect($duplicatedForm->archived_at)->toBeNull();
+});

--- a/app/Features/EventVersioningFeature.php
+++ b/app/Features/EventVersioningFeature.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/app/Features/EventVersioningFeature.php
+++ b/app/Features/EventVersioningFeature.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class EventVersioningFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2814

### Technical Description

> Introduce versioning so that events can be edited even after few attendees have registered for the event.

### Any deployment steps required?

> No

### Cleanup Tasks

> .cleanup-tasks/2026_07_13_event_versioning_feature.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
