### PR TITLE
[ADVAPP-2852] & [ADVAPP-2854]: Some users are experiencing issues when navigating to the resource hub portal

### DIFF
--- a/app-modules/portal/routes/portals.php
+++ b/app-modules/portal/routes/portals.php
@@ -41,16 +41,15 @@ use AdvisingApp\Portal\Http\Controllers\ResourceHub\ResourceHubPortalController;
 use AdvisingApp\Portal\Http\Controllers\ResourceHub\ResourceHubPortalLogoutController;
 use AdvisingApp\Portal\Http\Controllers\ResourceHub\ResourceHubPortalRequestAuthenticationController;
 use AdvisingApp\Portal\Http\Controllers\ResourceHub\ResourceHubPortalSearchController;
+use AdvisingApp\Portal\Http\Controllers\ResourceHub\ResourceHubPortalUserController;
 use AdvisingApp\Portal\Http\Middleware\AuthenticateIfRequiredByPortalDefinition;
 use AdvisingApp\Portal\Http\Middleware\EnsureResourceHubPortalIsEmbeddableAndAuthorized;
 use AdvisingApp\Portal\Http\Middleware\EnsureResourceHubPortalIsEnabled;
 use AdvisingApp\Portal\Http\Middleware\ResourceHubPortalCors;
-use AdvisingApp\StudentDataModel\Models\Contracts\Educatable;
 use App\Multitenancy\Http\Middleware\NeedsTenant;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
