### PR TITLE
chore: Update Filament to v4.12.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4323,16 +4323,16 @@
         },
         {
             "name": "filament/actions",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/actions.git",
-                "reference": "f6f527992a1b91ad0152b558cdd5d5172a6b996e"
+                "reference": "6fa2504a740dbde535016213a05fd19214601b03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/actions/zipball/f6f527992a1b91ad0152b558cdd5d5172a6b996e",
-                "reference": "f6f527992a1b91ad0152b558cdd5d5172a6b996e",
+                "url": "https://api.github.com/repos/filamentphp/actions/zipball/6fa2504a740dbde535016213a05fd19214601b03",
+                "reference": "6fa2504a740dbde535016213a05fd19214601b03",
                 "shasum": ""
             },
             "require": {
@@ -4368,20 +4368,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-17T11:48:04+00:00"
+            "time": "2026-07-22T16:50:49+00:00"
         },
         {
             "name": "filament/filament",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/panels.git",
-                "reference": "b1a6ec2e98982c89d4197997c1d0554610fd862d"
+                "reference": "fc178716e8644b9a2d2a46933b327d8b49182fbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/panels/zipball/b1a6ec2e98982c89d4197997c1d0554610fd862d",
-                "reference": "b1a6ec2e98982c89d4197997c1d0554610fd862d",
+                "url": "https://api.github.com/repos/filamentphp/panels/zipball/fc178716e8644b9a2d2a46933b327d8b49182fbb",
+                "reference": "fc178716e8644b9a2d2a46933b327d8b49182fbb",
                 "shasum": ""
             },
             "require": {
@@ -4425,20 +4425,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-17T11:48:57+00:00"
+            "time": "2026-07-22T16:54:53+00:00"
         },
         {
             "name": "filament/forms",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/forms.git",
-                "reference": "edba08804e3e60fed8806e08b2470287d8e08706"
+                "reference": "0276a5179d94f6f49d64373c05b7b576ee42a3fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/forms/zipball/edba08804e3e60fed8806e08b2470287d8e08706",
-                "reference": "edba08804e3e60fed8806e08b2470287d8e08706",
+                "url": "https://api.github.com/repos/filamentphp/forms/zipball/0276a5179d94f6f49d64373c05b7b576ee42a3fa",
+                "reference": "0276a5179d94f6f49d64373c05b7b576ee42a3fa",
                 "shasum": ""
             },
             "require": {
@@ -4475,20 +4475,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-17T13:30:44+00:00"
+            "time": "2026-07-22T16:53:42+00:00"
         },
         {
             "name": "filament/infolists",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/infolists.git",
-                "reference": "78e792e8336760fbe165442d0e112f9f27036a99"
+                "reference": "701113f8e497356d0e15dcf227c875c51635a878"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/78e792e8336760fbe165442d0e112f9f27036a99",
-                "reference": "78e792e8336760fbe165442d0e112f9f27036a99",
+                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/701113f8e497356d0e15dcf227c875c51635a878",
+                "reference": "701113f8e497356d0e15dcf227c875c51635a878",
                 "shasum": ""
             },
             "require": {
@@ -4520,20 +4520,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-17T13:19:09+00:00"
+            "time": "2026-07-22T16:54:52+00:00"
         },
         {
             "name": "filament/notifications",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/notifications.git",
-                "reference": "5b5907691ef6e735d17b7c96fbad3a595e8fc9f6"
+                "reference": "508b4e02c1cb8516a13077c67dd31f8a5c855802"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/notifications/zipball/5b5907691ef6e735d17b7c96fbad3a595e8fc9f6",
-                "reference": "5b5907691ef6e735d17b7c96fbad3a595e8fc9f6",
+                "url": "https://api.github.com/repos/filamentphp/notifications/zipball/508b4e02c1cb8516a13077c67dd31f8a5c855802",
+                "reference": "508b4e02c1cb8516a13077c67dd31f8a5c855802",
                 "shasum": ""
             },
             "require": {
@@ -4567,20 +4567,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-17T11:40:40+00:00"
+            "time": "2026-07-22T16:55:19+00:00"
         },
         {
             "name": "filament/query-builder",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/query-builder.git",
-                "reference": "9882be4ecb062878f6eacf46468d72b31563b492"
+                "reference": "08cb26b3d3c714150b1162c06c7e4976864160ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/query-builder/zipball/9882be4ecb062878f6eacf46468d72b31563b492",
-                "reference": "9882be4ecb062878f6eacf46468d72b31563b492",
+                "url": "https://api.github.com/repos/filamentphp/query-builder/zipball/08cb26b3d3c714150b1162c06c7e4976864160ce",
+                "reference": "08cb26b3d3c714150b1162c06c7e4976864160ce",
                 "shasum": ""
             },
             "require": {
@@ -4613,20 +4613,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-17T11:48:21+00:00"
+            "time": "2026-07-22T16:53:10+00:00"
         },
         {
             "name": "filament/schemas",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/schemas.git",
-                "reference": "e9b736636fae793684faad145e522a3ae46f0c99"
+                "reference": "9801fd6f63eba5f530acbf1afbd957280cb30c38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/schemas/zipball/e9b736636fae793684faad145e522a3ae46f0c99",
-                "reference": "e9b736636fae793684faad145e522a3ae46f0c99",
+                "url": "https://api.github.com/repos/filamentphp/schemas/zipball/9801fd6f63eba5f530acbf1afbd957280cb30c38",
+                "reference": "9801fd6f63eba5f530acbf1afbd957280cb30c38",
                 "shasum": ""
             },
             "require": {
@@ -4658,11 +4658,11 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-17T13:31:08+00:00"
+            "time": "2026-07-22T16:54:45+00:00"
         },
         {
             "name": "filament/spatie-laravel-media-library-plugin",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-media-library-plugin.git",
@@ -4699,7 +4699,7 @@
         },
         {
             "name": "filament/spatie-laravel-settings-plugin",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-settings-plugin.git",
@@ -4743,16 +4743,16 @@
         },
         {
             "name": "filament/support",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/support.git",
-                "reference": "4ed5a7239c149b3fdc5c068008321097397f3341"
+                "reference": "b271075b090f1dbbe03797604e4d7201fc060309"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/support/zipball/4ed5a7239c149b3fdc5c068008321097397f3341",
-                "reference": "4ed5a7239c149b3fdc5c068008321097397f3341",
+                "url": "https://api.github.com/repos/filamentphp/support/zipball/b271075b090f1dbbe03797604e4d7201fc060309",
+                "reference": "b271075b090f1dbbe03797604e4d7201fc060309",
                 "shasum": ""
             },
             "require": {
@@ -4797,20 +4797,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-17T11:46:04+00:00"
+            "time": "2026-07-22T16:54:40+00:00"
         },
         {
             "name": "filament/tables",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/tables.git",
-                "reference": "a7a1206d0e3b5c61b8ca5e4bffe812a990122ebe"
+                "reference": "13c54b7586a4cb5bedd4559c8395c3186cbacbf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/tables/zipball/a7a1206d0e3b5c61b8ca5e4bffe812a990122ebe",
-                "reference": "a7a1206d0e3b5c61b8ca5e4bffe812a990122ebe",
+                "url": "https://api.github.com/repos/filamentphp/tables/zipball/13c54b7586a4cb5bedd4559c8395c3186cbacbf1",
+                "reference": "13c54b7586a4cb5bedd4559c8395c3186cbacbf1",
                 "shasum": ""
             },
             "require": {
@@ -4843,20 +4843,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-17T11:49:06+00:00"
+            "time": "2026-07-22T16:54:36+00:00"
         },
         {
             "name": "filament/widgets",
-            "version": "v4.12.1",
+            "version": "v4.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/widgets.git",
-                "reference": "19f1367770b5790e5ba3a11a6a37b6ca0534be9d"
+                "reference": "0a191bbe472de9bb0ef735dce3538a7f9bb0f8fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/19f1367770b5790e5ba3a11a6a37b6ca0534be9d",
-                "reference": "19f1367770b5790e5ba3a11a6a37b6ca0534be9d",
+                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/0a191bbe472de9bb0ef735dce3538a7f9bb0f8fc",
+                "reference": "0a191bbe472de9bb0ef735dce3538a7f9bb0f8fc",
                 "shasum": ""
             },
             "require": {
@@ -4887,7 +4887,7 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-07-17T11:48:51+00:00"
+            "time": "2026-07-22T16:55:46+00:00"
         },
         {
             "name": "firebase/php-jwt",
@@ -5345,16 +5345,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.0",
+            "version": "7.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "90bd104afeb0fcc2190c9eb6fd8a441447e4b30d"
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/90bd104afeb0fcc2190c9eb6fd8a441447e4b30d",
-                "reference": "90bd104afeb0fcc2190c9eb6fd8a441447e4b30d",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
                 "shasum": ""
             },
             "require": {
@@ -5453,7 +5453,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
             },
             "funding": [
                 {
@@ -5469,7 +5469,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-17T12:26:48+00:00"
+            "time": "2026-07-18T11:23:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -5676,16 +5676,16 @@
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.9",
+            "version": "v1.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "d7580af6d3f8384325d9cd3e99b21c3ed1848176"
+                "reference": "f6c24c21f42b990e9a58912b332d0874df6ba839"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/d7580af6d3f8384325d9cd3e99b21c3ed1848176",
-                "reference": "d7580af6d3f8384325d9cd3e99b21c3ed1848176",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/f6c24c21f42b990e9a58912b332d0874df6ba839",
+                "reference": "f6c24c21f42b990e9a58912b332d0874df6ba839",
                 "shasum": ""
             },
             "require": {
@@ -5742,7 +5742,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.9"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.10"
             },
             "funding": [
                 {
@@ -5758,7 +5758,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T16:19:22+00:00"
+            "time": "2026-07-17T13:53:03+00:00"
         },
         {
             "name": "internachi/modular",
@@ -6708,16 +6708,16 @@
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.13",
+            "version": "v2.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce"
+                "reference": "dccd8bcb851bb03fcc005df650b708b57cc52661"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
-                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/dccd8bcb851bb03fcc005df650b708b57cc52661",
+                "reference": "dccd8bcb851bb03fcc005df650b708b57cc52661",
                 "shasum": ""
             },
             "require": {
@@ -6765,7 +6765,7 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-04-16T14:03:50+00:00"
+            "time": "2026-07-21T16:49:22+00:00"
         },
         {
             "name": "laravel/socialite",
@@ -9077,16 +9077,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.4",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
-                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "url": "https://api.github.com/repos/nette/utils/zipball/b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0",
                 "shasum": ""
             },
             "require": {
@@ -9106,7 +9106,7 @@
             },
             "suggest": {
                 "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-iconv": "to use Strings::chr(), ord() and reverse()",
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
@@ -9162,9 +9162,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.4"
+                "source": "https://github.com/nette/utils/tree/v4.1.5"
             },
-            "time": "2026-05-11T20:49:54+00:00"
+            "time": "2026-07-17T23:02:45+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -13345,16 +13345,16 @@
         },
         {
             "name": "spatie/laravel-medialibrary",
-            "version": "11.23.2",
+            "version": "11.23.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/laravel-medialibrary.git",
-                "reference": "cc1fdc4a9a9007101df610cd4a6733be71db4828"
+                "reference": "b578814b8c81a68c8ec9c9005246df5d417fe0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/laravel-medialibrary/zipball/cc1fdc4a9a9007101df610cd4a6733be71db4828",
-                "reference": "cc1fdc4a9a9007101df610cd4a6733be71db4828",
+                "url": "https://api.github.com/repos/spatie/laravel-medialibrary/zipball/b578814b8c81a68c8ec9c9005246df5d417fe0f9",
+                "reference": "b578814b8c81a68c8ec9c9005246df5d417fe0f9",
                 "shasum": ""
             },
             "require": {
@@ -13439,7 +13439,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/laravel-medialibrary/issues",
-                "source": "https://github.com/spatie/laravel-medialibrary/tree/11.23.2"
+                "source": "https://github.com/spatie/laravel-medialibrary/tree/11.23.3"
             },
             "funding": [
                 {
@@ -13451,7 +13451,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-09T13:26:15+00:00"
+            "time": "2026-07-22T07:06:25+00:00"
         },
         {
             "name": "spatie/laravel-multitenancy",


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

> Bumped Filament from v4.12.1 to v4.12.2 (patch/bugfix release, no breaking changes).

- Ran `composer update "filament/*" --with-all-dependencies` to update all `filament/*` packages to v4.12.2.
- No `composer.json` changes needed — existing `^4.12`/`^4.0` constraints already allow v4.12.2.
- `filament:upgrade` ran automatically via the existing composer hook, republishing assets.
- A few compatible transitive bumps also came along (`canyongbs/common`, `guzzlehttp/guzzle`, `spatie/laravel-medialibrary`).

### Any deployment steps required?

> NO

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
