### PR TITLE
[ADVAPP-2836]: Introduce support for latest AI models to power the application

### DIFF
--- a/.cleanup-tasks/2026_07_23_gpt56_luna_feature.md
+++ b/.cleanup-tasks/2026_07_23_gpt56_luna_feature.md
@@ -1,0 +1,12 @@
+---
+title: Gpt56 Luna Feature
+created: 2026-07-23
+---
+
+## Feature Flags
+
+- App\Features\Gpt56LunaFeature
+
+## Temporary Migrations
+
+## Additional Cleanup

--- a/.env.example
+++ b/.env.example
@@ -180,3 +180,7 @@ OPEN_AI_GPT_54_MINI_MODEL=
 OPEN_AI_GPT_54_NANO_BASE_URI=https://cgbs-partner-canyon-dev-east-2.openai.azure.com/openai/v1
 OPEN_AI_GPT_54_NANO_API_KEY=
 OPEN_AI_GPT_54_NANO_MODEL=
+
+OPEN_AI_GPT_56_LUNA_BASE_URI=https://cgbs-partner-canyon-dev-east-2.openai.azure.com/openai/v1
+OPEN_AI_GPT_56_LUNA_API_KEY=
+OPEN_AI_GPT_56_LUNA_MODEL=

--- a/app-modules/ai/database/migrations/2026_07_23_224001_add_gpt_56_luna_settings.php
+++ b/app-modules/ai/database/migrations/2026_07_23_224001_add_gpt_56_luna_settings.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\Gpt56LunaFeature;
 use Illuminate\Support\Facades\DB;
 use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;

--- a/app-modules/ai/database/migrations/2026_07_23_224001_add_gpt_56_luna_settings.php
+++ b/app-modules/ai/database/migrations/2026_07_23_224001_add_gpt_56_luna_settings.php
@@ -1,0 +1,65 @@
+<?php
+
+use App\Features\Gpt56LunaFeature;
+use Illuminate\Support\Facades\DB;
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        DB::transaction(function () {
+            try {
+                $this->migrator->add('ai.open_ai_gpt_56_luna_model_name');
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_56_luna_base_uri', config('integration-open-ai.gpt_56_luna_base_uri'), encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_56_luna_api_key', config('integration-open-ai.gpt_56_luna_api_key'), encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_56_luna_model', config('integration-open-ai.gpt_56_luna_model'), encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_56_luna_applicable_features', []);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('ai.open_ai_gpt_56_luna_image_generation_deployment', encrypted: true);
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            Gpt56LunaFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Gpt56LunaFeature::deactivate();
+
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_56_luna_base_uri');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_56_luna_api_key');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_56_luna_model');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_56_luna_applicable_features');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_56_luna_model_name');
+            $this->migrator->deleteIfExists('ai.open_ai_gpt_56_luna_image_generation_deployment');
+        });
+    }
+};

--- a/app-modules/ai/src/Enums/AiModel.php
+++ b/app-modules/ai/src/Enums/AiModel.php
@@ -45,6 +45,7 @@ use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt4oMiniService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt4oService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt54MiniService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt54NanoService;
+use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt56LunaService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt5MiniService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt5NanoService;
 use AdvisingApp\IntegrationOpenAi\Services\OpenAiGpt5Service;
@@ -78,6 +79,8 @@ enum AiModel: string implements HasLabel
 
     case OpenAiGpt54Nano = 'openai_gpt_54_nano';
 
+    case OpenAiGpt56Luna = 'openai_gpt_56_luna';
+
     case OpenAiGptTest = 'openai_gpt_test';
 
     case JinaDeepSearchV1 = 'jina_deepsearch_v1';
@@ -102,6 +105,7 @@ enum AiModel: string implements HasLabel
             self::OpenAiGpt54Mini => $aiIntegrationSettings->open_ai_gpt_54_mini_model_name ?? 'Canyon 5.4 mini',
             self::OpenAiGpt5Nano => $aiIntegrationSettings->open_ai_gpt_5_nano_model_name ?? 'Canyon 5 nano',
             self::OpenAiGpt54Nano => $aiIntegrationSettings->open_ai_gpt_54_nano_model_name ?? 'Canyon 5.4 nano',
