### PR TITLE
[ADVAPP-2825]: Interaction related Selects on Campaigns are duplicating options

### DIFF
--- a/app-modules/campaign/src/Filament/Blocks/InteractionBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/InteractionBlock.php
@@ -37,6 +37,10 @@
 namespace AdvisingApp\Campaign\Filament\Blocks;
 
 use AdvisingApp\Campaign\Filament\Forms\Components\CampaignDateTimeInput;
+use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\CreateCampaign;
+use AdvisingApp\Group\Enums\GroupModel;
+use AdvisingApp\Group\Models\Group;
+use AdvisingApp\Interaction\Enums\InteractableType;
 use AdvisingApp\Interaction\Models\Interaction;
 use AdvisingApp\Interaction\Models\InteractionDriver;
 use AdvisingApp\Interaction\Models\InteractionInitiative;
@@ -51,6 +55,8 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Fieldset;
+use Filament\Schemas\Components\Utilities\Get;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 class InteractionBlock extends CampaignActionBlock
@@ -77,14 +83,14 @@ class InteractionBlock extends CampaignActionBlock
             Fieldset::make('Details')
                 ->schema([
                     Select::make('interaction_initiative_id')
-                        ->relationship('initiative', 'name')
+                        ->relationship('initiative', 'name', $this->filterByInteractableType())
                         ->model(Interaction::class)
                         ->label('Initiative')
                         ->required(fn () => $settings->is_initiative_required)
                         ->visible(fn () => $settings->is_initiative_enabled)
                         ->exists((new InteractionInitiative())->getTable(), 'id'),
                     Select::make('interaction_driver_id')
-                        ->relationship('driver', 'name')
+                        ->relationship('driver', 'name', $this->filterByInteractableType())
                         ->model(Interaction::class)
                         ->preload()
                         ->label('Driver')
@@ -92,7 +98,7 @@ class InteractionBlock extends CampaignActionBlock
                         ->visible(fn () => $settings->is_driver_enabled)
                         ->exists((new InteractionDriver())->getTable(), 'id'),
                     Select::make('interaction_outcome_id')
-                        ->relationship('outcome', 'name')
+                        ->relationship('outcome', 'name', $this->filterByInteractableType())
                         ->model(Interaction::class)
                         ->preload()
                         ->label('Outcome')
@@ -100,7 +106,7 @@ class InteractionBlock extends CampaignActionBlock
                         ->visible(fn () => $settings->is_outcome_enabled)
                         ->exists((new InteractionOutcome())->getTable(), 'id'),
                     Select::make('interaction_relation_id')
-                        ->relationship('relation', 'name')
+                        ->relationship('relation', 'name', $this->filterByInteractableType())
                         ->model(Interaction::class)
                         ->preload()
                         ->label('Relation')
@@ -108,7 +114,7 @@ class InteractionBlock extends CampaignActionBlock
                         ->visible(fn () => $settings->is_relation_enabled)
                         ->exists((new InteractionRelation())->getTable(), 'id'),
                     Select::make('interaction_status_id')
-                        ->relationship('status', 'name')
+                        ->relationship('status', 'name', $this->filterByInteractableType())
                         ->model(Interaction::class)
                         ->preload()
                         ->label('Status')
@@ -116,7 +122,7 @@ class InteractionBlock extends CampaignActionBlock
                         ->visible(fn () => $settings->is_status_enabled)
                         ->exists((new InteractionStatus())->getTable(), 'id'),
                     Select::make('interaction_type_id')
-                        ->relationship('type', 'name')
+                        ->relationship('type', 'name', $this->filterByInteractableType())
                         ->model(Interaction::class)
                         ->preload()
                         ->label('Type')
@@ -147,5 +153,50 @@ class InteractionBlock extends CampaignActionBlock
     public static function type(): string
     {
         return 'interaction';
+    }
+
+    private function filterByInteractableType(): Closure
+    {
+        return function (Builder $query, Get $get, mixed $livewire) {
+            $interactableType = $this->resolveInteractableType($get, $livewire);
+            if (blank($interactableType)) {
+                $query->whereRaw('1 = 0');
+                return;
+            }
+            $query->where('interactable_type', $interactableType);
+        };
+    }
+
+    private function resolveInteractableType(Get $get, mixed $livewire): ?InteractableType
+    {
+        $groupId = $this->resolveGroupId($get, $livewire);
+
+        if (blank($groupId)) {
+            return null;
+        }
+
+        $group = Group::query()->find($groupId);
+
+        if (! $group) {
+            return null;
+        }
+
+        return match ($group->model) {
+            GroupModel::Student => InteractableType::Student,
+            GroupModel::Prospect => InteractableType::Prospect,
+        };
+    }
+
+    private function resolveGroupId(Get $get, mixed $livewire): mixed
+    {
+        if ($livewire instanceof CreateCampaign) {
+            return $get('../../../segment_id');
+        }
+
+        if (method_exists($livewire, 'getOwnerRecord')) {
+            return $livewire->getOwnerRecord()?->segment_id;
+        }
+
+        return null;
     }
 }

--- a/app-modules/campaign/src/Filament/Blocks/InteractionBlock.php
+++ b/app-modules/campaign/src/Filament/Blocks/InteractionBlock.php
@@ -159,8 +159,10 @@ class InteractionBlock extends CampaignActionBlock
     {
         return function (Builder $query, Get $get, mixed $livewire) {
             $interactableType = $this->resolveInteractableType($get, $livewire);
+
             if (blank($interactableType)) {
                 $query->whereRaw('1 = 0');
+
                 return;
             }
             $query->where('interactable_type', $interactableType);

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
@@ -50,6 +50,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\ViewField;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Resources\Pages\CreateRecord\Concerns\HasWizard;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Components\Wizard\Step;
 use Filament\Support\Enums\Width;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -113,7 +114,11 @@ class CreateCampaign extends CreateRecord
                                 ->pluck('name', 'id');
                         })
                         ->searchable()
-                        ->required(),
+                        ->required()
+                        ->live()
+                        ->afterStateUpdated(function (Set $set) {
+                            $set('actions', []);
+                        }),
                 ]),
             Step::make('Define Journey')
                 ->schema([

--- a/app-modules/campaign/tests/Tenant/Filament/Blocks/InteractionBlockTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Blocks/InteractionBlockTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of
@@ -102,4 +102,3 @@ it('shows interaction options only for campaign population model type when editi
             return true;
         });
 });
