### PR TITLE
[Chore]: Switch to workflow app auth

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,12 +22,24 @@ jobs:
             image: ${{ steps.build-image.outputs.image }}
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Login to Docker Hub
@@ -68,12 +80,24 @@ jobs:
         environment: staging
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Configure AWS credentials
@@ -122,12 +146,24 @@ jobs:
             image: ${{ steps.build-image.outputs.image }}
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Login to Docker Hub
@@ -168,12 +204,24 @@ jobs:
         environment: staging
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Configure AWS credentials
@@ -222,12 +270,24 @@ jobs:
         environment: staging
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Login to Docker Hub
@@ -268,12 +328,24 @@ jobs:
         environment: staging
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Configure AWS credentials
@@ -322,12 +394,24 @@ jobs:
         environment: staging
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Login to Docker Hub
@@ -368,12 +452,24 @@ jobs:
         environment: staging
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Configure AWS credentials

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -32,13 +32,21 @@ jobs:
             php-version: ${{ env.php-version }}
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  permission-contents: write
+
             - name: Checkout code | Internal
               if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }} # zizmor: ignore[secrets-outside-env]
-                  persist-credentials: true # zizmor: ignore[artipacked] -- credentials needed for git-auto-commit-action to push
+                  persist-credentials: false
 
             - name: Checkout code | External
               if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' }}
@@ -114,19 +122,39 @@ jobs:
             - name: Run Formatters
               run: composer format
 
+            - name: Get GitHub App User ID
+              id: get-user-id
+              if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+              env:
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
             - name: Commit changes
               if: ${{ github.event_name != 'merge_group' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
+              env:
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  APP_USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+                  APP_TOKEN: ${{ steps.app-token.outputs.token }}
+                  GH_REPOSITORY: ${{ github.repository }}
               run: |
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git config user.name "${APP_SLUG}[bot]"
+                  git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPOSITORY}.git"
                   git add -A
                   git diff --cached --quiet || (git commit -m "Update code formatting and copyright headers" && git push)
 
             - name: Check for changes
               if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name != github.repository || github.event.pull_request.user.login == 'dependabot[bot]' }}
-              uses: tj-actions/verify-changed-files@a1c6acee9df209257a246f2cc6ae8cb6581c1edf # v20.0.4
-              with:
-                  fail-if-changed: 'true'
+              run: |
+                  git add -A
+                  if ! git diff --cached --quiet; then
+                      echo "::error::Formatting changes were detected. Run 'composer format' locally and commit the changes."
+                      echo "::group::Diff"
+                      git --no-pager diff --cached --color
+                      echo "::endgroup::"
+                      exit 1
+                  fi
 
     test:
         name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,24 @@ jobs:
             image: ${{ steps.build-image.outputs.image }}
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Login to Docker Hub
@@ -68,12 +80,24 @@ jobs:
         environment: production
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Configure AWS credentials
@@ -122,12 +146,24 @@ jobs:
             image: ${{ steps.build-image.outputs.image }}
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Login to Docker Hub
@@ -168,12 +204,24 @@ jobs:
         environment: production
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Configure AWS credentials
@@ -222,12 +270,24 @@ jobs:
         environment: production
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Login to Docker Hub
@@ -268,12 +328,24 @@ jobs:
         environment: production
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Configure AWS credentials
@@ -322,12 +394,24 @@ jobs:
         environment: production
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Login to Docker Hub
@@ -368,12 +452,24 @@ jobs:
         environment: production
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  owner: canyongbs
+                  repositories: |
+                      advisingapp
+                      devops
+                  permission-contents: read
+
             - name: Checkout
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
                   submodules: true
                   ref: ${{ github.head_ref }}
-                  token: ${{ secrets.PAT }}
+                  token: ${{ steps.app-token.outputs.token }}
                   persist-credentials: false
 
             - name: Configure AWS credentials

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,8 +21,23 @@ jobs:
               with:
                   persist-credentials: false
 
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  permission-contents: write
+                  permission-issues: write
+                  permission-pull-requests: write
+                  permission-workflows: write
+                  permission-checks: write
+                  permission-statuses: write
+                  permission-vulnerability-alerts: read
+                  permission-administration: read
+
             - name: Run Renovate
               uses: renovatebot/github-action@b50d2ba2bd928235abdcc14d06dfafc217f1c565 # v46.1.18
               with:
                   configurationFile: renovate-config.json
-                  token: ${{ secrets.PAT }} # zizmor: ignore[secrets-outside-env]
+                  token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update_yearly_copyright.yml
+++ b/.github/workflows/update_yearly_copyright.yml
@@ -19,11 +19,19 @@ jobs:
         timeout-minutes: 10
 
         steps:
+            - name: Generate GitHub App Token
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  client-id: ${{ secrets.CGBS_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
+                  private-key: ${{ secrets.CGBS_AUTOMATION_APP_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
+                  permission-contents: write
+                  permission-pull-requests: write
+
             - name: Checkout `main` Branch
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
               with:
-                  token: ${{ secrets.PAT }} # zizmor: ignore[secrets-outside-env]
-                  persist-credentials: true # zizmor: ignore[artipacked] -- credentials needed for git push
+                  persist-credentials: false
 
             - name: Set up Ruby
               uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
@@ -31,13 +39,25 @@ jobs:
             - name: Run copyright script
               run: ruby ./copyright.rb
 
+            - name: Get GitHub App User ID
+              id: get-user-id
+              env:
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
+              run: echo "user-id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
             - name: Create Pull Request
               env:
-                  GH_TOKEN: ${{ secrets.PAT }} # zizmor: ignore[secrets-outside-env]
+                  APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+                  APP_USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+                  APP_TOKEN: ${{ steps.app-token.outputs.token }}
+                  GH_REPOSITORY: ${{ github.repository }}
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   BRANCH="update-yearly-copyright-$(date +%s)"
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git config user.name "${APP_SLUG}[bot]"
+                  git config user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+                  git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${GH_REPOSITORY}.git"
                   git checkout -b "${BRANCH}"
                   git add -A
                   git diff --cached --quiet && echo "No changes" && exit 0


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Switches to the CGBS Automation App for GitHub action authorization instead of a personally tied PAT.

Removes the usage of `tj-actions/verify-changed-files`, to replace it with standard git actions to make things easier and reduce supply-chain attack risk.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
