### PR TITLE
[OLYMPUS-1505]: Separate any delete functionality from the archiving components

### DIFF
--- a/app-modules/application/src/Models/Application.php
+++ b/app-modules/application/src/Models/Application.php
@@ -48,7 +48,6 @@ use Filament\Forms\Components\RichEditor\FileAttachmentProviders\SpatieMediaLibr
 use Filament\Forms\Components\RichEditor\Models\Concerns\InteractsWithRichContent;
 use Filament\Forms\Components\RichEditor\Models\Contracts\HasRichContent;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -187,38 +186,5 @@ class Application extends Submissible implements HasMedia, HasRichContent
         return Application::query()->where('root_id', $this->root_id)
             ->whereNull('archived_at')
             ->first();
-    }
-
-    /**
-     * @param Builder<Application> $query
-     */
-    public function used(Builder $query): void
-    {
-        $query->whereHas(
-            'versions',
-            fn (Builder $query) => $query
-                ->withoutGlobalScopes()
-                ->whereHas('submissions'),
-        );
-    }
-
-    public function isUsed(): bool
-    {
-        $submissionsExists = $this->getAttribute('submissions_exists');
-
-        if ($submissionsExists === null) {
-            $submissionsExists = ApplicationSubmission::query()
-                ->whereHas(
-                    'submissible',
-                    fn (Builder $query) => $query
-                        ->withoutGlobalScopes()
-                        ->where('root_id', $this->root_id),
-                )
-                ->exists();
-
-            $this->setAttribute('submissions_exists', $submissionsExists);
-        }
-
-        return (bool) $submissionsExists;
     }
 }

--- a/app-modules/application/tests/Tenant/Application/EditApplicationTest.php
+++ b/app-modules/application/tests/Tenant/Application/EditApplicationTest.php
@@ -44,7 +44,6 @@ use App\Models\User;
 use App\Settings\LicenseSettings;
 
 use function Pest\Laravel\actingAs;
-use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\seed;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
@@ -130,33 +129,27 @@ test('EditApplication is gated with proper feature access control', function () 
     // TODO: Finish the test by adding the request factory EditApplicationRequestFactory
 });
 
