### PR TITLE
[ADVAPP-2851]: Receiving errors with smart prompts

### DIFF
--- a/.cleanup-tasks/2026_08_03_smart_prompt_instructions_feature.md
+++ b/.cleanup-tasks/2026_08_03_smart_prompt_instructions_feature.md
@@ -1,0 +1,12 @@
+---
+title: Smart Prompt Instructions Feature
+created: 2026-08-03
+---
+
+## Feature Flags
+
+- App\Features\SmartPromptInstructionsFeature
+
+## Temporary Migrations
+
+## Additional Cleanup

--- a/app-modules/ai/database/migrations/2026_08_03_000000_add_smart_prompt_instructions_ai_settings.php
+++ b/app-modules/ai/database/migrations/2026_08_03_000000_add_smart_prompt_instructions_ai_settings.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Ai\Settings\AiSettings;
+use App\Features\SmartPromptInstructionsFeature;
+use Illuminate\Support\Facades\DB;
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class () extends SettingsMigration {
+    public function up(): void
+    {
+        DB::transaction(function () {
+            try {
+                $this->migrator->add('ai.smart_prompt_instructions', AiSettings::defaultSmartPromptInstructions());
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            SmartPromptInstructionsFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            SmartPromptInstructionsFeature::deactivate();
+
+            $this->migrator->deleteIfExists('ai.smart_prompt_instructions');
+        });
+    }
+};

--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManagePromptLibrary.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManagePromptLibrary.php
@@ -152,8 +152,10 @@ trait CanManagePromptLibrary
                                 ->when(
                                     $get('myDepartmentPrompts'),
                                     function (Builder $query) {
-                                        /** @var User $user */
                                         $user = auth()->user();
+
+                                        assert($user instanceof User);
+
                                         $departmentUsers = $user->department?->users;
 
                                         if ($departmentUsers) {
@@ -187,8 +189,24 @@ trait CanManagePromptLibrary
                                 fn (Builder $query) => $query->where('type_id', $get('typeId')),
                             )
                             ->when(
-                                filled($get('myPrompts')),
+                                $get('myPrompts'),
                                 fn (Builder $query) => $query->whereBelongsTo(auth()->user()),
+                            )
+                            ->when(
+                                $get('myDepartmentPrompts'),
+                                function (Builder $query) {
+                                    $user = auth()->user();
+
+                                    assert($user instanceof User);
+
+                                    $departmentUsers = $user->department?->users;
+
+                                    if ($departmentUsers) {
+                                        $query->whereHas('user', function (Builder $query) use ($departmentUsers) {
+                                            return $query->whereIn('id', $departmentUsers->pluck('id'));
+                                        });
+                                    }
+                                },
                             ));
                     })
                     ->getOptionLabelUsing(function (Get $get, string | int | null $value) use ($getPromptOptions): ?string {
@@ -212,14 +230,16 @@ trait CanManagePromptLibrary
                                 fn (Builder $query) => $query->where('type_id', $get('typeId')),
                             )
                             ->when(
-                                filled($get('myPrompts')),
+                                $get('myPrompts'),
                                 fn (Builder $query) => $query->whereBelongsTo(auth()->user()),
                             )
                             ->when(
                                 $get('myDepartmentPrompts'),
                                 function (Builder $query) {
-                                    /** @var User $user */
                                     $user = auth()->user();
+
+                                    assert($user instanceof User);
+
                                     $departmentmUsers = $user->department?->users;
 
                                     if ($departmentmUsers) {

--- a/app-modules/ai/src/Filament/Pages/ManageSmartPromptInstructionsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageSmartPromptInstructionsSettings.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Ai\Filament\Pages;
+
+use AdvisingApp\Ai\Settings\AiSettings;
+use AdvisingApp\Authorization\Enums\LicenseType;
+use App\Enums\NavigationGroup;
+use App\Features\SmartPromptInstructionsFeature;
+use App\Models\User;
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Forms\Components\RichEditor;
+use Filament\Pages\SettingsPage;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Set;
+use Filament\Schemas\Schema;
+use UnitEnum;
+
+class ManageSmartPromptInstructionsSettings extends SettingsPage
+{
+    protected static string $settings = AiSettings::class;
+
+    protected static ?string $title = 'Smart Prompt Instructions';
+
+    protected static ?string $navigationLabel = 'Smart Prompt Instructions';
+
+    protected static string | UnitEnum | null $navigationGroup = NavigationGroup::GlobalAdministration;
+
+    protected static ?int $navigationSort = 15;
+
+    public static function canAccess(): bool
+    {
+        // TODO: Cleanup Task - Remove the SmartPromptInstructionsFeature check once the flag is cleaned up.
+        if (! SmartPromptInstructionsFeature::active()) {
+            return false;
+        }
+
+        $user = auth()->user();
+
+        assert($user instanceof User);
+
+        if (! $user->hasLicense(LicenseType::ConversationalAi)) {
+            return false;
+        }
+
+        return $user->canAccessAiSettings();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Instructions')
+                    ->description('These instructions are prepended to every smart prompt before it is sent to the AI Advisor. Use the merge tags below to insert details about the selected prompt.')
+                    ->schema([
+                        RichEditor::make('smart_prompt_instructions')
+                            ->hiddenLabel()
+                            ->required()
+                            ->json()
+                            ->toolbarButtons([
+                                ['bold', 'italic'],
+                                ['bulletList', 'orderedList'],
+                                ['mergeTags'],
+                            ])
+                            ->activePanel('mergeTags')
+                            ->mergeTags([
+                                'prompt title',
+                                'prompt category',
+                                'prompt description',
+                            ])
+                            ->helperText('Insert a “{{” to see the list of available merge tags. The content of the selected prompt is automatically appended after these instructions.')
+                            ->hintAction(
+                                Action::make('resetSmartPromptInstructions')
+                                    ->label('Reset to default')
+                                    ->icon('heroicon-m-arrow-path')
+                                    ->requiresConfirmation()
+                                    ->modalHeading('Reset instructions to default?')
+                                    ->modalDescription('This will replace the current instructions with the system default. You can save or discard the change afterwards.')
+                                    ->action(fn (Set $set) => $set('smart_prompt_instructions', AiSettings::defaultSmartPromptInstructions()))
+                            )
+                            ->columnSpanFull(),
+                    ]),
+            ])
+            ->disabled(! auth()->user()->canAccessAiSettings());
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        if (blank($data['smart_prompt_instructions'] ?? null)) {
+            $data['smart_prompt_instructions'] = AiSettings::defaultSmartPromptInstructions();
+        }
+
+        return $data;
+    }
+
+    public function save(): void
+    {
+        if (! auth()->user()->canAccessAiSettings()) {
+            return;
+        }
+
+        parent::save();
+    }
+
+    /**
+     * @return array<Action | ActionGroup>
+     */
+    public function getFormActions(): array
+    {
+        if (! auth()->user()->canAccessAiSettings()) {
+            return [];
+        }
+
+        return parent::getFormActions();
+    }
+}

--- a/app-modules/ai/src/Filament/Pages/ManageSmartPromptInstructionsSettings.php
+++ b/app-modules/ai/src/Filament/Pages/ManageSmartPromptInstructionsSettings.php
@@ -118,20 +118,6 @@ class ManageSmartPromptInstructionsSettings extends SettingsPage
             ->disabled(! auth()->user()->canAccessAiSettings());
     }
 
-    /**
-     * @param array<string, mixed> $data
-     *
-     * @return array<string, mixed>
-     */
-    protected function mutateFormDataBeforeFill(array $data): array
-    {
-        if (blank($data['smart_prompt_instructions'] ?? null)) {
-            $data['smart_prompt_instructions'] = AiSettings::defaultSmartPromptInstructions();
-        }
-
-        return $data;
-    }
-
     public function save(): void
     {
         if (! auth()->user()->canAccessAiSettings()) {
@@ -151,5 +137,19 @@ class ManageSmartPromptInstructionsSettings extends SettingsPage
         }
 
         return parent::getFormActions();
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        if (blank($data['smart_prompt_instructions'] ?? null)) {
+            $data['smart_prompt_instructions'] = AiSettings::defaultSmartPromptInstructions();
+        }
+
+        return $data;
     }
 }