+            self::OpenAiGpt56Luna => $aiIntegrationSettings->open_ai_gpt_56_luna_model_name ?? 'Canyon 5.6 luna',
             self::JinaDeepSearchV1 => $aiIntegrationSettings->jina_deepsearch_v1_model_name ?? 'Canyon Deep Search',
             self::LlamaParse => $aiIntegrationSettings->llamaparse_model_name ?? 'Canyon Parsing Service',
             self::OpenAiGptTest => 'Canyon Test',
@@ -128,6 +132,7 @@ enum AiModel: string implements HasLabel
             self::OpenAiGpt54Mini => $aiIntegrationSettings->open_ai_gpt_54_mini_applicable_features,
             self::OpenAiGpt5Nano => $aiIntegrationSettings->open_ai_gpt_5_nano_applicable_features,
             self::OpenAiGpt54Nano => $aiIntegrationSettings->open_ai_gpt_54_nano_applicable_features,
+            self::OpenAiGpt56Luna => $aiIntegrationSettings->open_ai_gpt_56_luna_applicable_features,
             self::JinaDeepSearchV1 => $aiIntegrationSettings->jina_deepsearch_v1_applicable_features,
             self::LlamaParse => [],
             self::OpenAiGptTest => app()->hasDebugModeEnabled() ? AiModelApplicabilityFeature::cases() : [],
@@ -162,6 +167,7 @@ enum AiModel: string implements HasLabel
             self::OpenAiGpt5Nano => OpenAiGpt5NanoService::class,
             self::OpenAiGpt54Mini => OpenAiGpt54MiniService::class,
             self::OpenAiGpt54Nano => OpenAiGpt54NanoService::class,
+            self::OpenAiGpt56Luna => OpenAiGpt56LunaService::class,
             self::OpenAiGptTest => OpenAiGptTestService::class,
             self::Test => TestAiService::class,
             default => throw new Exception('No Service class found for this model.'),

--- a/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageAiIntegrationsSettings.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Ai\Filament\Pages;
 
 use AdvisingApp\Ai\Enums\AiModelApplicabilityFeature;
 use AdvisingApp\Ai\Settings\AiIntegrationsSettings;
+use App\Features\Gpt56LunaFeature;
 use App\Filament\Clusters\GlobalArtificialIntelligence;
 use App\Models\User;
 use Filament\Forms\Components\Select;
@@ -368,6 +369,34 @@ class ManageAiIntegrationsSettings extends SettingsPage
                                 TextInput::make('open_ai_gpt_54_nano_image_generation_deployment')
                                     ->label('Image generation model'),
                                 Select::make('open_ai_gpt_54_nano_applicable_features')
