### PR TITLE
[ADVAPP-2841]: Update the usage endpoint to include alerts, alert types, resource hub categories, and both personal and group appointments

### DIFF
--- a/app/Http/Controllers/UtilizationMetricsApiController.php
+++ b/app/Http/Controllers/UtilizationMetricsApiController.php
@@ -114,11 +114,15 @@ class UtilizationMetricsApiController extends Controller
             ->groupByRaw("date_trunc('month', submitted_at)")
             ->orderBy('month')
             ->get()
-            ->map(fn (object $item): array => [
-                'month' => CarbonImmutable::parse($item->month)->format('Y-m'),
-                'count' => (int) $item->monthly_total,
-                'label' => CarbonImmutable::parse($item->month)->format('Y, F'),
-            ])
+            ->map(function (FormSubmission $item): array {
+                $month = (string) data_get($item, 'month');
+
+                return [
+                    'month' => CarbonImmutable::parse($month)->format('Y-m'),
+                    'count' => (int) data_get($item, 'monthly_total'),
+                    'label' => CarbonImmutable::parse($month)->format('Y, F'),
+                ];
+            })
             ->values()
             ->all();
 
@@ -127,11 +131,15 @@ class UtilizationMetricsApiController extends Controller
             ->groupByRaw("date_trunc('month', created_at)")
             ->orderBy('month')
             ->get()
-            ->map(fn (object $item): array => [
-                'month' => CarbonImmutable::parse($item->month)->format('Y-m'),
-                'count' => (int) $item->monthly_total,
-                'label' => CarbonImmutable::parse($item->month)->format('Y, F'),
-            ])
+            ->map(function (ApplicationSubmission $item): array {
+                $month = (string) data_get($item, 'month');
+
+                return [
+                    'month' => CarbonImmutable::parse($month)->format('Y-m'),
+                    'count' => (int) data_get($item, 'monthly_total'),
+                    'label' => CarbonImmutable::parse($month)->format('Y, F'),
+                ];
+            })
             ->values()
             ->all();
 

--- a/app/Http/Controllers/UtilizationMetricsApiController.php
+++ b/app/Http/Controllers/UtilizationMetricsApiController.php
@@ -110,27 +110,27 @@ class UtilizationMetricsApiController extends Controller
 
         $formsSubmittedByMonth = FormSubmission::query()
             ->submitted()
-            ->select('submitted_at')
-            ->orderBy('submitted_at')
+            ->selectRaw("date_trunc('month', submitted_at) as month, COUNT(*) as monthly_total")
+            ->groupByRaw("date_trunc('month', submitted_at)")
+            ->orderBy('month')
             ->get()