--- a/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
@@ -43,11 +43,14 @@ use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiMessageFile;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Models\Prompt;
+use AdvisingApp\Ai\Settings\AiSettings;
 use AdvisingApp\Ai\Support\StreamingChunks\Finish;
 use AdvisingApp\Ai\Support\StreamingChunks\Image;
 use AdvisingApp\Ai\Support\StreamingChunks\Meta;
 use AdvisingApp\Ai\Support\StreamingChunks\Text;
 use AdvisingApp\Ai\Support\StreamingChunks\Thinking;
+use App\Features\SmartPromptInstructionsFeature;
+use Filament\Forms\Components\RichEditor\RichContentRenderer;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection;
@@ -85,16 +88,35 @@ class SendAdvisorMessage implements ShouldQueue
 
         if ($this->content instanceof Prompt) {
             if ($this->content->is_smart) {
-                $descriptionLine = $this->content->description
-                    ? "with the description {$this->content->description}"
-                    : null;
+                // TODO: Cleanup Task - Remove the SmartPromptInstructionsFeature check and the legacy else branch below, keeping only the settings-based instructions.
+                if (SmartPromptInstructionsFeature::active()) {
+                    $settings = app(AiSettings::class);
 
-                $additionalContent = "Below I will provide you the input content for a prompt with the name {$this->content->title}, in the category {$this->content->type->title}" . ($descriptionLine ? ", {$descriptionLine}" : '') . '.
-                The prompt may have variables {{ VARIABLE }} that are needed in order to effectively serve your function. Begin by analyzing the prompt.
-                Begin by introducing yourself as an AI Advisor, and based on the prompt name, category, and description, explain what your purpose is. Then if the prompt has any variables in it, ask the user for that information, one variable at a time, explaining why you need that input from the user. Once all the variables are collected, return a response for the prompt supplied below.
-                Note: If there are no variables, then just return a response for the prompt supplied below.';
+                    $instructions = filled($settings->smart_prompt_instructions)
+                        ? $settings->smart_prompt_instructions
+                        : AiSettings::defaultSmartPromptInstructions();
 
-                $message->content = $additionalContent . "\n\n" . $this->content->prompt;
+                    $additionalContent = RichContentRenderer::make($instructions)
+                        ->mergeTags([
+                            'prompt title' => $this->content->title,
+                            'prompt category' => $this->content->type->title,
+                            'prompt description' => $this->content->description ?? '',
+                        ])
+                        ->toText();
+
+                    $message->content = trim($additionalContent) . "\n\n" . $this->content->prompt;
+                } else {
+                    $descriptionLine = $this->content->description
+                        ? "with the description {$this->content->description}"
+                        : null;
+
+                    $additionalContent = "Below I will provide you the input content for a prompt with the name {$this->content->title}, in the category {$this->content->type->title}" . ($descriptionLine ? ", {$descriptionLine}" : '') . '.
+                    The prompt may have variables {{ VARIABLE }} that are needed in order to effectively serve your function. Begin by analyzing the prompt.
+                    Begin by introducing yourself as an AI Advisor, and based on the prompt name, category, and description, explain what your purpose is. Then if the prompt has any variables in it, ask the user for that information, one variable at a time, explaining why you need that input from the user. Once all the variables are collected, return a response for the prompt supplied below.
+                    Note: If there are no variables, then just return a response for the prompt supplied below.';
+
+                    $message->content = $additionalContent . "\n\n" . $this->content->prompt;
+                }
             } else {
                 $message->content = $this->content->prompt;
             }

--- a/app-modules/ai/src/Settings/AiSettings.php
+++ b/app-modules/ai/src/Settings/AiSettings.php
@@ -46,6 +46,8 @@ class AiSettings extends Settings
 
     public string $prompt_system_context = 'In every response, you need to remember that you are adopting the persona of an advanced AI-powered assistant with the name "Canyon" created by the company "Canyon GBS Inc.®". This product the user is using is called "Advising App by Canyon GBS®". The company website is "canyongbs.com" and the company phone number is "1-520-357-1351". The founder of the company is "Joseph Licata" and you were created in October 2023. You have a wide range of skills including performing research tasks, drafting communication, performing language translation, content creation, student profile analysis, project planning, ideation, and much more. Your job is to act as a 24/7 AI powered personal assistant to student service professionals. Your response should be clear, concise, and actionable. Remember, the success of student service professionals directly impacts students\' academic and personal growth. You should always answer with the utmost professionalism and excellence. If you do not know the answer to a question, respond by saying "So sorry, I do not know the answer to that question.".';
 
+    public array $smart_prompt_instructions = []; // @phpstan-ignore missingType.iterableValue
+
     public ?AiModel $default_model = null;
 
     public AiReasoningEffort $reasoning_effort = AiReasoningEffort::Medium;
@@ -55,5 +57,47 @@ class AiSettings extends Settings
     public static function group(): string
     {
         return 'ai';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function defaultSmartPromptInstructions(): array
+    {
+        return [
+            'type' => 'doc',
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        ['type' => 'text', 'text' => 'Below I will provide you the input content for a prompt with the name '],
+                        ['type' => 'mergeTag', 'attrs' => ['id' => 'prompt title']],
+                        ['type' => 'text', 'text' => ', in the category '],
+                        ['type' => 'mergeTag', 'attrs' => ['id' => 'prompt category']],
+                        ['type' => 'text', 'text' => ', with the description '],
+                        ['type' => 'mergeTag', 'attrs' => ['id' => 'prompt description']],
+                        ['type' => 'text', 'text' => '.'],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        ['type' => 'text', 'text' => 'The prompt may have variables {{ VARIABLE }} that are needed in order to effectively serve your function. Begin by analyzing the prompt.'],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        ['type' => 'text', 'text' => 'Begin by introducing yourself as an AI Advisor, and based on the prompt name, category, and description, explain what your purpose is. Then if the prompt has any variables in it, ask the user for that information, one variable at a time, explaining why you need that input from the user. Once all the variables are collected, return a response for the prompt supplied below.'],
+                    ],
+                ],
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        ['type' => 'text', 'text' => 'Note: If there are no variables, then just return a response for the prompt supplied below.'],
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Pages/AIAssistantPageTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Pages/AIAssistantPageTest.php
@@ -725,6 +725,24 @@ it('can insert a prompt from the library', function () use ($setUp) {
         ->assertDispatched('set-chat-message', content: $prompt->prompt);
 });
 
+it('can insert a prompt owned by another user when "my prompts only" is unchecked', function () use ($setUp) {
+    $setUp();
+
+    $prompt = Prompt::factory()->create();
+    $prompt->user()->associate(User::factory()->create())->save();
+
+    Livewire::test(InstitutionalAdvisor::class)
+        ->mountAction('insertFromPromptLibrary')
+        ->setActionData([
+            'isSmart' => 0,
+            'myPrompts' => false,
+            'promptId' => $prompt->getKey(),
+        ])
+        ->callMountedAction()
+        ->assertHasNoActionErrors()
+        ->assertDispatched('set-chat-message', content: $prompt->prompt);
+});
+
 it('can not insert a missing prompt from the library', function () use ($setUp) {
     $setUp();
 

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Pages/ManageSmartPromptInstructionsSettingsPageTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Pages/ManageSmartPromptInstructionsSettingsPageTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Ai\Filament\Pages\ManageSmartPromptInstructionsSettings;
+use AdvisingApp\Ai\Settings\AiSettings;
+use AdvisingApp\Authorization\Enums\LicenseType;
+use App\Models\User;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+use function Tests\asSuperAdmin;
+
+it('renders successfully', function () {
+    asSuperAdmin();
+
+    Livewire::test(ManageSmartPromptInstructionsSettings::class)
+        ->assertStatus(200);
+});
+
+it('does not load if you do not have permission to access', function () {
+    $user = User::factory()->licensed(LicenseType::ConversationalAi)->create();
+
+    actingAs($user);
+
+    Livewire::test(ManageSmartPromptInstructionsSettings::class)
+        ->assertStatus(403);
+});
+
+it('does not load without the required license', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    Livewire::test(ManageSmartPromptInstructionsSettings::class)
+        ->assertStatus(403);
+});
+
+it('can update the smart prompt instructions', function () {
+    asSuperAdmin();
+
+    $instructions = [
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Updated smart prompt instructions.'],
+                ],
+            ],
+        ],
+    ];
+
+    Livewire::test(ManageSmartPromptInstructionsSettings::class)
+        ->fillForm([
+            'smart_prompt_instructions' => $instructions,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect(app(AiSettings::class)->smart_prompt_instructions)
+        ->toBe($instructions);
+});

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/SendAdvisorMessageTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/SendAdvisorMessageTest.php
@@ -42,6 +42,7 @@ use AdvisingApp\Ai\Jobs\Advisors\SendAdvisorMessage;
 use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiThread;
+use AdvisingApp\Ai\Models\Prompt;
 use Illuminate\Support\Facades\Event;
 
 use function Tests\asSuperAdmin;
@@ -93,4 +94,45 @@ it('sends a message', function () {
 
     Event::assertDispatched(AdvisorMessageChunk::class);
     Event::assertDispatched(AdvisorMessageFinished::class);
+});
+
+it('builds smart prompt content from the editable instructions setting', function () {
+    Event::fake([
+        AdvisorMessageChunk::class,
+        AdvisorMessageFinished::class,
+    ]);
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->create();
+
+    $prompt = Prompt::factory()->create([
+        'is_smart' => true,
+        'title' => 'Draft An Email',
+        'description' => 'Helps you write an email',
+    ]);
+
+    dispatch(new SendAdvisorMessage(
+        $thread,
+        $prompt,
+    ));
+
+    $message = AiMessage::query()
+        ->whereNotNull('prompt_id')
+        ->first();
+
+    expect($message->content)
+        ->toContain($prompt->title)
+        ->toContain($prompt->type->title)
+        ->toContain($prompt->description)
+        ->toEndWith($prompt->prompt);
 });

--- a/app/Features/SmartPromptInstructionsFeature.php
+++ b/app/Features/SmartPromptInstructionsFeature.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class SmartPromptInstructionsFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2851

### Technical Description

Fixes Filament field config issue with options not being fetched using the correct filters, causing the validation error, including a regression test. Makes the smart prompt prompt configurable.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