- 

--- a/app-modules/campaign/tests/Tenant/Filament/Blocks/InteractionBlockTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Blocks/InteractionBlockTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\Campaign\Enums\CampaignActionType;
+use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\ViewCampaign;
+use AdvisingApp\Campaign\Filament\Resources\Campaigns\RelationManagers\CampaignActionsRelationManager;
+use AdvisingApp\Campaign\Models\Campaign;
+use AdvisingApp\Campaign\Models\CampaignAction;
+use AdvisingApp\Group\Enums\GroupModel;
+use AdvisingApp\Group\Models\Group;
+use AdvisingApp\Interaction\Enums\InteractableType;
+use AdvisingApp\Interaction\Models\InteractionDriver;
+use AdvisingApp\Interaction\Models\InteractionInitiative;
+use App\Models\User;
+use Filament\Forms\Components\Select;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('shows interaction options only for campaign population model type when editing journey step', function () {
+    asSuperAdmin();
+
+    $campaign = Campaign::factory()
+        ->for(User::factory()->licensed(LicenseType::cases()), 'createdBy')
+        ->for(Group::factory()->state(['model' => GroupModel::Student]), 'group')
+        ->create();
+
+    $studentInitiative = InteractionInitiative::factory()->create(['interactable_type' => InteractableType::Student]);
+    $prospectInitiative = InteractionInitiative::factory()->create(['interactable_type' => InteractableType::Prospect]);
+    $studentDriver = InteractionDriver::factory()->create(['interactable_type' => InteractableType::Student]);
+    $prospectDriver = InteractionDriver::factory()->create(['interactable_type' => InteractableType::Prospect]);
+
+    /** @var CampaignAction $action */
+    $action = CampaignAction::factory()
+        ->for($campaign, 'campaign')
+        ->create([
+            'type' => CampaignActionType::Interaction,
+            'execute_at' => now()->addDay(),
+            'data' => [
+                'interaction_initiative_id' => $studentInitiative->getKey(),
+                'interaction_driver_id' => $studentDriver->getKey(),
+                'start_datetime' => now()->toDateTimeString(),
+                'end_datetime' => now()->addHour()->toDateTimeString(),
+                'subject' => 'Test subject',
+                'description' => 'Test description',
+            ],
+        ]);
+
+    livewire(CampaignActionsRelationManager::class, [
+        'ownerRecord' => $campaign,
+        'pageClass' => ViewCampaign::class,
+    ])
+        ->mountTableAction('edit', record: $action->getKey())
+        ->assertFormFieldExists('data.interaction_initiative_id', checkFieldUsing: function (Select $field) use ($studentInitiative, $prospectInitiative) {
+            $optionKeys = array_keys($field->getOptions());
+
+            expect($optionKeys)->toContain($studentInitiative->getKey())
+                ->and($optionKeys)->not->toContain($prospectInitiative->getKey());
+
+            return true;
+        })
+        ->assertFormFieldExists('data.interaction_driver_id', checkFieldUsing: function (Select $field) use ($studentDriver, $prospectDriver) {
+            $optionKeys = array_keys($field->getOptions());
+
+            expect($optionKeys)->toContain($studentDriver->getKey())
+                ->and($optionKeys)->not->toContain($prospectDriver->getKey());
+
+            return true;
+        });
+});
+ 

