### PR TITLE
[ADVAPP-2841]: Update usage endpoint with additional required data

### DIFF
--- a/app/Http/Controllers/UtilizationMetricsApiController.php
+++ b/app/Http/Controllers/UtilizationMetricsApiController.php
@@ -39,6 +39,8 @@ namespace App\Http\Controllers;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Models\Prompt;
 use AdvisingApp\Ai\Models\PromptUse;
+use AdvisingApp\Alert\Models\AlertConfiguration;
+use AdvisingApp\Alert\Presets\AlertPreset;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Campaign\Models\Campaign;
 use AdvisingApp\Campaign\Models\CampaignAction;
@@ -46,6 +48,8 @@ use AdvisingApp\Concern\Models\Concern;
 use AdvisingApp\Form\Models\Form;
 use AdvisingApp\Form\Models\FormSubmission;
 use AdvisingApp\Group\Models\Group;
+use AdvisingApp\MeetingCenter\Models\BookingGroupAppointment;
+use AdvisingApp\MeetingCenter\Models\CalendarEvent;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\Notification\Models\EmailMessage;
 use AdvisingApp\Notification\Models\SmsMessage;
@@ -53,6 +57,7 @@ use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Models\TrackedEventCount;
 use AdvisingApp\ResourceHub\Models\ResourceHubArticle;
+use AdvisingApp\ResourceHub\Models\ResourceHubCategory;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Survey\Models\Survey;
 use AdvisingApp\Survey\Models\SurveySubmission;
@@ -79,6 +84,27 @@ class UtilizationMetricsApiController extends Controller
             ->whereBetween('created_at', [$resetWindow['start'], $resetWindow['end']])
             ->sum('quota_usage');
 