-            ->countBy(fn (FormSubmission $submission): string => $submission->submitted_at->format('Y-m'))
-            ->map(fn (int $count, string $month): array => [
-                'month' => $month,
-                'count' => $count,
-                'label' => CarbonImmutable::createFromFormat('Y-m', $month)->format('Y, F'),
+            ->map(fn (object $item): array => [
+                'month' => CarbonImmutable::parse($item->month)->format('Y-m'),
+                'count' => (int) $item->monthly_total,
+                'label' => CarbonImmutable::parse($item->month)->format('Y, F'),
             ])
             ->values()
             ->all();
 
         $applicationSubmissionsByMonth = ApplicationSubmission::query()
-            ->select('created_at')
-            ->orderBy('created_at')
+            ->selectRaw("date_trunc('month', created_at) as month, COUNT(*) as monthly_total")
+            ->groupByRaw("date_trunc('month', created_at)")
+            ->orderBy('month')
             ->get()
-            ->countBy(fn (ApplicationSubmission $submission): string => $submission->created_at->format('Y-m'))
-            ->map(fn (int $count, string $month): array => [
-                'month' => $month,
-                'count' => $count,
-                'label' => CarbonImmutable::createFromFormat('Y-m', $month)->format('Y, F'),
+            ->map(fn (object $item): array => [
+                'month' => CarbonImmutable::parse($item->month)->format('Y-m'),
+                'count' => (int) $item->monthly_total,
+                'label' => CarbonImmutable::parse($item->month)->format('Y, F'),
             ])
             ->values()
             ->all();

--- a/app/Http/Controllers/UtilizationMetricsApiController.php
+++ b/app/Http/Controllers/UtilizationMetricsApiController.php
@@ -41,6 +41,7 @@ use AdvisingApp\Ai\Models\Prompt;
 use AdvisingApp\Ai\Models\PromptUse;
 use AdvisingApp\Alert\Models\AlertConfiguration;
 use AdvisingApp\Alert\Presets\AlertPreset;
+use AdvisingApp\Application\Models\ApplicationSubmission;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Campaign\Models\Campaign;
 use AdvisingApp\Campaign\Models\CampaignAction;
@@ -65,6 +66,7 @@ use AdvisingApp\Survey\Models\SurveySubmission;
 use AdvisingApp\Task\Models\Task;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Carbon\CarbonImmutable;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -106,6 +108,33 @@ class UtilizationMetricsApiController extends Controller
             ->map(fn (int|string $count): int => (int) $count)
             ->all();
 
+        $formsSubmittedByMonth = FormSubmission::query()
+            ->submitted()
+            ->select('submitted_at')
+            ->orderBy('submitted_at')
+            ->get()
+            ->countBy(fn (FormSubmission $submission): string => $submission->submitted_at->format('Y-m'))
+            ->map(fn (int $count, string $month): array => [
+                'month' => $month,
+                'count' => $count,
+                'label' => CarbonImmutable::createFromFormat('Y-m', $month)->format('Y, F'),
+            ])
+            ->values()
+            ->all();
+
+        $applicationSubmissionsByMonth = ApplicationSubmission::query()
+            ->select('created_at')
+            ->orderBy('created_at')
+            ->get()
+            ->countBy(fn (ApplicationSubmission $submission): string => $submission->created_at->format('Y-m'))
+            ->map(fn (int $count, string $month): array => [
+                'month' => $month,
+                'count' => $count,
+                'label' => CarbonImmutable::createFromFormat('Y-m', $month)->format('Y, F'),
+            ])
+            ->values()
+            ->all();
+
         try {
             return response()->json([
                 'data' => [
@@ -131,6 +160,8 @@ class UtilizationMetricsApiController extends Controller
                     'personal_appointments' => CalendarEvent::count(),
                     'forms_created' => Form::count(),
                     'forms_submitted' => FormSubmission::count(),
+                    'forms_submitted_by_month' => $formsSubmittedByMonth,
+                    'applications_submitted_by_month' => $applicationSubmissionsByMonth,
                     'surveys_created' => Survey::count(),
                     'surveys_submitted' => SurveySubmission::count(),
                     'alerts_by_alert_type' => $alertsByAlertType,

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -57,6 +57,7 @@ use AdvisingApp\MeetingCenter\Models\Calendar;
 use AdvisingApp\MeetingCenter\Models\CalendarEvent;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\Prospect\Models\Prospect;
+use Mockery\MockInterface;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Models\TrackedEventCount;
 use AdvisingApp\ResourceHub\Models\ResourceHubArticle;

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -57,7 +57,6 @@ use AdvisingApp\MeetingCenter\Models\Calendar;
 use AdvisingApp\MeetingCenter\Models\CalendarEvent;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\Prospect\Models\Prospect;
-use Mockery\MockInterface;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Models\TrackedEventCount;
 use AdvisingApp\ResourceHub\Models\ResourceHubArticle;

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -68,6 +68,7 @@ use AdvisingApp\Task\Models\Task;
 use App\Http\Middleware\CheckOlympusKey;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Mockery;
 use Mockery\MockInterface;
 
 use function Pest\Laravel\actingAs;

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -40,6 +40,8 @@ use AdvisingApp\Ai\Models\PromptUse;
 use AdvisingApp\Alert\Actions\GenerateStudentAlertsView;
 use AdvisingApp\Alert\Models\AlertConfiguration;
 use AdvisingApp\Alert\Presets\AlertPreset;
+use AdvisingApp\Application\Database\Seeders\ApplicationSubmissionStateSeeder;
+use AdvisingApp\Application\Models\ApplicationSubmission;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Campaign\Models\Campaign;
 use AdvisingApp\Campaign\Models\CampaignAction;
@@ -68,10 +70,12 @@ use AdvisingApp\Task\Models\Task;
 use App\Http\Middleware\CheckOlympusKey;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Carbon\CarbonImmutable;
 use Mockery\MockInterface;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
+use function Pest\Laravel\seed;
 use function Pest\Laravel\withoutMiddleware;
 
 beforeEach(function () {
@@ -543,6 +547,68 @@ it('checks the API returns Forms Submitted', function () {
     $response->assertStatus(200);
 
     expect($data['forms_submitted'])->toBe($randomRecords);
+});
+
+it('checks the API returns Forms Submitted By Month', function () {
+    FormSubmission::factory()
+        ->count(2)
+        ->state(['submitted_at' => CarbonImmutable::parse('2026-01-10 10:00:00')])
+        ->create();
+
+    FormSubmission::factory()
+        ->count(3)
+        ->state(['submitted_at' => CarbonImmutable::parse('2026-02-15 10:00:00')])
+        ->create();
+
+    $response = get(route('utilization-metrics'));
+
+    $data = $response->json('data');
+
+    $response->assertStatus(200);
+
+    expect($data['forms_submitted_by_month'])
+        ->toContain([
+            'month' => '2026-01',
+            'count' => 2,
+            'label' => '2026, January',
+        ])
+        ->toContain([
+            'month' => '2026-02',
+            'count' => 3,
+            'label' => '2026, February',
+        ]);
+});
+
+it('checks the API returns Applications Submitted By Month', function () {
+    seed(ApplicationSubmissionStateSeeder::class);
+
+    ApplicationSubmission::factory()
+        ->count(2)
+        ->state(['created_at' => CarbonImmutable::parse('2026-03-10 10:00:00')])
+        ->create();
+
+    ApplicationSubmission::factory()
+        ->count(3)
+        ->state(['created_at' => CarbonImmutable::parse('2026-04-15 10:00:00')])
+        ->create();
+
+    $response = get(route('utilization-metrics'));
+
+    $data = $response->json('data');
+
+    $response->assertStatus(200);
+
+    expect($data['applications_submitted_by_month'])
+        ->toContain([
+            'month' => '2026-03',
+            'count' => 2,
+            'label' => '2026, March',
+        ])
+        ->toContain([
+            'month' => '2026-04',
+            'count' => 3,
+            'label' => '2026, April',
+        ]);
 });
 
 it('checks the API returns Surveys Created', function () {

--- a/tests/Tenant/Unit/UtilizationMetricsApisTest.php
+++ b/tests/Tenant/Unit/UtilizationMetricsApisTest.php
@@ -68,7 +68,6 @@ use AdvisingApp\Task\Models\Task;
 use App\Http\Middleware\CheckOlympusKey;
 use App\Models\User;
 use App\Settings\LicenseSettings;
-use Mockery;
 use Mockery\MockInterface;
 
 use function Pest\Laravel\actingAs;


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2841

### Technical Description

> Update usage endpoint with additional data:
> Send Admissions and forms submissions month wise

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
