### PR TITLE
[ADVAPP-2855], [ADVAPP-2856], [ADVAPP-2857], [ADVAPP-2858], [ADVAPP-2859], [ADVAPP-2860]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
         "orrison/meliorstan": "^0.4.1",
         "owen-it/laravel-auditing": "^14.0",
         "php-mime-mail-parser/php-mime-mail-parser": "^9.0",
+        "phpoffice/phpspreadsheet": "^1.30.6",
         "saade/filament-fullcalendar": "^4.0@beta",
         "sentry/sentry-laravel": "^4.16.0",
         "shuvroroy/filament-spatie-laravel-health": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "536a8b771af8392516ec9fde63bc56d7",
+    "content-hash": "080142219d8d933d480692f3483f9de0",
     "packages": [
         {
             "name": "ably/ably-php",
@@ -10394,16 +10394,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.30.5",
+            "version": "1.30.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "97bcabd32a64924688487dcd64aceaf158affb5c"
+                "reference": "a416375ffc8bf5b661c1bb4e6c60d8f3fddbe5ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/97bcabd32a64924688487dcd64aceaf158affb5c",
-                "reference": "97bcabd32a64924688487dcd64aceaf158affb5c",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/a416375ffc8bf5b661c1bb4e6c60d8f3fddbe5ce",
+                "reference": "a416375ffc8bf5b661c1bb4e6c60d8f3fddbe5ce",
                 "shasum": ""
             },
             "require": {
@@ -10496,9 +10496,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.30.5"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.30.6"
             },
-            "time": "2026-05-31T05:13:11+00:00"
+            "time": "2026-07-12T19:59:31+00:00"
         },
         {
             "name": "phpoption/phpoption",


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2855
- https://canyongbs.atlassian.net/browse/ADVAPP-2856
- https://canyongbs.atlassian.net/browse/ADVAPP-2857
- https://canyongbs.atlassian.net/browse/ADVAPP-2858
- https://canyongbs.atlassian.net/browse/ADVAPP-2859
- https://canyongbs.atlassian.net/browse/ADVAPP-2860

### Technical Description

Upgrade phpoffice/phpspreadsheet to v1.30.6 to resolve CVE-2026-59931

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