--- a/app-modules/campaign/tests/Tenant/Filament/Blocks/InteractionBlockTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Blocks/InteractionBlockTest.php
@@ -102,3 +102,58 @@ it('shows interaction options only for campaign population model type when editi
             return true;
         });
 });
+
+it('shows correct interaction options when creating campaign with prospect population group', function () {
+    asSuperAdmin();
+
+    $prospectGroup = Group::factory()->state(['model' => GroupModel::Prospect])->create();
+
+    $studentInitiative = InteractionInitiative::factory()->create(['interactable_type' => InteractableType::Student]);
+    $prospectInitiative = InteractionInitiative::factory()->create(['interactable_type' => InteractableType::Prospect]);
+    $studentDriver = InteractionDriver::factory()->create(['interactable_type' => InteractableType::Student]);
+    $prospectDriver = InteractionDriver::factory()->create(['interactable_type' => InteractableType::Prospect]);
+
+    /** @var CampaignAction $action */
+    $action = CampaignAction::factory()
+        ->for(
+            Campaign::factory()
+                ->for(User::factory()->licensed(LicenseType::cases()), 'createdBy')
+                ->for($prospectGroup, 'group')
+                ->create(),
+            'campaign'
+        )
+        ->create([
+            'type' => CampaignActionType::Interaction,
+            'execute_at' => now()->addDay(),
+            'data' => [
+                'interaction_initiative_id' => $prospectInitiative->getKey(),
+                'interaction_driver_id' => $prospectDriver->getKey(),
+                'start_datetime' => now()->toDateTimeString(),
+                'end_datetime' => now()->addHour()->toDateTimeString(),
+                'subject' => 'Test subject',
+                'description' => 'Test description',
+            ],
+        ]);
+
+    livewire(CampaignActionsRelationManager::class, [
+        'ownerRecord' => $action->campaign,
+        'pageClass' => ViewCampaign::class,
+    ])
+        ->mountTableAction('edit', record: $action->getKey())
+        ->assertFormFieldExists('data.interaction_initiative_id', checkFieldUsing: function (Select $field) use ($studentInitiative, $prospectInitiative) {
+            $optionKeys = array_keys($field->getOptions());
+
+            expect($optionKeys)->toContain($prospectInitiative->getKey())
+                ->and($optionKeys)->not->toContain($studentInitiative->getKey());
+
+            return true;
+        })
+        ->assertFormFieldExists('data.interaction_driver_id', checkFieldUsing: function (Select $field) use ($studentDriver, $prospectDriver) {
+            $optionKeys = array_keys($field->getOptions());
+
+            expect($optionKeys)->toContain($prospectDriver->getKey())
+                ->and($optionKeys)->not->toContain($studentDriver->getKey());
+
+            return true;
+        });
+});

