### PR TITLE
[Bugfix]: Enable serializable classes for caching

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -115,5 +115,5 @@ return [
     |
     */
 
-    'serializable_classes' => false,
+    'serializable_classes' => true,
 ];


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Sets Laravel serializable_classes to be `true` as there are different packages that seem to serialize things in the cache that we can't spend time tracking down.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