-use Laravel\Sanctum\PersonalAccessToken;
 
 Route::middleware([
     'api',
@@ -62,19 +61,7 @@ Route::middleware([
     ->prefix('portals')
     ->name('portals.')
     ->group(function () {
-        Route::get('/user', function (Request $request) {
-            // Resolve the portal token directly rather than through the Sanctum guard, which would
-            // otherwise return an ambient first-party session user (e.g. a logged-in admin) instead.
-            $accessToken = PersonalAccessToken::findToken((string) $request->bearerToken());
-
-            $educatable = $accessToken?->tokenable;
-
-            if (! $educatable instanceof Educatable || ! $accessToken->can('resource-hub-portal')) {
-                return response()->json(['message' => 'Unauthenticated.'], 401);
-            }
-
-            return $educatable;
-        })
+        Route::get('/user', ResourceHubPortalUserController::class)
             ->name('user.auth-check');
 
         // Handle preflight CORS requests for all routes in this group

--- a/app-modules/portal/routes/portals.php
+++ b/app-modules/portal/routes/portals.php
@@ -45,10 +45,12 @@ use AdvisingApp\Portal\Http\Middleware\AuthenticateIfRequiredByPortalDefinition;
 use AdvisingApp\Portal\Http\Middleware\EnsureResourceHubPortalIsEmbeddableAndAuthorized;
 use AdvisingApp\Portal\Http\Middleware\EnsureResourceHubPortalIsEnabled;
 use AdvisingApp\Portal\Http\Middleware\ResourceHubPortalCors;
+use AdvisingApp\StudentDataModel\Models\Contracts\Educatable;
 use App\Multitenancy\Http\Middleware\NeedsTenant;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+use Laravel\Sanctum\PersonalAccessToken;
 
 Route::middleware([
     'api',
@@ -61,15 +63,18 @@ Route::middleware([
     ->name('portals.')
     ->group(function () {
         Route::get('/user', function (Request $request) {
-            $user = $request->user('student') ?? $request->user('prospect');
+            // Resolve the portal token directly rather than through the Sanctum guard, which would
+            // otherwise return an ambient first-party session user (e.g. a logged-in admin) instead.
+            $accessToken = PersonalAccessToken::findToken((string) $request->bearerToken());
 
-            if (! $user || ! $user->tokenCan('resource-hub-portal')) {
+            $educatable = $accessToken?->tokenable;
+
+            if (! $educatable instanceof Educatable || ! $accessToken->can('resource-hub-portal')) {
                 return response()->json(['message' => 'Unauthenticated.'], 401);
             }
 
-            return $user;
+            return $educatable;
         })
-            ->middleware(['auth:sanctum'])
             ->name('user.auth-check');
 
         // Handle preflight CORS requests for all routes in this group

--- a/app-modules/portal/src/DataTransferObjects/ResourceHubCategoryData.php
+++ b/app-modules/portal/src/DataTransferObjects/ResourceHubCategoryData.php
@@ -43,7 +43,7 @@ class ResourceHubCategoryData extends Data
     public function __construct(
         public string $id,
         public string $name,
-        public string $description,
+        public ?string $description,
         public ?string $icon,
     ) {}
 }

--- a/app-modules/portal/src/Http/Controllers/ResourceHub/ResourceHubPortalLogoutController.php
+++ b/app-modules/portal/src/Http/Controllers/ResourceHub/ResourceHubPortalLogoutController.php
@@ -53,7 +53,7 @@ class ResourceHubPortalLogoutController extends Controller
 
         $user = $accessToken?->tokenable;
 
-        if (! $user instanceof Educatable) {
+        if (! ($user instanceof Educatable)) {
             return response()->json([
                 'success' => false,
             ]);

--- a/app-modules/portal/src/Http/Controllers/ResourceHub/ResourceHubPortalLogoutController.php
+++ b/app-modules/portal/src/Http/Controllers/ResourceHub/ResourceHubPortalLogoutController.php
@@ -36,24 +36,34 @@
 
 namespace AdvisingApp\Portal\Http\Controllers\ResourceHub;
 
+use AdvisingApp\StudentDataModel\Models\Contracts\Educatable;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Laravel\Sanctum\PersonalAccessToken;
 
 class ResourceHubPortalLogoutController extends Controller
 {
     public function __invoke(Request $request)
     {
-        $user = auth('sanctum')->user();
+        // Resolve the portal token directly rather than through the Sanctum guard, which would
+        // otherwise return an ambient first-party session user (e.g. a logged-in admin) instead.
+        $accessToken = PersonalAccessToken::findToken((string) $request->bearerToken());
 
-        if (! $user) {
+        $user = $accessToken?->tokenable;
+
+        if (! $user instanceof Educatable) {
             return response()->json([
                 'success' => false,
             ]);
         }
 
-        $user->tokens()->where('name', 'resource-hub-portal-access-token')->delete();
+        PersonalAccessToken::query()
+            ->where('tokenable_type', $user->getMorphClass())
+            ->where('tokenable_id', $user->getKey())
+            ->where('name', 'resource-hub-portal-access-token')
+            ->delete();
 
         $guard = $user instanceof Student ? 'student' : 'prospect';
         Auth::guard($guard)->logout();

--- a/app-modules/portal/src/Http/Controllers/ResourceHub/ResourceHubPortalUserController.php
+++ b/app-modules/portal/src/Http/Controllers/ResourceHub/ResourceHubPortalUserController.php
@@ -52,7 +52,7 @@ class ResourceHubPortalUserController extends Controller
 
         $educatable = $accessToken?->tokenable;
 
-        if (! $educatable instanceof Educatable || ! $accessToken->can('resource-hub-portal')) {
+        if (! ($educatable instanceof Educatable) || ! $accessToken->can('resource-hub-portal')) {
             return response()->json(['message' => 'Unauthenticated.'], 401);
         }
 

--- a/app-modules/portal/src/Http/Controllers/ResourceHub/ResourceHubPortalUserController.php
+++ b/app-modules/portal/src/Http/Controllers/ResourceHub/ResourceHubPortalUserController.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Portal\Http\Controllers\ResourceHub;
+
+use AdvisingApp\StudentDataModel\Models\Contracts\Educatable;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
+
+class ResourceHubPortalUserController extends Controller
+{
+    public function __invoke(Request $request): Educatable|JsonResponse
+    {
+        // Resolve the portal token directly rather than through the Sanctum guard, which would
+        // otherwise return an ambient first-party session user (e.g. a logged-in admin) instead.
+        $accessToken = PersonalAccessToken::findToken((string) $request->bearerToken());
+
+        $educatable = $accessToken?->tokenable;
+
+        if (! $educatable instanceof Educatable || ! $accessToken->can('resource-hub-portal')) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        return $educatable;
+    }
+}

--- a/app-modules/portal/src/Http/Middleware/AuthenticateIfRequiredByPortalDefinition.php
+++ b/app-modules/portal/src/Http/Middleware/AuthenticateIfRequiredByPortalDefinition.php
@@ -59,7 +59,7 @@ class AuthenticateIfRequiredByPortalDefinition
 
         $educatable = $accessToken?->tokenable;
 
-        if (! $educatable instanceof Educatable || ! $accessToken->can('resource-hub-portal')) {
+        if (! ($educatable instanceof Educatable) || ! $accessToken->can('resource-hub-portal')) {
             abort(Response::HTTP_FORBIDDEN);
         }
 

--- a/app-modules/portal/tests/Tenant/Http/Controllers/ResourceHub/ResourceHubPortalCategoryControllerTest.php
+++ b/app-modules/portal/tests/Tenant/Http/Controllers/ResourceHub/ResourceHubPortalCategoryControllerTest.php
@@ -34,35 +34,26 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Portal\Http\Middleware;
-
 use AdvisingApp\Portal\Settings\PortalSettings;
-use AdvisingApp\StudentDataModel\Models\Contracts\Educatable;
-use Closure;
-use Illuminate\Http\Request;
-use Laravel\Sanctum\PersonalAccessToken;
-use Symfony\Component\HttpFoundation\Response;
+use AdvisingApp\ResourceHub\Models\ResourceHubCategory;
 
-class AuthenticateIfRequiredByPortalDefinition
-{
-    public function handle(Request $request, Closure $next): Response
-    {
-        $settings = resolve(PortalSettings::class);
+use function Pest\Laravel\get;
 
-        if (! $settings->resource_hub_portal_requires_authentication) {
-            return $next($request);
-        }
+beforeEach(function () {
+    $settings = app(PortalSettings::class);
+    $settings->resource_hub_portal_enabled = true;
+    $settings->resource_hub_portal_requires_authentication = false;
+    $settings->save();
+});
 
-        // Resolve the portal token directly rather than through the Sanctum guard, which would
-        // otherwise return an ambient first-party session user (e.g. a logged-in admin) instead.
-        $accessToken = PersonalAccessToken::findToken((string) $request->bearerToken());
+it('lists categories with a null description', function () {
+    $category = ResourceHubCategory::factory()->create(['description' => null]);
 
-        $educatable = $accessToken?->tokenable;
-
-        if (! $educatable instanceof Educatable || ! $accessToken->can('resource-hub-portal')) {
-            abort(Response::HTTP_FORBIDDEN);
-        }
-
-        return $next($request);
-    }
-}
+    get(route('portals.resource-hub.api.category.index'))
+        ->assertSuccessful()
+        ->assertJsonFragment([
+            'id' => $category->getKey(),
+            'name' => $category->name,
+            'description' => null,
+        ]);
+});

--- a/app-modules/portal/tests/Tenant/Http/Controllers/ResourceHub/ResourceHubPortalUserControllerTest.php
+++ b/app-modules/portal/tests/Tenant/Http/Controllers/ResourceHub/ResourceHubPortalUserControllerTest.php
@@ -86,7 +86,7 @@ it('resolves the portal token even when a first-party session user is present', 
         ->assertJsonFragment(['sisid' => $student->sisid]);
 });
 
-it('rejects a token without the `resource-hub-portal` ability', function () {
+it('does not authenticate a token without the `resource-hub-portal` ability', function () {
     $student = Student::factory()->create();
 
     $token = $student->createToken('resource-hub-portal-access-token', ['some-other-ability']);
@@ -97,7 +97,7 @@ it('rejects a token without the `resource-hub-portal` ability', function () {
         ->assertUnauthorized();
 });
 
-it('rejects a request without a token', function () {
+it('does not authenticate a request without a token', function () {
     getJson(route('portals.user.auth-check'))
         ->assertUnauthorized();
 });

--- a/app-modules/portal/tests/Tenant/Http/ResourceHubPortalUserAuthCheckTest.php
+++ b/app-modules/portal/tests/Tenant/Http/ResourceHubPortalUserAuthCheckTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Portal\Settings\PortalSettings;
+use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Models\Student;
+
+use function Pest\Laravel\get;
+use function Pest\Laravel\getJson;
+use function Tests\asSuperAdmin;
+
+beforeEach(function () {
+    $settings = app(PortalSettings::class);
+    $settings->resource_hub_portal_enabled = true;
+    $settings->save();
+});
+
+it('authenticates a student via a resource hub portal bearer token', function () {
+    $student = Student::factory()->create();
+
+    $token = $student->createToken('resource-hub-portal-access-token', ['resource-hub-portal']);
+
+    get(route('portals.user.auth-check'), [
+        'Authorization' => "Bearer {$token->plainTextToken}",
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment(['sisid' => $student->sisid]);
+});
+
+it('authenticates a prospect via a resource hub portal bearer token', function () {
+    $prospect = Prospect::factory()->create();
+
+    $token = $prospect->createToken('resource-hub-portal-access-token', ['resource-hub-portal']);
+
+    get(route('portals.user.auth-check'), [
+        'Authorization' => "Bearer {$token->plainTextToken}",
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment(['id' => $prospect->getKey()]);
+});
+
+it('resolves the portal token even when a first-party session user is present', function () {
+    asSuperAdmin();
+
+    $student = Student::factory()->create();
+
+    $token = $student->createToken('resource-hub-portal-access-token', ['resource-hub-portal']);
+
+    get(route('portals.user.auth-check'), [
+        'Authorization' => "Bearer {$token->plainTextToken}",
+    ])
+        ->assertSuccessful()
+        ->assertJsonFragment(['sisid' => $student->sisid]);
+});
+
+it('rejects a token without the `resource-hub-portal` ability', function () {
+    $student = Student::factory()->create();
+
+    $token = $student->createToken('resource-hub-portal-access-token', ['some-other-ability']);
+
+    getJson(route('portals.user.auth-check'), [
+        'Authorization' => "Bearer {$token->plainTextToken}",
+    ])
+        ->assertUnauthorized();
+});
+
+it('rejects a request without a token', function () {
+    getJson(route('portals.user.auth-check'))
+        ->assertUnauthorized();
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2852
- https://canyongbs.atlassian.net/browse/ADVAPP-2854

### Technical Description

Allows category descriptions to be null. Fixes authentication so that it is consistent with auth for customer advisors which already works well. Aiding App does not use the same portal auth method since it uses session auth rather than a token in local storage.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
