### PR TITLE
[ADVAPP-2853]: Disable broken system health checks reporting false issues

### DIFF
--- a/app/Providers/HealthServiceProvider.php
+++ b/app/Providers/HealthServiceProvider.php
@@ -41,6 +41,7 @@ use App\Health\Checks\AzureCredentialsExpiringCheck;
 use CanyonGBS\Common\Health\Checks\OpcacheCachedFilesCheck;
 use CanyonGBS\Common\Health\Checks\OpcacheHitRateCheck;
 use CanyonGBS\Common\Health\Services\OpcacheStatusService;
+use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\ServiceProvider;
 use Spatie\Health\Checks\Checks\CacheCheck;
@@ -66,7 +67,6 @@ class HealthServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $local = app()->isLocal() && str(config('app.url'))->contains(['localhost', '.local']);
-        $parsedUrl = parse_url(config('app.url'));
 
         Health::checks([
             CacheCheck::new(),
@@ -82,8 +82,9 @@ class HealthServiceProvider extends ServiceProvider
                 ->unless($local || app()->environment('staging')),
             // cloudflare dns
             PingCheck::new()
-                ->url($parsedUrl['host'])
-                ->timeout(2),
+                ->url((string) Filament::getPanel('admin')->getUrl())
+                ->timeout(5)
+                ->unless($local),
             QueueCheck::new()
                 ->failAfterMinutes(3),
             RedisCheck::new(),
@@ -100,12 +101,12 @@ class HealthServiceProvider extends ServiceProvider
                     filled($azureSsoSettings->tenant_id);
                 })
                 ->daily(),
-            OpcacheHitRateCheck::new()
-                ->if(fn () => app(OpcacheStatusService::class)->getStatus() !== false)
-                ->label('OPcache Hit Rate'),
-            OpcacheCachedFilesCheck::new()
-                ->if(fn () => app(OpcacheStatusService::class)->getStatus() !== false)
-                ->label('OPcache Cached Files'),
+            // OpcacheHitRateCheck::new()
+            //     ->if(fn () => app(OpcacheStatusService::class)->getStatus() !== false)
+            //     ->label('OPcache Hit Rate'),
+            // OpcacheCachedFilesCheck::new()
+            //     ->if(fn () => app(OpcacheStatusService::class)->getStatus() !== false)
+            //     ->label('OPcache Cached Files'),
             // ScheduleCheck::new()
             //     ->heartbeatMaxAgeInMinutes(2),
             // ScheduleMonitorCheck::new(),


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2853

### Technical Description

Disable the OPCache health checks and fix the ping check.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