+        $alertsByAlertType = collect(AlertPreset::cases())
+            ->mapWithKeys(fn (AlertPreset $preset): array => [$preset->value => 0])
+            ->replace(
+                AlertConfiguration::query()
+                    ->selectRaw('alert_configurations.preset, COUNT(student_alerts.sisid) AS alert_count')
+                    ->leftJoin('student_alerts', 'student_alerts.alert_configuration_id', '=', 'alert_configurations.id')
+                    ->groupBy('alert_configurations.preset')
+                    ->pluck('alert_count', 'alert_configurations.preset')
+                    ->map(fn (int|string $count): int => (int) $count)
+                    ->all()
+            )
+            ->all();
+
+        $resourceHubArticlesByCategory = ResourceHubCategory::query()
+            ->leftJoin('resource_hub_articles', 'resource_hub_articles.category_id', '=', 'resource_hub_categories.id')
+            ->selectRaw('resource_hub_categories.name, COUNT(resource_hub_articles.id) AS article_count')
+            ->groupBy('resource_hub_categories.id', 'resource_hub_categories.name')
+            ->pluck('article_count', 'resource_hub_categories.name')
+            ->map(fn (int|string $count): int => (int) $count)
+            ->all();
+
         try {
             return response()->json([
                 'data' => [
@@ -99,10 +125,14 @@ class UtilizationMetricsApiController extends Controller
                     'groups' => Group::count(),
                     'resource_hub_articles' => ResourceHubArticle::count(),
                     'events_created' => Event::count(),
+                    'group_appointments' => BookingGroupAppointment::count(),
+                    'personal_appointments' => CalendarEvent::count(),
                     'forms_created' => Form::count(),
                     'forms_submitted' => FormSubmission::count(),
                     'surveys_created' => Survey::count(),
                     'surveys_submitted' => SurveySubmission::count(),
+                    'alerts_by_alert_type' => $alertsByAlertType,
+                    'resource_hub_articles_by_category' => $resourceHubArticlesByCategory,
                     'emails' => $currentQuotaUsageOfEmail . '/' . $licenseSettings->data->limits->emails,
                     'text_messages' => $currentQuotaUsageOfSms . '/' . $licenseSettings->data->limits->sms,
                     'messages_reset' => $licenseSettings->data->limits->resetDate,

--- a/app/Http/Controllers/UtilizationMetricsApiController.php
+++ b/app/Http/Controllers/UtilizationMetricsApiController.php
@@ -48,6 +48,7 @@ use AdvisingApp\Concern\Models\Concern;
 use AdvisingApp\Form\Models\Form;
 use AdvisingApp\Form\Models\FormSubmission;
 use AdvisingApp\Group\Models\Group;
+use AdvisingApp\Interaction\Models\Interaction;
 use AdvisingApp\MeetingCenter\Models\BookingGroupAppointment;
 use AdvisingApp\MeetingCenter\Models\CalendarEvent;
 use AdvisingApp\MeetingCenter\Models\Event;
@@ -122,6 +123,7 @@ class UtilizationMetricsApiController extends Controller
                     'journey_steps_executed' => CampaignAction::whereNotNull('execution_finished_at')->count(),
                     'tasks' => Task::count(),
                     'concerns' => Concern::count(),
+                    'interactions' => Interaction::count(),
                     'groups' => Group::count(),
                     'resource_hub_articles' => ResourceHubArticle::count(),
                     'events_created' => Event::count(),

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -37,18 +37,30 @@
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Models\Prompt;
 use AdvisingApp\Ai\Models\PromptUse;
+use AdvisingApp\Alert\Actions\GenerateStudentAlertsView;
+use AdvisingApp\Alert\Models\AlertConfiguration;
+use AdvisingApp\Alert\Presets\AlertPreset;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Campaign\Models\Campaign;
 use AdvisingApp\Campaign\Models\CampaignAction;
+use AdvisingApp\Concern\Enums\SystemConcernStatusClassification;
 use AdvisingApp\Concern\Models\Concern;
+use AdvisingApp\Concern\Models\ConcernStatus;
 use AdvisingApp\Form\Models\Form;
 use AdvisingApp\Form\Models\FormSubmission;
 use AdvisingApp\Group\Models\Group;
+use AdvisingApp\MeetingCenter\Managers\CalendarManager;
+use AdvisingApp\MeetingCenter\Managers\Contracts\CalendarInterface;
+use AdvisingApp\MeetingCenter\Models\BookingGroupAppointment;
+use AdvisingApp\MeetingCenter\Models\Calendar;
+use AdvisingApp\MeetingCenter\Models\CalendarEvent;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\Prospect\Models\Prospect;
+use Mockery\MockInterface;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Models\TrackedEventCount;
 use AdvisingApp\ResourceHub\Models\ResourceHubArticle;
+use AdvisingApp\ResourceHub\Models\ResourceHubCategory;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Survey\Models\Survey;
 use AdvisingApp\Survey\Models\SurveySubmission;
@@ -57,6 +69,7 @@ use App\Http\Middleware\CheckOlympusKey;
 use App\Models\User;
 use App\Settings\LicenseSettings;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
 use function Pest\Laravel\withoutMiddleware;
 
@@ -321,6 +334,37 @@ it('checks the API returns Concerns', function () {
     expect($data['concerns'])->toBe($randomRecords);
 });
 
+it('checks the API returns Alerts Grouped by Alert Type', function () {
+    AlertConfiguration::factory()
+        ->state(['preset' => AlertPreset::ConcernRaised])
+        ->enabled()
+        ->create();
+
+    $activeStatus = ConcernStatus::factory()->create([
+        'classification' => SystemConcernStatusClassification::Active,
+    ]);
+
+    $student = Student::factory()->create();
+
+    Concern::factory()->create([
+        'concern_type' => $student->getMorphClass(),
+        'concern_id' => $student->getKey(),
+        'status_id' => $activeStatus->id,
+    ]);
+
+    app(GenerateStudentAlertsView::class)->execute();
+
+    $response = get(route('utilization-metrics'));
+
+    $data = $response->json('data');
+
+    $response->assertStatus(200);
+
+    expect($data['alerts_by_alert_type'])->toBeArray();
+    expect($data['alerts_by_alert_type']['concern_raised'])->toBe(1);
+    expect($data['alerts_by_alert_type']['new_student'])->toBeInt();
+});
+
 it('checks the API returns Groups', function () {
     $randomRecords = random_int(1, 10);
 
@@ -355,6 +399,29 @@ it('checks the API returns Resource Hub Articles', function () {
     expect($data['resource_hub_articles'])->toBe($randomRecords);
 });
 
+it('checks the API returns Resource Hub Articles Grouped by Category', function () {
+    $categoryA = ResourceHubCategory::factory()->create(['name' => 'Category A']);
+    $categoryB = ResourceHubCategory::factory()->create(['name' => 'Category B']);
+
+    ResourceHubArticle::factory()->count(2)->create([
+        'category_id' => $categoryA->id,
+    ]);
+
+    ResourceHubArticle::factory()->count(3)->create([
+        'category_id' => $categoryB->id,
+    ]);
+
+    $response = get(route('utilization-metrics'));
+
+    $data = $response->json('data');
+
+    $response->assertStatus(200);
+
+    expect($data['resource_hub_articles_by_category'])->toBeArray();
+    expect($data['resource_hub_articles_by_category']['Category A'])->toBe(2);
+    expect($data['resource_hub_articles_by_category']['Category B'])->toBe(3);
+});
+
 it('checks the API returns Events Created', function () {
     $randomRecords = random_int(1, 10);
 
@@ -370,6 +437,69 @@ it('checks the API returns Events Created', function () {
     $response->assertStatus(200);
 
     expect($data['events_created'])->toBe($randomRecords);
+});
+
+it('checks the API returns Group Appointments', function () {
+    $randomRecords = random_int(1, 10);
+
+    BookingGroupAppointment::factory()->count($randomRecords)->create();
+
+    $response = get(route('utilization-metrics'));
+
+    $data = $response->json('data');
+
+    $response->assertStatus(200);
+
+    expect($data['group_appointments'])->toBe($randomRecords);
+});
+
+it('checks the API returns Personal Appointments', function () {
+    $randomRecords = random_int(1, 10);
+
+    $mockDriver = \Mockery::mock(CalendarInterface::class);
+    /** @phpstan-ignore method.notFound */
+    $mockDriver->shouldReceive('createEvent')->andReturnUsing(function (CalendarEvent $event) {
+        $event->updateQuietly([
+            'provider_id' => 'mock-provider-id',
+            'provider_uid' => 'mock-provider-uid',
+        ]);
+    });
+    $mockDriver->shouldReceive('updateEvent')->andReturn(null);
+    $mockDriver->shouldReceive('deleteEvent')->andReturn(null);
+
+    $mockManager = \Mockery::mock(CalendarManager::class, function (MockInterface $mock) use ($mockDriver) {
+        $mock->shouldReceive('driver')->andReturn($mockDriver);
+    });
+
+    app()->instance(CalendarManager::class, $mockManager);
+
+    $user = User::factory()->create();
+    $calendar = Calendar::factory()->for($user)->create();
+
+    actingAs($user);
+
+    CalendarEvent::factory()->count($randomRecords)->create([
+        'calendar_id' => $calendar->id,
+    ]);
+
+    CalendarEvent::factory()->create([
+        'calendar_id' => $calendar->id,
+    ]);
+
+    $otherUser = User::factory()->create();
+    $otherCalendar = Calendar::factory()->for($otherUser)->create();
+
+    CalendarEvent::factory()->create([
+        'calendar_id' => $otherCalendar->id,
+    ]);
+
+    $response = get(route('utilization-metrics'));
+
+    $data = $response->json('data');
+
+    $response->assertStatus(200);
+
+    expect($data['personal_appointments'])->toBe($randomRecords + 2);
 });
 
 it('checks the API returns Forms Created', function () {

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -56,7 +56,6 @@ use AdvisingApp\MeetingCenter\Models\Calendar;
 use AdvisingApp\MeetingCenter\Models\CalendarEvent;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\Prospect\Models\Prospect;
-use Mockery\MockInterface;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Models\TrackedEventCount;
 use AdvisingApp\ResourceHub\Models\ResourceHubArticle;
@@ -68,6 +67,7 @@ use AdvisingApp\Task\Models\Task;
 use App\Http\Middleware\CheckOlympusKey;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Mockery\MockInterface;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
@@ -456,7 +456,7 @@ it('checks the API returns Group Appointments', function () {
 it('checks the API returns Personal Appointments', function () {
     $randomRecords = random_int(1, 10);
 
-    $mockDriver = \Mockery::mock(CalendarInterface::class);
+    $mockDriver = Mockery::mock(CalendarInterface::class);
     /** @phpstan-ignore method.notFound */
     $mockDriver->shouldReceive('createEvent')->andReturnUsing(function (CalendarEvent $event) {
         $event->updateQuietly([
@@ -467,7 +467,7 @@ it('checks the API returns Personal Appointments', function () {
     $mockDriver->shouldReceive('updateEvent')->andReturn(null);
     $mockDriver->shouldReceive('deleteEvent')->andReturn(null);
 
-    $mockManager = \Mockery::mock(CalendarManager::class, function (MockInterface $mock) use ($mockDriver) {
+    $mockManager = Mockery::mock(CalendarManager::class, function (MockInterface $mock) use ($mockDriver) {
         $mock->shouldReceive('driver')->andReturn($mockDriver);
     });
 

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -49,6 +49,7 @@ use AdvisingApp\Concern\Models\ConcernStatus;
 use AdvisingApp\Form\Models\Form;
 use AdvisingApp\Form\Models\FormSubmission;
 use AdvisingApp\Group\Models\Group;
+use AdvisingApp\Interaction\Models\Interaction;
 use AdvisingApp\MeetingCenter\Managers\CalendarManager;
 use AdvisingApp\MeetingCenter\Managers\Contracts\CalendarInterface;
 use AdvisingApp\MeetingCenter\Models\BookingGroupAppointment;
@@ -67,6 +68,7 @@ use AdvisingApp\Task\Models\Task;
 use App\Http\Middleware\CheckOlympusKey;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Mockery;
 use Mockery\MockInterface;
 
 use function Pest\Laravel\actingAs;
@@ -332,6 +334,20 @@ it('checks the API returns Concerns', function () {
     $response->assertStatus(200);
 
     expect($data['concerns'])->toBe($randomRecords);
+});
+
+it('checks the API returns Interactions', function () {
+    $randomRecords = random_int(1, 10);
+
+    Interaction::factory()->count($randomRecords)->create();
+
+    $response = get(route('utilization-metrics'));
+
+    $data = $response->json('data');
+
+    $response->assertStatus(200);
+
+    expect($data['interactions'])->toBe($randomRecords);
 });
 
 it('checks the API returns Alerts Grouped by Alert Type', function () {

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -68,7 +68,6 @@ use AdvisingApp\Task\Models\Task;
 use App\Http\Middleware\CheckOlympusKey;
 use App\Models\User;
 use App\Settings\LicenseSettings;
-use Mockery;
 use Mockery\MockInterface;
 
 use function Pest\Laravel\actingAs;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2841

### Technical Description

> Update usage endpoint with additional data: 
> Alerts count grouped by Alert Types
> Resource hub count grouped by categories
> Personal appointments count
> Group Appointments count

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