--- a/app-modules/campaign/tests/Tenant/Filament/Blocks/InteractionBlockTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Blocks/InteractionBlockTest.php
@@ -36,6 +36,7 @@
 
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Campaign\Enums\CampaignActionType;
+use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\CreateCampaign;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\ViewCampaign;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\RelationManagers\CampaignActionsRelationManager;
 use AdvisingApp\Campaign\Models\Campaign;
@@ -45,15 +46,22 @@ use AdvisingApp\Group\Models\Group;
 use AdvisingApp\Interaction\Enums\InteractableType;
 use AdvisingApp\Interaction\Models\InteractionDriver;
 use AdvisingApp\Interaction\Models\InteractionInitiative;
+use AdvisingApp\Interaction\Models\InteractionOutcome;
+use AdvisingApp\Interaction\Models\InteractionRelation;
+use AdvisingApp\Interaction\Models\InteractionStatus;
+use AdvisingApp\Interaction\Models\InteractionType;
 use App\Models\User;
+use Filament\Actions\Testing\TestAction;
 use Filament\Forms\Components\Select;
 
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
-it('shows interaction options only for campaign population model type when editing journey step', function () {
+beforeEach(function () {
     asSuperAdmin();
+});
 
+it('shows interaction options only for campaign population model type when editing journey step', function () {
     $campaign = Campaign::factory()
         ->for(User::factory()->licensed(LicenseType::cases()), 'createdBy')
         ->for(Group::factory()->state(['model' => GroupModel::Student]), 'group')
@@ -84,7 +92,7 @@ it('shows interaction options only for campaign population model type when editi
         'ownerRecord' => $campaign,
         'pageClass' => ViewCampaign::class,
     ])
-        ->mountTableAction('edit', record: $action->getKey())
+        ->mountAction(TestAction::make('edit')->table($action))
         ->assertFormFieldExists('data.interaction_initiative_id', checkFieldUsing: function (Select $field) use ($studentInitiative, $prospectInitiative) {
             $optionKeys = array_keys($field->getOptions());
 
@@ -103,9 +111,7 @@ it('shows interaction options only for campaign population model type when editi
         });
 });
 
-it('shows correct interaction options when creating campaign with prospect population group', function () {
-    asSuperAdmin();
-
+it('shows interaction options only for campaign population model type when editing journey step of a prospect campaign', function () {
     $prospectGroup = Group::factory()->state(['model' => GroupModel::Prospect])->create();
 
     $studentInitiative = InteractionInitiative::factory()->create(['interactable_type' => InteractableType::Student]);
@@ -139,7 +145,7 @@ it('shows correct interaction options when creating campaign with prospect popul
         'ownerRecord' => $action->campaign,
         'pageClass' => ViewCampaign::class,
     ])
-        ->mountTableAction('edit', record: $action->getKey())
+        ->mountAction(TestAction::make('edit')->table($action))
         ->assertFormFieldExists('data.interaction_initiative_id', checkFieldUsing: function (Select $field) use ($studentInitiative, $prospectInitiative) {
             $optionKeys = array_keys($field->getOptions());
 
@@ -153,6 +159,96 @@ it('shows correct interaction options when creating campaign with prospect popul
 
             expect($optionKeys)->toContain($prospectDriver->getKey())
                 ->and($optionKeys)->not->toContain($studentDriver->getKey());
+
+            return true;
+        });
+});
+
+it('shows interaction options only for the selected population model type in the create wizard', function (GroupModel $groupModel, InteractableType $expected, InteractableType $excluded) {
+    $group = Group::factory()->create(['model' => $groupModel, 'user_id' => auth()->id()]);
+
+    $selects = [
+        'interaction_initiative_id' => InteractionInitiative::class,
+        'interaction_driver_id' => InteractionDriver::class,
+        'interaction_outcome_id' => InteractionOutcome::class,
+        'interaction_relation_id' => InteractionRelation::class,
+        'interaction_status_id' => InteractionStatus::class,
+        'interaction_type_id' => InteractionType::class,
+    ];
+
+    $expectedRecords = [];
+    $excludedRecords = [];
+
+    foreach ($selects as $field => $model) {
+        $expectedRecords[$field] = $model::factory()->create(['interactable_type' => $expected]);
+        $excludedRecords[$field] = $model::factory()->create(['interactable_type' => $excluded]);
+    }
+
+    $component = livewire(CreateCampaign::class)
+        ->fillForm([
+            'name' => 'Test Campaign',
+            'segment_id' => $group->getKey(),
+            'actions' => [
+                'step-one' => [
+                    'type' => 'interaction',
+                    'data' => [
+                        ...array_map(fn ($record) => $record->getKey(), $expectedRecords),
+                        'start_datetime' => now()->toDateTimeString(),
+                        'end_datetime' => now()->addHour()->toDateTimeString(),
+                        'subject' => 'Test subject',
+                        'description' => 'Test description',
+                        'execute_at' => now()->addDay()->toDateTimeString(),
+                    ],
+                ],
+            ],
+        ]);
+
+    foreach (array_keys($selects) as $field) {
+        $component->assertFormFieldExists(
+            "actions.step-one.data.{$field}",
+            checkFieldUsing: function (Select $select) use ($expectedRecords, $excludedRecords, $field) {
+                $optionKeys = array_keys($select->getOptions());
+
+                expect($optionKeys)->toContain($expectedRecords[$field]->getKey())
+                    ->and($optionKeys)->not->toContain($excludedRecords[$field]->getKey());
+
+                return true;
+            }
+        );
+    }
+})->with([
+    'student population group' => [GroupModel::Student, InteractableType::Student, InteractableType::Prospect],
+    'prospect population group' => [GroupModel::Prospect, InteractableType::Prospect, InteractableType::Student],
+]);
+
+it('offers no interaction options in the create wizard until a population group is selected', function () {
+    InteractionInitiative::factory()->create(['interactable_type' => InteractableType::Student]);
+    InteractionInitiative::factory()->create(['interactable_type' => InteractableType::Prospect]);
+
+    livewire(CreateCampaign::class)
+        ->fillForm([
+            'name' => 'Test Campaign',
+            'actions' => [
+                'step-one' => [
+                    'type' => 'interaction',
+                    'data' => [
+                        'interaction_initiative_id' => InteractionInitiative::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'interaction_driver_id' => InteractionDriver::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'interaction_outcome_id' => InteractionOutcome::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'interaction_relation_id' => InteractionRelation::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'interaction_status_id' => InteractionStatus::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'interaction_type_id' => InteractionType::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'start_datetime' => now()->toDateTimeString(),
+                        'end_datetime' => now()->addHour()->toDateTimeString(),
+                        'subject' => 'Test subject',
+                        'description' => 'Test description',
+                        'execute_at' => now()->addDay()->toDateTimeString(),
+                    ],
+                ],
+            ],
+        ])
+        ->assertFormFieldExists('actions.step-one.data.interaction_initiative_id', checkFieldUsing: function (Select $select) {
+            expect($select->getOptions())->toBeEmpty();
 
             return true;
         });

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor's trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Campaign\Tests\Tenant\Filament\Resources\Campaigns\Pages;
+
+use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\CreateCampaign;
+use AdvisingApp\Group\Enums\GroupModel;
+use AdvisingApp\Group\Models\Group;
+use App\Models\User;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('clears journey steps when population group is changed', function () {
+    asSuperAdmin();
+
+    // Create groups owned by the current user
+    $studentGroup = Group::factory()
+        ->for(User::factory(), 'user')
+        ->state(['model' => GroupModel::Student])
+        ->create();
+
+    $prospectGroup = Group::factory()
+        ->for(User::factory(), 'user')
+        ->state(['model' => GroupModel::Prospect])
+        ->create();
+
+    // Make groups accessible by making the current user owner
+    $studentGroup->update(['user_id' => auth()->id()]);
+    $prospectGroup->update(['user_id' => auth()->id()]);
+
+    livewire(CreateCampaign::class)
+        ->fillForm([
+            'name' => 'Test Campaign',
+            'segment_id' => $studentGroup->id,
+        ])
+        ->assertFormSet([
+            'segment_id' => $studentGroup->id,
+        ])
+        // Change to prospect group — actions should be cleared
+        ->fillForm([
+            'segment_id' => $prospectGroup->id,
+        ])
+        ->assertFormSet([
+            'segment_id' => $prospectGroup->id,
+            'actions' => [],
+        ]);
+});
+
+it('requires population group on campaign creation', function () {
+    asSuperAdmin();
+
+    livewire(CreateCampaign::class)
+        ->fillForm([
+            'name' => 'Test Campaign',
+        ])
+        ->call('create')
+        ->assertHasFormErrors([
+            'segment_id' => 'required',
+        ]);
+});

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
@@ -39,50 +39,60 @@ namespace AdvisingApp\Campaign\Tests\Tenant\Filament\Resources\Campaigns\Pages;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\CreateCampaign;
 use AdvisingApp\Group\Enums\GroupModel;
 use AdvisingApp\Group\Models\Group;
-use App\Models\User;
+use AdvisingApp\Interaction\Enums\InteractableType;
+use AdvisingApp\Interaction\Models\InteractionDriver;
+use AdvisingApp\Interaction\Models\InteractionInitiative;
+use AdvisingApp\Interaction\Models\InteractionOutcome;
+use AdvisingApp\Interaction\Models\InteractionRelation;
+use AdvisingApp\Interaction\Models\InteractionStatus;
+use AdvisingApp\Interaction\Models\InteractionType;
 
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
-it('clears journey steps when population group is changed', function () {
+beforeEach(function () {
     asSuperAdmin();
+});
 
-    // Create groups owned by the current user
-    $studentGroup = Group::factory()
-        ->for(User::factory(), 'user')
-        ->state(['model' => GroupModel::Student])
-        ->create();
-
-    $prospectGroup = Group::factory()
-        ->for(User::factory(), 'user')
-        ->state(['model' => GroupModel::Prospect])
-        ->create();
-
-    // Make groups accessible by making the current user owner
-    $studentGroup->update(['user_id' => auth()->id()]);
-    $prospectGroup->update(['user_id' => auth()->id()]);
+it('clears journey steps when the population group is changed', function (GroupModel $newPopulationModel) {
+    $studentGroup = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => auth()->id()]);
+    $newGroup = Group::factory()->create(['model' => $newPopulationModel, 'user_id' => auth()->id()]);
 
     livewire(CreateCampaign::class)
         ->fillForm([
             'name' => 'Test Campaign',
-            'segment_id' => $studentGroup->id,
+            'segment_id' => $studentGroup->getKey(),
+            'actions' => [
+                'step-one' => [
+                    'type' => 'interaction',
+                    'data' => [
+                        'interaction_initiative_id' => InteractionInitiative::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'interaction_driver_id' => InteractionDriver::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'interaction_outcome_id' => InteractionOutcome::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'interaction_relation_id' => InteractionRelation::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'interaction_status_id' => InteractionStatus::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'interaction_type_id' => InteractionType::factory()->create(['interactable_type' => InteractableType::Student])->getKey(),
+                        'start_datetime' => now()->toDateTimeString(),
+                        'end_datetime' => now()->addHour()->toDateTimeString(),
+                        'subject' => 'Test subject',
+                        'description' => 'Test description',
+                        'execute_at' => now()->addDay()->toDateTimeString(),
+                    ],
+                ],
+            ],
         ])
-        ->assertFormSet([
-            'segment_id' => $studentGroup->id,
-        ])
-        // Change to prospect group — actions should be cleared
-        ->fillForm([
-            'segment_id' => $prospectGroup->id,
-        ])
-        ->assertFormSet([
-            'segment_id' => $prospectGroup->id,
+        ->assertSchemaStateSet(['actions.step-one.data.subject' => 'Test subject'])
+        ->fillForm(['segment_id' => $newGroup->getKey()])
+        ->assertSchemaStateSet([
+            'segment_id' => $newGroup->getKey(),
             'actions' => [],
         ]);
-});
+})->with([
+    'to a group of a different population model type' => GroupModel::Prospect,
+    'to another group of the same population model type' => GroupModel::Student,
+]);
 
 it('requires population group on campaign creation', function () {
-    asSuperAdmin();
-
     livewire(CreateCampaign::class)
         ->fillForm([
             'name' => 'Test Campaign',


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2825

### Technical Description

- Add interaction options filtering for campaign population model in InteractionBlock

### Any deployment steps required?

No

### Cleanup Tasks

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
