### PR TITLE
[ADVAPP-2868]: Update Campaigns to multi-select archive

### DIFF
--- a/app-modules/campaign/src/Filament/Actions/ArchiveCampaignBulkAction.php
+++ b/app-modules/campaign/src/Filament/Actions/ArchiveCampaignBulkAction.php
@@ -43,6 +43,10 @@ class ArchiveCampaignBulkAction
 {
     public static function make(): BulkAction
     {
+        // Relies on the default per-record fetching: the action must call $record->archive()
+        // per record so Campaign's archiving event fires and disables enabled campaigns. Do not
+        // set fetchSelectedRecords(false) — query-level archive bypasses model events and would
+        // archive campaigns while leaving them enabled.
         return ArchiveBulkAction::make()
             ->modalDescription(function (ArchiveBulkAction $action): string {
                 $count = $action->getSelectedRecordsQuery()->count();

--- a/app-modules/campaign/src/Filament/Actions/ArchiveCampaignBulkAction.php
+++ b/app-modules/campaign/src/Filament/Actions/ArchiveCampaignBulkAction.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Campaign\Filament\Actions;
+
+use CanyonGBS\Common\Filament\Actions\ArchiveBulkAction;
+use Filament\Actions\BulkAction;
+
+class ArchiveCampaignBulkAction
+{
+    public static function make(): BulkAction
+    {
+        return ArchiveBulkAction::make()
+            ->modalDescription(function (ArchiveBulkAction $action): string {
+                $count = $action->getSelectedRecordsQuery()->count();
+
+                return "This action will disable and archive {$count} selected campaign(s).";
+            });
+    }
+}

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/ListCampaigns.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/ListCampaigns.php
@@ -36,16 +36,15 @@
 
 namespace AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages;
 
+use AdvisingApp\Campaign\Filament\Actions\ArchiveCampaignBulkAction;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\CampaignResource;
 use AdvisingApp\Campaign\Models\Campaign;
 use AdvisingApp\Group\Actions\TranslateGroupFilters;
 use AdvisingApp\Group\Models\Group;
 use App\Filament\Tables\Columns\IdColumn;
 use App\Models\User;
+use Filament\Actions\BulkActionGroup;
 use Filament\Actions\CreateAction;
-use Filament\Actions\DeleteAction;
-use Filament\Actions\EditAction;
-use Filament\Actions\ViewAction;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
@@ -110,13 +109,13 @@ class ListCampaigns extends ListRecords
 
                 return $query;
             })
-            ->recordActions([
-                ViewAction::make(),
-                EditAction::make()
-                    ->hidden(fn (Campaign $record) => $record->hasBeenExecuted() === true),
-                DeleteAction::make()
-                    ->hidden(fn (Campaign $record) => $record->hasBeenExecuted() === true),
-            ])->filters([
+            ->recordUrl(fn (Campaign $record): string => CampaignResource::getUrl('view', ['record' => $record]))
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    ArchiveCampaignBulkAction::make(),
+                ]),
+            ])
+            ->filters([
                 Filter::make('My Campaigns')
                     ->query(
                         fn (Builder $query) => $query

--- a/app-modules/campaign/src/Models/Campaign.php
+++ b/app-modules/campaign/src/Models/Campaign.php
@@ -48,6 +48,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\DB;
 use OwenIt\Auditing\Contracts\Auditable;
 
 /**
@@ -58,7 +59,9 @@ class Campaign extends BaseModel implements Auditable
 {
     use AuditableTrait;
     use SoftDeletes;
-    use CanBeArchived;
+    use CanBeArchived {
+        archive as protected archiveWithoutTransaction;
+    }
 
     protected $fillable = [
         'name',
@@ -104,6 +107,14 @@ class Campaign extends BaseModel implements Auditable
     public function createdBy(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    public function archive(): bool
+    {
+        // The archiving event disables the campaign in a separate write from the archive
+        // itself, so wrap both in a transaction to keep them atomic: a failure must not
+        // leave a campaign disabled but not archived.
+        return DB::transaction(fn (): bool => $this->archiveWithoutTransaction());
     }
 
     protected static function booted(): void

--- a/app-modules/campaign/src/Models/Campaign.php
+++ b/app-modules/campaign/src/Models/Campaign.php
@@ -115,5 +115,12 @@ class Campaign extends BaseModel implements Auditable
 
             $builder->whereHas('group');
         });
+
+        static::archiving(function (Campaign $campaign): void {
+            if ($campaign->enabled) {
+                $campaign->enabled = false;
+                $campaign->save();
+            }
+        });
     }
 }

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/ListCampaignsTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/ListCampaignsTest.php
@@ -37,14 +37,18 @@
 namespace AdvisingApp\Campaign\Tests\Tenant\Filament\Resources\Campaigns\Pages;
 
 use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\Campaign\Filament\Resources\Campaigns\CampaignResource;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\ListCampaigns;
 use AdvisingApp\Campaign\Models\Campaign;
 use AdvisingApp\Campaign\Models\CampaignAction;
 use AdvisingApp\Group\Enums\GroupModel;
 use AdvisingApp\Group\Models\Group;
 use App\Models\User;
+use Filament\Actions\Testing\TestAction;
 use Illuminate\Database\Eloquent\Model;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertModelExists;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
@@ -269,3 +273,87 @@ it('shows the group name and population as the name column description for a dyn
     'students' => [GroupModel::Student, 'Students', 'last'],
     'prospects' => [GroupModel::Prospect, 'Prospects', 'last_name'],
 ]);
+
+it('archives and disables every selected campaign without deleting any', function () {
+    asSuperAdmin();
+
+    $executed = Campaign::factory()->enabled()
+        ->has(CampaignAction::factory()->finishedAt(), 'actions')
+        ->create();
+
+    $neverExecuted = Campaign::factory()->enabled()->create();
+
+    $records = collect([$executed, $neverExecuted]);
+
+    // Establish starting state: both enabled and not archived.
+    foreach ($records as $record) {
+        expect($record->enabled)->toBeTrue()
+            ->and($record->archived_at)->toBeNull();
+    }
+
+    livewire(ListCampaigns::class)
+        ->selectTableRecords($records->pluck('id')->all())
+        ->callAction(TestAction::make('archive')->table()->bulk())
+        ->assertNotified();
+
+    foreach ($records as $record) {
+        // Still present — archive-only never deletes, even the never-executed one.
+        assertModelExists($record);
+
+        $record->refresh();
+
+        expect($record->archived_at)->not->toBeNull()
+            ->and($record->enabled)->toBeFalse();
+    }
+});
+
+it('shows the disable and archive confirmation copy with the selected count', function () {
+    asSuperAdmin();
+
+    $campaigns = Campaign::factory()->count(2)->create();
+
+    livewire(ListCampaigns::class)
+        ->mountTableBulkAction('archive', $campaigns->pluck('id')->all())
+        ->assertMountedActionModalSee('This action will disable and archive 2 selected campaign(s).');
+});
+
+it('does not render per-row view, edit, or delete actions', function () {
+    asSuperAdmin();
+
+    $campaign = Campaign::factory()->create();
+
+    livewire(ListCampaigns::class)
+        ->assertCanSeeTableRecords([$campaign])
+        ->assertTableActionDoesNotExist('view')
+        ->assertTableActionDoesNotExist('edit')
+        ->assertTableActionDoesNotExist('delete');
+});
+
+it('links each row to the campaign view page', function () {
+    asSuperAdmin();
+
+    $campaign = Campaign::factory()->create();
+
+    livewire(ListCampaigns::class)
+        ->assertCanSeeTableRecords([$campaign])
+        ->assertSee(CampaignResource::getUrl('view', ['record' => $campaign]));
+});
+
+it('hides the archive bulk action from users without delete permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('campaign.view-any');
+
+    actingAs($user);
+
+    $campaigns = Campaign::factory()->count(2)->create();
+
+    livewire(ListCampaigns::class)
+        ->assertCanSeeTableRecords($campaigns)
+        ->assertTableBulkActionHidden('archive');
+
+    $user->givePermissionTo('campaign.*.delete');
+
+    livewire(ListCampaigns::class)
+        ->assertCanSeeTableRecords($campaigns)
+        ->assertTableBulkActionVisible('archive');
+});

--- a/app-modules/campaign/tests/Tenant/Models/CampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Models/CampaignTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor's trademarks is subject
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of

--- a/app-modules/campaign/tests/Tenant/Models/CampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Models/CampaignTest.php
@@ -17,7 +17,7 @@
       in the software, and you may not remove or obscure any functionality in the
       software that is protected by the license key.
     - You may not alter, remove, or obscure any licensing, copyright, or other notices
-      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      of the licensor in the software. Any use of the licensor's trademarks is subject
       to applicable law.
     - Canyon GBS Inc. respects the intellectual property rights of others and expects the
       same in return. Canyon GBS® and Advising App® are registered trademarks of
@@ -34,39 +34,41 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Campaign\Filament\Actions;
+namespace AdvisingApp\Campaign\Tests\Tenant\Models;
 
 use AdvisingApp\Campaign\Models\Campaign;
-use CanyonGBS\Common\Filament\Actions\ArchiveAction;
-use Filament\Actions\Action;
-use Filament\Notifications\Notification;
-use Throwable;
 
-class ArchiveCampaignAction
-{
-    public static function make(): Action
-    {
-        return ArchiveAction::make()
-            ->label(fn (Campaign $record): string => $record->enabled ? 'Disable and Archive' : 'Archive')
-            ->modalHeading(fn (Campaign $record): string => $record->enabled ? 'Disable and Archive Campaign' : 'Archive Campaign')
-            ->modalSubmitActionLabel(fn (Campaign $record): string => $record->enabled ? 'Disable and Archive' : 'Archive')
-            ->action(function (Campaign $record): void {
-                try {
-                    $record->archive();
+use function Tests\asSuperAdmin;
 
-                    Notification::make()
-                        ->success()
-                        ->title('Campaign archived successfully')
-                        ->send();
-                } catch (Throwable $exception) {
-                    report($exception);
+it('disables an enabled campaign when it is archived', function () {
+    asSuperAdmin();
 
-                    Notification::make()
-                        ->danger()
-                        ->title('Failed to archive campaign')
-                        ->body($exception->getMessage())
-                        ->send();
-                }
-            });
-    }
-}
+    $campaign = Campaign::factory()->enabled()->create();
+
+    // Establish starting state before the side effect.
+    expect($campaign->enabled)->toBeTrue()
+        ->and($campaign->archived_at)->toBeNull();
+
+    $campaign->archive();
+
+    $campaign->refresh();
+
+    expect($campaign->enabled)->toBeFalse()
+        ->and($campaign->archived_at)->not->toBeNull();
+});
+
+it('archives an already disabled campaign without re-enabling it', function () {
+    asSuperAdmin();
+
+    $campaign = Campaign::factory()->disabled()->create();
+
+    expect($campaign->enabled)->toBeFalse()
+        ->and($campaign->archived_at)->toBeNull();
+
+    $campaign->archive();
+
+    $campaign->refresh();
+
+    expect($campaign->enabled)->toBeFalse()
+        ->and($campaign->archived_at)->not->toBeNull();
+});

--- a/app-modules/campaign/tests/Tenant/Models/CampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Models/CampaignTest.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\Campaign\Tests\Tenant\Models;
 
 use AdvisingApp\Campaign\Models\Campaign;
+use RuntimeException;
 
 use function Tests\asSuperAdmin;
 
@@ -55,6 +56,26 @@ it('disables an enabled campaign when it is archived', function () {
 
     expect($campaign->enabled)->toBeFalse()
         ->and($campaign->archived_at)->not->toBeNull();
+});
+
+it('rolls back the disable when archiving fails, leaving the campaign enabled and not archived', function () {
+    asSuperAdmin();
+
+    $campaign = Campaign::factory()->enabled()->create();
+
+    // Force a failure after the archiving event has disabled the campaign and the
+    // archived_at write has run, but before archive() returns — both writes share the
+    // transaction, so both must roll back.
+    Campaign::archived(function (): void {
+        throw new RuntimeException('Archiving failed.');
+    });
+
+    expect(fn () => $campaign->archive())->toThrow(RuntimeException::class);
+
+    $persisted = Campaign::withoutGlobalScopes()->findOrFail($campaign->getKey());
+
+    expect($persisted->enabled)->toBeTrue()
+        ->and($persisted->archived_at)->toBeNull();
 });
 
 it('archives an already disabled campaign without re-enabling it', function () {


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2868

### Technical Description

Reworks the Campaigns list page to archive-based management via a multi-select bulk action, replacing the per-row actions.

- **Removed** the per-row `View`, `Edit`, and `Delete` actions from the Campaigns list table. Rows now link directly to the campaign view page via `recordUrl`.
- **Added** an `ArchiveCampaignBulkAction` to the list's bulk action group. It reuses the shared `CanyonGBS\Common\Filament\Actions\ArchiveBulkAction`, so it archives selected campaigns (never deletes — `Campaign` intentionally defines no `used()`/`isUsed()`) and overrides the modal description with a count-aware confirmation ("This action will disable and archive N selected campaign(s).").
- **Disable-on-archive:** archiving a campaign now also disables it. This is enforced as a caller-agnostic invariant via a `static::archiving()` model event in `Campaign::booted()`, so it holds for both the single-record archive action and the new bulk action. The single-record `ArchiveCampaignAction` was simplified to rely on this event.
- The list query already excludes archived records (`withoutArchived()`), so archived campaigns drop out of the list.
- Tests: a new `CampaignTest` covers the archiving model event (disables enabled, leaves already-disabled alone); `ListCampaignsTest` covers bulk archive-and-disable without deletion, the modal copy, removal of per-row actions, the row URL, and bulk-action authorization.

### Any deployment steps required?

No

### Cleanup Tasks

N/A
