### PR TITLE
[Bugfix]: Add migration to delete case timeline records and corresponding tests

### DIFF
--- a/.cleanup-tasks/2026_08_05_delete_case_timeline_records.md
+++ b/.cleanup-tasks/2026_08_05_delete_case_timeline_records.md
@@ -1,0 +1,20 @@
+---
+title: Delete Case Timeline Records
+created: 2026-08-05
+---
+
+## Feature Flags
+
+## Temporary Migrations
+
+- database/migrations/2026_08_05_233648_tmp_delete_case_timeline_records.php
+
+## Additional Cleanup
+
+<!--
+Only list cleanup that has no home in code. Do NOT restate obvious feature-flag
+removals (keep the active path, drop the inactive path), and do NOT include file
+paths or line numbers. For non-obvious changes, put a `TODO: Cleanup Task (<tag>)`
+comment at the change site and reference the tag here — e.g.
+"Search for `TODO: Cleanup Task (some-feature)`".
+-->

--- a/database/migrations/2026_08_05_233648_tmp_delete_case_timeline_records.php
+++ b/database/migrations/2026_08_05_233648_tmp_delete_case_timeline_records.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class () extends Migration {
+    /**
+     * @var array<string>
+     */
+    private array $caseTimelineableTypes = [
+        'case_assignment',
+        'case_history',
+        'case_update',
+    ];
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            DB::table('timelines')
+                ->whereIn('timelineable_type', $this->caseTimelineableTypes)
+                ->delete();
+        });
+    }
+
+    public function down(): void
+    {
+        // Deleted timeline records for removed case models cannot be restored.
+    }
+};

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -128,3 +128,63 @@ test('2026_04_08_145038_rename_campaign_action_id_to_source_morph_on_engagements
         }
     );
 });
+
+test('2026_08_05_233648_tmp_delete_case_timeline_records removes timeline records for removed case models', function () {
+    isolatedMigration(
+        '2026_08_05_233648_tmp_delete_case_timeline_records',
+        function () {
+            $caseTimelineIds = collect(['case_assignment', 'case_history', 'case_update'])
+                ->map(function (string $timelineableType): string {
+                    $id = (string) Str::uuid();
+
+                    DB::table('timelines')->insert([
+                        'id' => $id,
+                        'entity_type' => 'student',
+                        'entity_id' => (string) Str::uuid(),
+                        'timelineable_type' => $timelineableType,
+                        'timelineable_id' => (string) Str::uuid(),
+                        'record_sortable_date' => now(),
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ]);
+
+                    return $id;
+                });
+
+            $softDeletedCaseTimelineId = (string) Str::uuid();
+
+            DB::table('timelines')->insert([
+                'id' => $softDeletedCaseTimelineId,
+                'entity_type' => 'student',
+                'entity_id' => (string) Str::uuid(),
+                'timelineable_type' => 'case_update',
+                'timelineable_id' => (string) Str::uuid(),
+                'record_sortable_date' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+                'deleted_at' => now(),
+            ]);
+
+            $engagementTimelineId = (string) Str::uuid();
+
+            DB::table('timelines')->insert([
+                'id' => $engagementTimelineId,
+                'entity_type' => 'student',
+                'entity_id' => (string) Str::uuid(),
+                'timelineable_type' => 'engagement',
+                'timelineable_id' => (string) Str::uuid(),
+                'record_sortable_date' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $migrate = Artisan::call('migrate', ['--path' => 'database/migrations/2026_08_05_233648_tmp_delete_case_timeline_records.php']);
+
+            expect($migrate)->toBe(Command::SUCCESS);
+
+            expect(DB::table('timelines')->whereIn('id', $caseTimelineIds->all())->count())->toBe(0);
+            expect(DB::table('timelines')->where('id', $softDeletedCaseTimelineId)->count())->toBe(0);
+            expect(DB::table('timelines')->where('id', $engagementTimelineId)->count())->toBe(1);
+        }
+    );
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

This pull request introduces a temporary database migration to remove timeline records associated with deprecated case models, along with a corresponding test and documentation. The migration ensures that only records related to specific case types are deleted, and includes safeguards and tests to confirm correct behavior.

**Database Migration: Case Timeline Cleanup**

* Added a temporary migration `2026_08_05_233648_tmp_delete_case_timeline_records.php` that deletes all records in the `timelines` table where `timelineable_type` is one of `case_assignment`, `case_history`, or `case_update`.
* The migration is documented in `.cleanup-tasks/2026_08_05_delete_case_timeline_records.md` to track its purpose and future cleanup needs.

**Testing and Validation**

* Added a test in `tests/TenantMigrationTests.php` to ensure the migration deletes only the targeted timeline records, leaves unrelated records untouched, and removes both active and soft-deleted case timeline entries.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
