### PR TITLE
[ADVAPP-2826]: Interactions from campaigns are not saving subject or descriptions

### DIFF
--- a/app-modules/campaign/src/Jobs/InteractionCampaignActionJob.php
+++ b/app-modules/campaign/src/Jobs/InteractionCampaignActionJob.php
@@ -71,6 +71,10 @@ class InteractionCampaignActionJob extends ExecuteCampaignActionOnEducatableJob
                 'interaction_driver_id' => $action->data['interaction_driver_id'],
                 'interaction_status_id' => $action->data['interaction_status_id'],
                 'interaction_outcome_id' => $action->data['interaction_outcome_id'],
+                'subject' => $action->data['subject'],
+                'description' => $action->data['description'],
+                'start_datetime' => $action->data['start_datetime'],
+                'end_datetime' => $action->data['end_datetime'],
             ]);
 
             $this->actionEducatable->succeeded_at = now();

--- a/app-modules/campaign/tests/Tenant/Jobs/InteractionCampaignActionJobTest.php
+++ b/app-modules/campaign/tests/Tenant/Jobs/InteractionCampaignActionJobTest.php
@@ -81,6 +81,11 @@ it('will execute appropriately on each educatable in the group', function (Educa
     $interactionStatus = InteractionStatus::factory()->create();
     $interactionOutcome = InteractionOutcome::factory()->create();
 
+    $subject = 'Test Subject';
+    $description = 'Test Description';
+    $startDateTime = now()->addDay();
+    $endDateTime = $startDateTime->clone()->addHour();
+
     /** @var CampaignAction $action */
     $action = CampaignAction::factory()
         ->for($campaign, 'campaign')
@@ -93,6 +98,10 @@ it('will execute appropriately on each educatable in the group', function (Educa
                 'interaction_driver_id' => $interactionDriver->getKey(),
                 'interaction_status_id' => $interactionStatus->getKey(),
                 'interaction_outcome_id' => $interactionOutcome->getKey(),
+                'subject' => $subject,
+                'description' => $description,
+                'start_datetime' => $startDateTime->toDateTimeString(),
+                'end_datetime' => $endDateTime->toDateTimeString(),
             ],
         ]);
 
@@ -111,13 +120,20 @@ it('will execute appropriately on each educatable in the group', function (Educa
 
     $interactions = $educatable->interactions()->get();
 
-    expect($interactions)->toHaveCount(1)
-        ->and($interactions->first()->type->getKey())->toEqual($interactionType->getKey())
-        ->and($interactions->first()->initiative->getKey())->toEqual($interactionInitiative->getKey())
-        ->and($interactions->first()->relation->getKey())->toEqual($interactionRelation->getKey())
-        ->and($interactions->first()->driver->getKey())->toEqual($interactionDriver->getKey())
-        ->and($interactions->first()->status->getKey())->toEqual($interactionStatus->getKey())
-        ->and($interactions->first()->outcome->getKey())->toEqual($interactionOutcome->getKey());
+    expect($interactions)->toHaveCount(1);
+
+    $interaction = $interactions->first();
+
+    expect($interaction->type->getKey())->toEqual($interactionType->getKey())
+        ->and($interaction->initiative->getKey())->toEqual($interactionInitiative->getKey())
+        ->and($interaction->relation->getKey())->toEqual($interactionRelation->getKey())
+        ->and($interaction->driver->getKey())->toEqual($interactionDriver->getKey())
+        ->and($interaction->status->getKey())->toEqual($interactionStatus->getKey())
+        ->and($interaction->outcome->getKey())->toEqual($interactionOutcome->getKey())
+        ->and($interaction->subject)->toEqual($subject)
+        ->and($interaction->description)->toEqual($description)
+        ->and($interaction->start_datetime->toDateTimeString())->toEqual($startDateTime->toDateTimeString())
+        ->and($interaction->end_datetime->toDateTimeString())->toEqual($endDateTime->toDateTimeString());
 
     expect($campaignActionEducatable->succeeded_at)->not()->toBeNull()
         ->and($campaignActionEducatable->last_failed_at)->toBeNull()

--- a/app-modules/interaction/src/Filament/Resources/Interactions/Pages/ListInteractions.php
+++ b/app-modules/interaction/src/Filament/Resources/Interactions/Pages/ListInteractions.php
@@ -78,7 +78,10 @@ class ListInteractions extends ListRecords
                     ->label('End Time')
                     ->dateTime(),
                 TextColumn::make('created_at')
-                    ->state(fn ($record) => $record->end_datetime->diffForHumans($record->start_datetime, CarbonInterface::DIFF_ABSOLUTE, true, 6))
+                    ->state(fn ($record) => filled($record->end_datetime) && filled($record->start_datetime) 
+                        ? $record->end_datetime->diffForHumans($record->start_datetime, CarbonInterface::DIFF_ABSOLUTE, true, 6)
+                        : '-'
+                    )
                     ->label('Duration'),
                 TextColumn::make('subject')
                     ->searchable(),

--- a/app-modules/interaction/src/Filament/Resources/Interactions/Pages/ListInteractions.php
+++ b/app-modules/interaction/src/Filament/Resources/Interactions/Pages/ListInteractions.php
@@ -78,7 +78,8 @@ class ListInteractions extends ListRecords
                     ->label('End Time')
                     ->dateTime(),
                 TextColumn::make('created_at')
-                    ->state(fn ($record) => filled($record->end_datetime) && filled($record->start_datetime) 
+                    ->state(
+                        fn ($record) => filled($record->end_datetime) && filled($record->start_datetime)
                         ? $record->end_datetime->diffForHumans($record->start_datetime, CarbonInterface::DIFF_ABSOLUTE, true, 6)
                         : '-'
                     )


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2826

### Technical Description

- Add subject, description, and datetime fields to interaction records

### Any deployment steps required?

No

### Cleanup Tasks

No

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
