### PR TITLE
Fix Copilot code review setup and request review only once per PR

### DIFF
--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -25,32 +25,31 @@ jobs:
 
         timeout-minutes: 15
 
-        env:
-            php-extensions: gd, gmp, redis, mailparse
-            php-extensions-key: ext-cache-copilot-v1
-            php-version: '8.4'
-
+        # NOTE: Copilot code review lifts these steps into its own runner and does NOT carry a
+        # job-level `env:` block, so the PHP config is inlined below rather than referenced via
+        # `${{ env.* }}`. Using job-level env here causes empty inputs (e.g. "Input required and
+        # not supplied: extensions"), which aborts setup and forces a limited default review.
         steps:
             - name: Setup cache environment
               id: extcache
               uses: shivammathur/cache-extensions@9b476298b44f2e4d4268dd103ff4c3e216314e27 #1.14.6
               with:
-                  php-version: ${{ env.php-version }}
-                  extensions: ${{ env.php-extensions }}
-                  key: ${{ env.php-extensions-key }}
+                  php-version: '8.4'
+                  extensions: gd, gmp, redis, mailparse
+                  key: ext-cache-copilot-v1
 
             - name: Cache extensions
               uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
               with:
                   path: ${{ steps.extcache.outputs.dir }}
-                  key: ${{ runner.os }}-phpext-${{ env.php-version }}-${{ env.php-extensions-key }}
-                  restore-keys: ${{ runner.os }}-phpext-${{ env.php-version }}
+                  key: ${{ runner.os }}-phpext-8.4-ext-cache-copilot-v1
+                  restore-keys: ${{ runner.os }}-phpext-8.4
 
             - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 #2.37.2
               with:
-                  php-version: ${{ env.php-version }}
+                  php-version: '8.4'
                   coverage: none
-                  extensions: ${{ env.php-extensions }}
+                  extensions: gd, gmp, redis, mailparse
 
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
               with:

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -440,6 +440,16 @@ jobs:
                   GH_REPOSITORY: ${{ github.repository }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
               run: |
+                  # Request Copilot at most once per PR. It is removed from requested_reviewers once
+                  # it finishes, so a pending-request check alone would re-request on every push.
+                  # Skip if Copilot has already submitted a review (diminishing returns on re-reviews);
+                  # a maintainer can still manually re-request from the PR UI when needed.
+                  reviewed=$(gh api "/repos/${GH_REPOSITORY}/pulls/${PR_NUMBER}/reviews" --paginate \
+                      --jq '.[].user.login')
+                  if echo "$reviewed" | grep -q 'copilot-pull-request-reviewer'; then
+                      echo 'Copilot has already reviewed this PR; not requesting again.'
+                      exit 0
+                  fi
                   existing=$(gh api "/repos/${GH_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" --jq '.users[].login')
                   if echo "$existing" | grep -q 'copilot-pull-request-reviewer'; then
                       echo 'Copilot review already requested.'


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

Two fixes to the automatic Copilot code review workflow.

**1. Copilot code review setup was failing → limited default review**

Since ~Aug 12, 2026, Copilot code review runs began posting "one or more custom setup steps failed" and falling back to a limited default review (without our `AGENTS.md`, skills, and guidelines). The failing step was `Setup cache environment` with `##[error]Input required and not supplied: extensions`.

Root cause: `copilot-code-review.yml` defined the PHP config in a **job-level `env:` block** and referenced it via `${{ env.php-extensions }}` etc. The Copilot code review runner lifts the `copilot-setup-steps` job's steps into its own harness and no longer propagates job-level `env`, so those expressions resolved to empty and the first step errored out, aborting setup.

The workflow file itself has not changed since it was added on Aug 4 — this is an undocumented behavior change on GitHub's side (corroborated by community reports; the official docs/changelog do not mention it). This only affects the code review runner; `copilot-setup-steps.yml` (the cloud coding agent) is intentionally left untouched.

Fix: inline the literal PHP version, extensions, and cache key directly into each step instead of relying on job-level `env`.

**2. Copilot was re-reviewing on every push**

The `request-copilot-review` job runs on every `pull_request` event (including `synchronize`), and its guard only checked the *currently requested* reviewers. Copilot is removed from `requested_reviewers` once it finishes, so every subsequent push re-requested a review — some PRs accumulated 5–11 Copilot reviews, with diminishing value.

Fix: the guard now checks whether Copilot has **ever submitted a review** on the PR (via the reviews API) and skips if so. Combined with the existing `needs: [test, lint]` green-gate, this yields exactly one automatic review per PR, at the first green state. Manual re-requests from the PR UI are unaffected.

### Any deployment steps required?

No

### Cleanup Tasks

N/A