+                                    ->label('Applicability')
+                                    ->options(AiModelApplicabilityFeature::class)
+                                    ->multiple()
+                                    ->nestedRecursiveRules([Rule::enum(AiModelApplicabilityFeature::class)]),
+                            ]),
+                        Section::make('GPT 5.6 luna')
+                            ->collapsible()
+                            ->visible(Gpt56LunaFeature::active())
+                            ->schema([
+                                TextInput::make('open_ai_gpt_56_luna_model_name')
+                                    ->label('Model Name')
+                                    ->placeholder('Canyon 5.6 luna')
+                                    ->string()
+                                    ->maxLength(255)
+                                    ->nullable(),
+                                TextInput::make('open_ai_gpt_56_luna_base_uri')
+                                    ->label('Base URI')
+                                    ->placeholder('https://example.openai.azure.com/openai')
+                                    ->url(),
+                                TextInput::make('open_ai_gpt_56_luna_api_key')
+                                    ->label('API Key')
+                                    ->password()
+                                    ->autocomplete(false),
+                                TextInput::make('open_ai_gpt_56_luna_model')
+                                    ->label('Model'),
+                                TextInput::make('open_ai_gpt_56_luna_image_generation_deployment')
+                                    ->label('Image generation model'),
+                                Select::make('open_ai_gpt_56_luna_applicable_features')
                                     ->label('Applicability')
                                     ->options(AiModelApplicabilityFeature::class)
                                     ->multiple()

--- a/app-modules/ai/src/Settings/AiIntegrationsSettings.php
+++ b/app-modules/ai/src/Settings/AiIntegrationsSettings.php
@@ -200,6 +200,21 @@ class AiIntegrationsSettings extends Settings
      */
     public array $open_ai_gpt_54_nano_applicable_features = [];
 
+    public ?string $open_ai_gpt_56_luna_model_name = null;
+
+    public ?string $open_ai_gpt_56_luna_base_uri = null;
+
+    public ?string $open_ai_gpt_56_luna_api_key = null;
+
+    public ?string $open_ai_gpt_56_luna_model = null;
+
+    public ?string $open_ai_gpt_56_luna_image_generation_deployment = null;
+
+    /**
+     * @var array<string>
+     */
+    public array $open_ai_gpt_56_luna_applicable_features = [];
+
     /**
      * @var array<string>
      */
@@ -270,6 +285,10 @@ class AiIntegrationsSettings extends Settings
             'open_ai_gpt_54_nano_api_key',
             'open_ai_gpt_54_nano_model',
             'open_ai_gpt_54_nano_image_generation_deployment',
+            'open_ai_gpt_56_luna_base_uri',
+            'open_ai_gpt_56_luna_api_key',
+            'open_ai_gpt_56_luna_model',
+            'open_ai_gpt_56_luna_image_generation_deployment',
             'jina_deepsearch_v1_api_key',
             'llamaparse_api_key',
         ];

--- a/app-modules/integration-open-ai/config/integration-open-ai.php
+++ b/app-modules/integration-open-ai/config/integration-open-ai.php
@@ -112,4 +112,10 @@ return [
     'gpt_54_nano_api_key' => env('OPEN_AI_GPT_54_NANO_API_KEY'),
 
     'gpt_54_nano_model' => env('OPEN_AI_GPT_54_NANO_MODEL'),
+
+    'gpt_56_luna_base_uri' => env('OPEN_AI_GPT_56_LUNA_BASE_URI'),
+
+    'gpt_56_luna_api_key' => env('OPEN_AI_GPT_56_LUNA_API_KEY'),
+
+    'gpt_56_luna_model' => env('OPEN_AI_GPT_56_LUNA_MODEL'),
 ];

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt56LunaService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt56LunaService.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace AdvisingApp\IntegrationOpenAi\Services;
 
 class OpenAiGpt56LunaService extends BaseOpenAiService

--- a/app-modules/integration-open-ai/src/Services/OpenAiGpt56LunaService.php
+++ b/app-modules/integration-open-ai/src/Services/OpenAiGpt56LunaService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AdvisingApp\IntegrationOpenAi\Services;
+
+class OpenAiGpt56LunaService extends BaseOpenAiService
+{
+    public function getApiKey(): string
+    {
+        return $this->settings->open_ai_gpt_56_luna_api_key ?? config('integration-open-ai.gpt_56_luna_api_key');
+    }
+
+    public function getModel(): string
+    {
+        return $this->settings->open_ai_gpt_56_luna_model ?? config('integration-open-ai.gpt_56_luna_model');
+    }
+
+    public function getDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_56_luna_base_uri ?? config('integration-open-ai.gpt_56_luna_base_uri');
+    }
+
+    public function getImageGenerationDeployment(): ?string
+    {
+        return $this->settings->open_ai_gpt_56_luna_image_generation_deployment;
+    }
+}

--- a/app/Features/Gpt56LunaFeature.php
+++ b/app/Features/Gpt56LunaFeature.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/app/Features/Gpt56LunaFeature.php
+++ b/app/Features/Gpt56LunaFeature.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class Gpt56LunaFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2836

### Technical Description

Add support for GPT 5.6 Luna configuration

### Any deployment steps required?

Three new keys have been added to `.env.example`:
```
OPEN_AI_GPT_56_LUNA_BASE_URI
OPEN_AI_GPT_56_LUNA_API_KEY
OPEN_AI_GPT_56_LUNA_MODEL
```

### Cleanup Tasks

.cleanup-tasks/2026_07_23_gpt56_luna_feature.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