-it('shows archive mode for the header archive action when the application has submissions', function () {
+it('archive action is always visible and labeled Archive', function () {
     seed(ApplicationSubmissionStateSeeder::class);
 
     asSuperAdmin();
 
-    $application = Application::factory()->create();
+    $applicationWithSubmissions = Application::factory()->create();
 
     ApplicationSubmission::factory()->create([
-        'application_id' => $application->id,
+        'application_id' => $applicationWithSubmissions->id,
     ]);
 
-    livewire(EditApplication::class, ['record' => $application->getRouteKey()])
+    $applicationWithoutSubmissions = Application::factory()->create();
+    $applicationWithoutSubmissions->submissions()->delete();
+
+    livewire(EditApplication::class, ['record' => $applicationWithSubmissions->getRouteKey()])
         ->assertActionVisible('archive')
         ->assertActionHasLabel('archive', 'Archive');
-});
 
-it('shows delete mode for the header archive action when the application has no submissions', function () {
-    seed(ApplicationSubmissionStateSeeder::class);
-
-    asSuperAdmin();
-
-    $application = Application::factory()->create();
-    $application->submissions()->delete();
-
-    livewire(EditApplication::class, ['record' => $application->getRouteKey()])
+    livewire(EditApplication::class, ['record' => $applicationWithoutSubmissions->getRouteKey()])
         ->assertActionVisible('archive')
-        ->assertActionHasLabel('archive', 'Delete');
+        ->assertActionHasLabel('archive', 'Archive');
 });
 
 it('archive action archives the application and redirects to the index when the application has submissions', function () {
@@ -171,19 +164,4 @@ it('archive action archives the application and redirects to the index when the 
         ->assertRedirect(ApplicationResource::getUrl('index'));
 
     expect($application->fresh()->isArchived())->toBeTrue();
-});
-
-it('archive action deletes the application and redirects to the index when the application has no submissions', function () {
-    seed(ApplicationSubmissionStateSeeder::class);
-
-    asSuperAdmin();
-
-    $application = Application::factory()->create();
-    $application->submissions()->delete();
-
-    livewire(EditApplication::class, ['record' => $application->getRouteKey()])
-        ->callAction('archive')
-        ->assertRedirect(ApplicationResource::getUrl('index'));
-
-    assertModelMissing($application);
 });

--- a/app-modules/application/tests/Tenant/Application/ListApplicationsTest.php
+++ b/app-modules/application/tests/Tenant/Application/ListApplicationsTest.php
@@ -38,11 +38,11 @@ use AdvisingApp\Application\Database\Seeders\ApplicationSubmissionStateSeeder;
 use AdvisingApp\Application\Filament\Resources\Applications\ApplicationResource;
 use AdvisingApp\Application\Filament\Resources\Applications\Pages\ListApplications;
 use AdvisingApp\Application\Models\Application;
+use AdvisingApp\Application\Models\ApplicationSubmission;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use App\Models\User;
 use App\Settings\LicenseSettings;
 use Filament\Actions\Testing\TestAction;
-use Illuminate\Database\Eloquent\Builder;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\seed;
@@ -195,12 +195,35 @@ test('submissions count does not include archived submissions', function () {
         ->assertTableColumnStateSet('submissions_count', $expectedCount, $application);
 });
 
-it('archives applications with submissions and deletes applications without submissions via the archive or delete bulk action', function () {
+it('archive action is always visible regardless of submission status', function () {
     seed(ApplicationSubmissionStateSeeder::class);
 
     asSuperAdmin();
 
     $applicationWithSubmissions = Application::factory()->create();
+
+    ApplicationSubmission::factory()->create([
+        'application_id' => $applicationWithSubmissions->id,
+    ]);
+
+    $applicationWithoutSubmissions = Application::factory()->create();
+    $applicationWithoutSubmissions->submissions()->delete();
+
+    livewire(ListApplications::class)
+        ->assertTableActionVisible('archive', $applicationWithSubmissions)
+        ->assertTableActionVisible('archive', $applicationWithoutSubmissions);
+});
+
+it('archive bulk action archives all selected applications', function () {
+    seed(ApplicationSubmissionStateSeeder::class);
+
+    asSuperAdmin();
+
+    $applicationWithSubmissions = Application::factory()->create();
+
+    ApplicationSubmission::factory()->create([
+        'application_id' => $applicationWithSubmissions->id,
+    ]);
 
     $applicationWithoutSubmissions = Application::factory()->create();
     $applicationWithoutSubmissions->submissions()->delete();
@@ -213,63 +236,5 @@ it('archives applications with submissions and deletes applications without subm
         ->assertNotified();
 
     expect($applicationWithSubmissions->fresh()->archived_at)->not->toBeNull();
-    expect(Application::find($applicationWithoutSubmissions->id))->toBeNull();
-});
-
-it('marks an application as used when any version has submitted forms', function () {
-    seed(ApplicationSubmissionStateSeeder::class);
-
-    $application = Application::factory()->create();
-    $application->submissions()->delete();
-
-    Application::factory()->create([
-        'root_id' => $application->root_id,
-        'archived_at' => now(),
-    ]);
-
-    expect($application->isUsed())->toBeTrue();
-});
-
-it('marks an application as unused when no version has submitted forms', function () {
-    seed(ApplicationSubmissionStateSeeder::class);
-
-    $application = Application::factory()->create();
-    $application->submissions()->delete();
-
-    $archivedVersion = Application::factory()->create([
-        'root_id' => $application->root_id,
-        'archived_at' => now(),
-    ]);
-    $archivedVersion->submissions()->delete();
-
-    expect($application->isUsed())->toBeFalse();
-});
-
-it('used query includes application roots that have submissions on any version', function () {
-    seed(ApplicationSubmissionStateSeeder::class);
-
-    $application = Application::factory()->create();
-    $application->submissions()->delete();
-
-    Application::factory()->create([
-        'root_id' => $application->root_id,
-        'archived_at' => now(),
-    ]);
-
-    $unusedApplication = Application::factory()->create();
-    $unusedApplication->submissions()->delete();
-
-    $unusedArchivedVersion = Application::factory()->create([
-        'root_id' => $unusedApplication->root_id,
-        'archived_at' => now(),
-    ]);
-    $unusedArchivedVersion->submissions()->delete();
-
-    $usedRootIds = Application::query()
-        ->tap(fn (Builder $query) => $application->used($query))
-        ->pluck('root_id')
-        ->unique();
-
-    expect($usedRootIds)->toContain($application->root_id)
-        ->not->toContain($unusedApplication->root_id);
+    expect($applicationWithoutSubmissions->fresh()->archived_at)->not->toBeNull();
 });

--- a/app-modules/application/tests/Tenant/Application/ListApplicationsTest.php
+++ b/app-modules/application/tests/Tenant/Application/ListApplicationsTest.php
@@ -38,11 +38,9 @@ use AdvisingApp\Application\Database\Seeders\ApplicationSubmissionStateSeeder;
 use AdvisingApp\Application\Filament\Resources\Applications\ApplicationResource;
 use AdvisingApp\Application\Filament\Resources\Applications\Pages\ListApplications;
 use AdvisingApp\Application\Models\Application;
-use AdvisingApp\Application\Models\ApplicationSubmission;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use App\Models\User;
 use App\Settings\LicenseSettings;
-use Filament\Actions\Testing\TestAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\seed;
@@ -193,48 +191,4 @@ test('submissions count does not include archived submissions', function () {
 
     livewire(ListApplications::class)
         ->assertTableColumnStateSet('submissions_count', $expectedCount, $application);
-});
-
-it('archive action is always visible regardless of submission status', function () {
-    seed(ApplicationSubmissionStateSeeder::class);
-
-    asSuperAdmin();
-
-    $applicationWithSubmissions = Application::factory()->create();
-
-    ApplicationSubmission::factory()->create([
-        'application_id' => $applicationWithSubmissions->id,
-    ]);
-
-    $applicationWithoutSubmissions = Application::factory()->create();
-    $applicationWithoutSubmissions->submissions()->delete();
-
-    livewire(ListApplications::class)
-        ->assertTableActionVisible('archive', $applicationWithSubmissions)
-        ->assertTableActionVisible('archive', $applicationWithoutSubmissions);
-});
-
-it('archive bulk action archives all selected applications', function () {
-    seed(ApplicationSubmissionStateSeeder::class);
-
-    asSuperAdmin();
-
-    $applicationWithSubmissions = Application::factory()->create();
-
-    ApplicationSubmission::factory()->create([
-        'application_id' => $applicationWithSubmissions->id,
-    ]);
-
-    $applicationWithoutSubmissions = Application::factory()->create();
-    $applicationWithoutSubmissions->submissions()->delete();
-
-    $records = collect([$applicationWithSubmissions, $applicationWithoutSubmissions]);
-
-    livewire(ListApplications::class)
-        ->selectTableRecords($records->pluck('id')->all())
-        ->callAction(TestAction::make('archive')->table()->bulk())
-        ->assertNotified();
-
-    expect($applicationWithSubmissions->fresh()->archived_at)->not->toBeNull();
-    expect($applicationWithoutSubmissions->fresh()->archived_at)->not->toBeNull();
 });

--- a/app-modules/application/tests/Tenant/Application/ListApplicationsTest.php
+++ b/app-modules/application/tests/Tenant/Application/ListApplicationsTest.php
@@ -38,9 +38,11 @@ use AdvisingApp\Application\Database\Seeders\ApplicationSubmissionStateSeeder;
 use AdvisingApp\Application\Filament\Resources\Applications\ApplicationResource;
 use AdvisingApp\Application\Filament\Resources\Applications\Pages\ListApplications;
 use AdvisingApp\Application\Models\Application;
+use AdvisingApp\Application\Models\ApplicationSubmission;
 use AdvisingApp\Authorization\Enums\LicenseType;
 use App\Models\User;
 use App\Settings\LicenseSettings;
+use Filament\Actions\Testing\TestAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\seed;
@@ -191,4 +193,29 @@ test('submissions count does not include archived submissions', function () {
 
     livewire(ListApplications::class)
         ->assertTableColumnStateSet('submissions_count', $expectedCount, $application);
+});
+
+it('archive bulk action archives all selected applications', function () {
+    seed(ApplicationSubmissionStateSeeder::class);
+
+    asSuperAdmin();
+
+    $applicationWithSubmissions = Application::factory()->create();
+
+    ApplicationSubmission::factory()->create([
+        'application_id' => $applicationWithSubmissions->id,
+    ]);
+
+    $applicationWithoutSubmissions = Application::factory()->create();
+    $applicationWithoutSubmissions->submissions()->delete();
+
+    $records = collect([$applicationWithSubmissions, $applicationWithoutSubmissions]);
+
+    livewire(ListApplications::class)
+        ->selectTableRecords($records->pluck('id')->all())
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified();
+
+    expect($applicationWithSubmissions->fresh()->archived_at)->not->toBeNull();
+    expect($applicationWithoutSubmissions->fresh()->archived_at)->not->toBeNull();
 });

--- a/app-modules/application/tests/Tenant/Application/ViewApplicationTest.php
+++ b/app-modules/application/tests/Tenant/Application/ViewApplicationTest.php
@@ -40,38 +40,31 @@ use AdvisingApp\Application\Filament\Resources\Applications\Pages\ViewApplicatio
 use AdvisingApp\Application\Models\Application;
 use AdvisingApp\Application\Models\ApplicationSubmission;
 
-use function Pest\Laravel\assertModelMissing;
 use function Pest\Laravel\seed;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
-it('shows archive mode for the header archive action when the application has submissions', function () {
+it('archive action is always visible and labeled Archive', function () {
     seed(ApplicationSubmissionStateSeeder::class);
 
     asSuperAdmin();
 
-    $application = Application::factory()->create();
+    $applicationWithSubmissions = Application::factory()->create();
 
     ApplicationSubmission::factory()->create([
-        'application_id' => $application->id,
+        'application_id' => $applicationWithSubmissions->id,
     ]);
 
-    livewire(ViewApplication::class, ['record' => $application->getRouteKey()])
+    $applicationWithoutSubmissions = Application::factory()->create();
+    $applicationWithoutSubmissions->submissions()->delete();
+
+    livewire(ViewApplication::class, ['record' => $applicationWithSubmissions->getRouteKey()])
         ->assertActionVisible('archive')
         ->assertActionHasLabel('archive', 'Archive');
-});
 
-it('shows delete mode for the header archive action when the application has no submissions', function () {
-    seed(ApplicationSubmissionStateSeeder::class);
-
-    asSuperAdmin();
-
-    $application = Application::factory()->create();
-    $application->submissions()->delete();
-
-    livewire(ViewApplication::class, ['record' => $application->getRouteKey()])
+    livewire(ViewApplication::class, ['record' => $applicationWithoutSubmissions->getRouteKey()])
         ->assertActionVisible('archive')
-        ->assertActionHasLabel('archive', 'Delete');
+        ->assertActionHasLabel('archive', 'Archive');
 });
 
 it('archive action archives the application and redirects to the index when the application has submissions', function () {
@@ -90,19 +83,4 @@ it('archive action archives the application and redirects to the index when the 
         ->assertRedirect(ApplicationResource::getUrl('index'));
 
     expect($application->fresh()->isArchived())->toBeTrue();
-});
-
-it('archive action deletes the application and redirects to the index when the application has no submissions', function () {
-    seed(ApplicationSubmissionStateSeeder::class);
-
-    asSuperAdmin();
-
-    $application = Application::factory()->create();
-    $application->submissions()->delete();
-
-    livewire(ViewApplication::class, ['record' => $application->getRouteKey()])
-        ->callAction('archive')
-        ->assertRedirect(ApplicationResource::getUrl('index'));
-
-    assertModelMissing($application);
 });

--- a/app-modules/form/src/Models/Form.php
+++ b/app-modules/form/src/Models/Form.php
@@ -43,7 +43,6 @@ use App\Enums\FontWeight;
 use App\Models\User;
 use CanyonGBS\Common\Models\Concerns\CanBeArchived;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -182,38 +181,5 @@ class Form extends Submissible
         return Form::query()->where('root_id', $this->root_id)
             ->whereNull('archived_at')
             ->first();
-    }
-
-    /**
-    * @param Builder<Form> $query
-    */
-    public function used(Builder $query): void
-    {
-        $query->whereHas(
-            'versions',
-            fn (Builder $query) => $query
-                ->withoutGlobalScopes()
-                ->whereHas('submissions'),
-        );
-    }
-
-    public function isUsed(): bool
-    {
-        $submissionsExists = $this->getAttribute('submissions_exists');
-
-        if ($submissionsExists === null) {
-            $submissionsExists = FormSubmission::query()
-                ->whereHas(
-                    'submissible',
-                    fn (Builder $query) => $query
-                        ->withoutGlobalScopes()
-                        ->where('root_id', $this->root_id),
-                )
-                ->exists();
-
-            $this->setAttribute('submissions_exists', $submissionsExists);
-        }
-
-        return (bool) $submissionsExists;
     }
 }

--- a/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/EditFormTest.php
+++ b/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/EditFormTest.php
@@ -39,33 +39,28 @@ use AdvisingApp\Form\Filament\Resources\Forms\Pages\EditForm;
 use AdvisingApp\Form\Models\Form;
 use AdvisingApp\Form\Models\FormSubmission;
 
-use function Pest\Laravel\assertModelMissing;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
-it('shows archive mode for the header archive action when the form has submissions', function () {
+it('archive action is always visible and labeled Archive', function () {
     asSuperAdmin();
 
-    $form = Form::factory()->create();
+    $formWithSubmissions = Form::factory()->create();
 
     FormSubmission::factory()->create([
-        'form_id' => $form->id,
+        'form_id' => $formWithSubmissions->id,
         'submitted_at' => now(),
     ]);
 
-    livewire(EditForm::class, ['record' => $form->getRouteKey()])
+    $formWithoutSubmissions = Form::factory()->create();
+
+    livewire(EditForm::class, ['record' => $formWithSubmissions->getRouteKey()])
         ->assertActionVisible('archive')
         ->assertActionHasLabel('archive', 'Archive');
-});
 
-it('shows delete mode for the header archive action when the form has no submissions', function () {
-    asSuperAdmin();
-
-    $form = Form::factory()->create();
-
-    livewire(EditForm::class, ['record' => $form->getRouteKey()])
+    livewire(EditForm::class, ['record' => $formWithoutSubmissions->getRouteKey()])
         ->assertActionVisible('archive')
-        ->assertActionHasLabel('archive', 'Delete');
+        ->assertActionHasLabel('archive', 'Archive');
 });
 
 it('archive action archives the form and redirects to the index when the form has submissions', function () {
@@ -83,16 +78,4 @@ it('archive action archives the form and redirects to the index when the form ha
         ->assertRedirect(FormResource::getUrl('index'));
 
     expect($form->fresh()->isArchived())->toBeTrue();
-});
-
-it('archive action deletes the form and redirects to the index when the form has no submissions', function () {
-    asSuperAdmin();
-
-    $form = Form::factory()->create();
-
-    livewire(EditForm::class, ['record' => $form->getRouteKey()])
-        ->callAction('archive')
-        ->assertRedirect(FormResource::getUrl('index'));
-
-    assertModelMissing($form);
 });

--- a/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/ListFormsTest.php
+++ b/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/ListFormsTest.php
@@ -41,7 +41,6 @@ use AdvisingApp\Form\Models\FormSubmission;
 use App\Models\User;
 use App\Settings\LicenseSettings;
 use Filament\Actions\Testing\TestAction;
-use Illuminate\Database\Eloquent\Builder;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -209,7 +208,24 @@ it('does not count archived submissions in the submissions count', function () {
         ->assertTableColumnStateSet('submissions_count', 3, $form);
 });
 
-it('archives forms with submissions and deletes forms without submissions via the archive or delete bulk action', function () {
+it('archive action is always visible regardless of submission status', function () {
+    asSuperAdmin();
+
+    $formWithSubmissions = Form::factory()->create();
+
+    FormSubmission::factory()->create([
+        'form_id' => $formWithSubmissions->id,
+        'submitted_at' => now(),
+    ]);
+
+    $formWithoutSubmissions = Form::factory()->create();
+
+    livewire(ListForms::class)
+        ->assertTableActionVisible('archive', $formWithSubmissions)
+        ->assertTableActionVisible('archive', $formWithoutSubmissions);
+});
+
+it('archive bulk action archives all selected forms', function () {
     asSuperAdmin();
 
     $formWithSubmissions = Form::factory()->create();
@@ -229,67 +245,5 @@ it('archives forms with submissions and deletes forms without submissions via th
         ->assertNotified();
 
     expect($formWithSubmissions->fresh()->archived_at)->not->toBeNull();
-    expect(Form::find($formWithoutSubmissions->id))->toBeNull();
-});
-
-it('marks a form as used when any version has submissions', function () {
-    asSuperAdmin();
-
-    $form = Form::factory()->create();
-
-    $archivedVersion = Form::factory()->create([
-        'root_id' => $form->root_id,
-        'archived_at' => now(),
-    ]);
-
-    FormSubmission::factory()->create([
-        'form_id' => $archivedVersion->id,
-        'submitted_at' => now(),
-    ]);
-
-    expect($form->isUsed())->toBeTrue();
-});
-
-it('marks a form as unused when no version has submissions', function () {
-    asSuperAdmin();
-
-    $form = Form::factory()->create();
-
-    Form::factory()->create([
-        'root_id' => $form->root_id,
-        'archived_at' => now(),
-    ]);
-
-    expect($form->isUsed())->toBeFalse();
-});
-
-it('used query includes form roots that have submissions on any version', function () {
-    asSuperAdmin();
-
-    $form = Form::factory()->create();
-
-    $archivedVersion = Form::factory()->create([
-        'root_id' => $form->root_id,
-        'archived_at' => now(),
-    ]);
-
-    FormSubmission::factory()->create([
-        'form_id' => $archivedVersion->id,
-        'submitted_at' => now(),
-    ]);
-
-    $unusedForm = Form::factory()->create();
-
-    Form::factory()->create([
-        'root_id' => $unusedForm->root_id,
-        'archived_at' => now(),
-    ]);
-
-    $usedRootIds = Form::query()
-        ->tap(fn (Builder $query) => $form->used($query))
-        ->pluck('root_id')
-        ->unique();
-
-    expect($usedRootIds)->toContain($form->root_id)
-        ->not->toContain($unusedForm->root_id);
+    expect($formWithoutSubmissions->fresh()->archived_at)->not->toBeNull();
 });

--- a/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/ListFormsTest.php
+++ b/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/ListFormsTest.php
@@ -208,23 +208,6 @@ it('does not count archived submissions in the submissions count', function () {
         ->assertTableColumnStateSet('submissions_count', 3, $form);
 });
 
-it('archive action is always visible regardless of submission status', function () {
-    asSuperAdmin();
-
-    $formWithSubmissions = Form::factory()->create();
-
-    FormSubmission::factory()->create([
-        'form_id' => $formWithSubmissions->id,
-        'submitted_at' => now(),
-    ]);
-
-    $formWithoutSubmissions = Form::factory()->create();
-
-    livewire(ListForms::class)
-        ->assertTableActionVisible('archive', $formWithSubmissions)
-        ->assertTableActionVisible('archive', $formWithoutSubmissions);
-});
-
 it('archive bulk action archives all selected forms', function () {
     asSuperAdmin();
 

--- a/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/ViewFormTest.php
+++ b/app-modules/form/tests/Tenant/Filament/Resources/Forms/Pages/ViewFormTest.php
@@ -39,33 +39,28 @@ use AdvisingApp\Form\Filament\Resources\Forms\Pages\ViewForm;
 use AdvisingApp\Form\Models\Form;
 use AdvisingApp\Form\Models\FormSubmission;
 
-use function Pest\Laravel\assertModelMissing;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
-it('shows archive mode for the header archive action when the form has submissions', function () {
+it('archive action is always visible and labeled Archive', function () {
     asSuperAdmin();
 
-    $form = Form::factory()->create();
+    $formWithSubmissions = Form::factory()->create();
 
     FormSubmission::factory()->create([
-        'form_id' => $form->id,
+        'form_id' => $formWithSubmissions->id,
         'submitted_at' => now(),
     ]);
 
-    livewire(ViewForm::class, ['record' => $form->getRouteKey()])
+    $formWithoutSubmissions = Form::factory()->create();
+
+    livewire(ViewForm::class, ['record' => $formWithSubmissions->getRouteKey()])
         ->assertActionVisible('archive')
         ->assertActionHasLabel('archive', 'Archive');
-});
 
-it('shows delete mode for the header archive action when the form has no submissions', function () {
-    asSuperAdmin();
-
-    $form = Form::factory()->create();
-
-    livewire(ViewForm::class, ['record' => $form->getRouteKey()])
+    livewire(ViewForm::class, ['record' => $formWithoutSubmissions->getRouteKey()])
         ->assertActionVisible('archive')
-        ->assertActionHasLabel('archive', 'Delete');
+        ->assertActionHasLabel('archive', 'Archive');
 });
 
 it('archive action archives the form and redirects to the index when the form has submissions', function () {
@@ -83,16 +78,4 @@ it('archive action archives the form and redirects to the index when the form ha
         ->assertRedirect(FormResource::getUrl('index'));
 
     expect($form->fresh()->isArchived())->toBeTrue();
-});
-
-it('archive action deletes the form and redirects to the index when the form has no submissions', function () {
-    asSuperAdmin();
-
-    $form = Form::factory()->create();
-
-    livewire(ViewForm::class, ['record' => $form->getRouteKey()])
-        ->callAction('archive')
-        ->assertRedirect(FormResource::getUrl('index'));
-
-    assertModelMissing($form);
 });

--- a/app-modules/meeting-center/src/Models/Event.php
+++ b/app-modules/meeting-center/src/Models/Event.php
@@ -43,7 +43,6 @@ use CanyonGBS\Common\Models\Concerns\HasUserSaveTracking;
 use Filament\Forms\Components\RichEditor\FileAttachmentProviders\SpatieMediaLibraryFileAttachmentProvider;
 use Filament\Forms\Components\RichEditor\Models\Concerns\InteractsWithRichContent;
 use Filament\Forms\Components\RichEditor\Models\Contracts\HasRichContent;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -118,26 +117,5 @@ class Event extends BaseModel implements HasMedia, HasRichContent
     public function attendees(): HasMany
     {
         return $this->hasMany(EventAttendee::class, 'event_id');
-    }
-
-    /**
-     * @param Builder<Event> $query
-     */
-    public function used(Builder $query): void
-    {
-        $query->whereHas('attendees');
-    }
-
-    public function isUsed(): bool
-    {
-        $attendeesExists = $this->getAttribute('attendees_exists');
-
-        if ($attendeesExists === null) {
-            $attendeesExists = $this->attendees()->exists();
-
-            $this->setAttribute('attendees_exists', $attendeesExists);
-        }
-
-        return (bool) $attendeesExists;
     }
 }

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/EditEventDetailsTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/EditEventDetailsTest.php
@@ -39,30 +39,25 @@ use AdvisingApp\MeetingCenter\Filament\Resources\Events\Pages\EditEventDetails;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\MeetingCenter\Models\EventAttendee;
 
-use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
-it('shows archive mode for the header archive action when the event has attendees', function () {
+it('archive action is always visible and labeled Archive', function () {
     asSuperAdmin();
 
-    $event = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    EventAttendee::factory()->create(['event_id' => $event->id]);
+    $eventWithAttendees = Event::factory()->create(['starts_at' => now()->addWeek()]);
+    EventAttendee::factory()->create(['event_id' => $eventWithAttendees->id]);
 
-    livewire(EditEventDetails::class, ['record' => $event->getRouteKey()])
+    $eventWithoutAttendees = Event::factory()->create(['starts_at' => now()->addWeek()]);
+    $eventWithoutAttendees->attendees()->delete();
+
+    livewire(EditEventDetails::class, ['record' => $eventWithAttendees->getRouteKey()])
         ->assertActionVisible('archive')
         ->assertActionHasLabel('archive', 'Archive');
-});
 
-it('shows delete mode for the header archive action when the event has no attendees', function () {
-    asSuperAdmin();
-
-    $event = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    $event->attendees()->delete();
-
-    livewire(EditEventDetails::class, ['record' => $event->getRouteKey()])
+    livewire(EditEventDetails::class, ['record' => $eventWithoutAttendees->getRouteKey()])
         ->assertActionVisible('archive')
-        ->assertActionHasLabel('archive', 'Delete');
+        ->assertActionHasLabel('archive', 'Archive');
 });
 
 it('archive action archives the event and redirects to the index when the event has attendees', function () {
@@ -76,17 +71,4 @@ it('archive action archives the event and redirects to the index when the event 
         ->assertRedirect(EventResource::getUrl('index'));
 
     expect($event->fresh()->isArchived())->toBeTrue();
-});
-
-it('archive action deletes the event and redirects to the index when the event has no attendees', function () {
-    asSuperAdmin();
-
-    $event = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    $event->attendees()->delete();
-
-    livewire(EditEventDetails::class, ['record' => $event->getRouteKey()])
-        ->callAction('archive')
-        ->assertRedirect(EventResource::getUrl('index'));
-
-    assertSoftDeleted($event);
 });

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/ListEventsTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/ListEventsTest.php
@@ -43,7 +43,6 @@ use AdvisingApp\MeetingCenter\Models\EventRegistrationFormSubmission;
 use App\Models\User;
 use App\Settings\LicenseSettings;
 use Filament\Actions\Testing\TestAction;
-use Illuminate\Database\Eloquent\Builder;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -143,7 +142,22 @@ it('gives a duplicated event registration form its own version tree rather than 
     expect($duplicatedForm->archived_at)->toBeNull();
 });
 
-it('archives events with attendees and deletes events without attendees via the archive or delete bulk action', function () {
+it('shows archive action is always visible regardless of attendee status', function () {
+    asSuperAdmin();
+
+    $eventWithAttendees = Event::factory()->create(['starts_at' => now()->addWeek()]);
+    EventAttendee::factory()->create(['event_id' => $eventWithAttendees->id]);
+
+    $eventWithoutAttendees = Event::factory()->create(['starts_at' => now()->addWeek()]);
+    $eventWithoutAttendees->attendees()->delete();
+
+    livewire(ListEvents::class)
+        ->removeTableFilter('pastEvents')
+        ->assertTableActionVisible('archive', $eventWithAttendees)
+        ->assertTableActionVisible('archive', $eventWithoutAttendees);
+});
+
+it('archive bulk action archives all selected events', function () {
     asSuperAdmin();
 
     $eventWithAttendees = Event::factory()->create(['starts_at' => now()->addWeek()]);
@@ -161,39 +175,5 @@ it('archives events with attendees and deletes events without attendees via the 
         ->assertNotified();
 
     expect($eventWithAttendees->fresh()->archived_at)->not->toBeNull();
-    expect(Event::find($eventWithoutAttendees->id))->toBeNull();
-});
-
-it('marks an event as used when it has attendees', function () {
-    asSuperAdmin();
-
-    $event = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    EventAttendee::factory()->create(['event_id' => $event->id]);
-
-    expect($event->isUsed())->toBeTrue();
-});
-
-it('marks an event as unused when it has no attendees', function () {
-    asSuperAdmin();
-
-    $event = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    $event->attendees()->delete();
-
-    expect($event->isUsed())->toBeFalse();
-});
-
-it('used query includes only events that have attendees', function () {
-    asSuperAdmin();
-
-    $usedEvent = Event::factory()->create(['starts_at' => now()->addWeek()]);
-
-    $unusedEvent = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    $unusedEvent->attendees()->delete();
-
-    $usedEventIds = Event::query()
-        ->tap(fn (Builder $query) => $usedEvent->used($query))
-        ->pluck('id');
-
-    expect($usedEventIds)->toContain($usedEvent->id)
-        ->not->toContain($unusedEvent->id);
+    expect($eventWithoutAttendees->fresh()->archived_at)->not->toBeNull();
 });

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/ListEventsTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/ListEventsTest.php
@@ -142,21 +142,6 @@ it('gives a duplicated event registration form its own version tree rather than 
     expect($duplicatedForm->archived_at)->toBeNull();
 });
 
-it('shows archive action is always visible regardless of attendee status', function () {
-    asSuperAdmin();
-
-    $eventWithAttendees = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    EventAttendee::factory()->create(['event_id' => $eventWithAttendees->id]);
-
-    $eventWithoutAttendees = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    $eventWithoutAttendees->attendees()->delete();
-
-    livewire(ListEvents::class)
-        ->removeTableFilter('pastEvents')
-        ->assertTableActionVisible('archive', $eventWithAttendees)
-        ->assertTableActionVisible('archive', $eventWithoutAttendees);
-});
-
 it('archive bulk action archives all selected events', function () {
     asSuperAdmin();
 

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/ViewEventTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/ViewEventTest.php
@@ -39,30 +39,25 @@ use AdvisingApp\MeetingCenter\Filament\Resources\Events\Pages\ViewEvent;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\MeetingCenter\Models\EventAttendee;
 
-use function Pest\Laravel\assertSoftDeleted;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
-it('shows archive mode for the header archive action when the event has attendees', function () {
+it('archive action is always visible and labeled Archive', function () {
     asSuperAdmin();
 
-    $event = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    EventAttendee::factory()->create(['event_id' => $event->id]);
+    $eventWithAttendees = Event::factory()->create(['starts_at' => now()->addWeek()]);
+    EventAttendee::factory()->create(['event_id' => $eventWithAttendees->id]);
 
-    livewire(ViewEvent::class, ['record' => $event->getRouteKey()])
+    $eventWithoutAttendees = Event::factory()->create(['starts_at' => now()->addWeek()]);
+    $eventWithoutAttendees->attendees()->delete();
+
+    livewire(ViewEvent::class, ['record' => $eventWithAttendees->getRouteKey()])
         ->assertActionVisible('archive')
         ->assertActionHasLabel('archive', 'Archive');
-});
 
-it('shows delete mode for the header archive action when the event has no attendees', function () {
-    asSuperAdmin();
-
-    $event = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    $event->attendees()->delete();
-
-    livewire(ViewEvent::class, ['record' => $event->getRouteKey()])
+    livewire(ViewEvent::class, ['record' => $eventWithoutAttendees->getRouteKey()])
         ->assertActionVisible('archive')
-        ->assertActionHasLabel('archive', 'Delete');
+        ->assertActionHasLabel('archive', 'Archive');
 });
 
 it('archive action archives the event and redirects to the index when the event has attendees', function () {
@@ -76,17 +71,4 @@ it('archive action archives the event and redirects to the index when the event 
         ->assertRedirect(EventResource::getUrl('index'));
 
     expect($event->fresh()->isArchived())->toBeTrue();
-});
-
-it('archive action deletes the event and redirects to the index when the event has no attendees', function () {
-    asSuperAdmin();
-
-    $event = Event::factory()->create(['starts_at' => now()->addWeek()]);
-    $event->attendees()->delete();
-
-    livewire(ViewEvent::class, ['record' => $event->getRouteKey()])
-        ->callAction('archive')
-        ->assertRedirect(EventResource::getUrl('index'));
-
-    assertSoftDeleted($event);
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/OLYMPUS-1505

### Technical Description

> Separate any delete functionality from the archiving components

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
