### PR TITLE
[ADVAPP-2889]: Refactor the way automated chat naming works

### DIFF
--- a/.cleanup-tasks/2026_08_14_ai_thread_auto_naming_feature.md
+++ b/.cleanup-tasks/2026_08_14_ai_thread_auto_naming_feature.md
@@ -11,5 +11,5 @@ created: 2026-08-14
 
 ## Additional Cleanup
 
-- In `BaseOpenAiService::sendMessage()`, delete the entire inner try/catch block inside the outer `finally` that names the thread when `AiThreadAutoNamingFeature` is inactive. Thread naming is now handled by `GenerateAiThreadName`, dispatched from `SendAdvisorMessage` after three exchanges.
+- In `BaseOpenAiService::sendNewMessage()`, delete the entire inner try/catch block inside the outer `finally` that names the thread when `AiThreadAutoNamingFeature` is inactive.
 - In `TestAiService::sendMessage()`, delete the `if` block that fakes a thread name when `AiThreadAutoNamingFeature` is inactive, for the same reason.

--- a/.cleanup-tasks/2026_08_14_ai_thread_auto_naming_feature.md
+++ b/.cleanup-tasks/2026_08_14_ai_thread_auto_naming_feature.md
@@ -1,0 +1,15 @@
+---
+title: AI Thread Auto Naming Feature
+created: 2026-08-14
+---
+
+## Feature Flags
+
+- App\Features\AiThreadAutoNamingFeature
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+- In `BaseOpenAiService::sendMessage()`, delete the entire inner try/catch block inside the outer `finally` that names the thread when `AiThreadAutoNamingFeature` is inactive. Thread naming is now handled by `GenerateAiThreadName`, dispatched from `SendAdvisorMessage` after three exchanges.
+- In `TestAiService::sendMessage()`, delete the `if` block that fakes a thread name when `AiThreadAutoNamingFeature` is inactive, for the same reason.

--- a/app-modules/ai/database/migrations/2026_08_14_134958_add_named_by_user_at_column_to_ai_threads_table.php
+++ b/app-modules/ai/database/migrations/2026_08_14_134958_add_named_by_user_at_column_to_ai_threads_table.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Features\AiThreadAutoNamingFeature;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;

--- a/app-modules/ai/database/migrations/2026_08_14_134958_add_named_by_user_at_column_to_ai_threads_table.php
+++ b/app-modules/ai/database/migrations/2026_08_14_134958_add_named_by_user_at_column_to_ai_threads_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Features\AiThreadAutoNamingFeature;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::transaction(function () {
+            Schema::table('ai_threads', function (Blueprint $table) {
+                $table->dateTime('named_by_user_at')->nullable();
+            });
+
+            AiThreadAutoNamingFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            AiThreadAutoNamingFeature::deactivate();
+
+            Schema::table('ai_threads', function (Blueprint $table) {
+                $table->dropColumn('named_by_user_at');
+            });
+        });
+    }
+};

--- a/app-modules/ai/resources/js/chat.js
+++ b/app-modules/ai/resources/js/chat.js
@@ -398,6 +398,11 @@ document.addEventListener('alpine:init', () => {
                 }
 
                 this.$wire.refreshThreads();
+
+                // The thread may be renamed by a background AI job shortly after this
+                // exchange completes (see GenerateAiThreadName). Re-check for an updated
+                // name a few seconds later so the sidebar doesn't wait for the next message.
+                setTimeout(() => this.$wire.refreshThreads(), 5000);
             },
 
             handleResponse: async function ({ response }) {

--- a/app-modules/ai/resources/js/chat.js
+++ b/app-modules/ai/resources/js/chat.js
@@ -306,6 +306,13 @@ document.addEventListener('alpine:init', () => {
                             ADD_TAGS: ['a'],
                             ADD_ATTR: ['href', 'title'],
                         });
+                    })
+                    .listen('.advisor-thread.renamed', () => {
+                        // The thread may be renamed by a background AI job shortly after
+                        // an exchange completes (see GenerateAiThreadName). This event is
+                        // broadcast once the new name has been saved, so the sidebar can
+                        // update immediately instead of waiting for the next message.
+                        this.$wire.refreshThreads();
                     });
 
                 this.isLoading = false;
@@ -398,11 +405,6 @@ document.addEventListener('alpine:init', () => {
                 }
 
                 this.$wire.refreshThreads();
-
-                // The thread may be renamed by a background AI job shortly after this
-                // exchange completes (see GenerateAiThreadName). Re-check for an updated
-                // name a few seconds later so the sidebar doesn't wait for the next message.
-                setTimeout(() => this.$wire.refreshThreads(), 5000);
             },
 
             handleResponse: async function ({ response }) {

--- a/app-modules/ai/src/Actions/CreateThread.php
+++ b/app-modules/ai/src/Actions/CreateThread.php
@@ -42,6 +42,7 @@ use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Settings\AiSettings;
 use App\Features\AiThreadAutoNamingFeature;
 use App\Models\Tenant;
+use App\Settings\DisplaySettings;
 
 class CreateThread
 {
@@ -80,7 +81,7 @@ class CreateThread
 
     protected function getDefaultThreadName(): string
     {
-        return 'New Chat ' . now()->format('n/j/y @ g:i A');
+        return 'New Chat ' . now()->setTimezone(app(DisplaySettings::class)->getTimezone())->format('n/j/y @ g:i A');
     }
 
     protected function getDefaultAiAssistant(AiAssistantApplication $application): AiAssistant

--- a/app-modules/ai/src/Actions/CreateThread.php
+++ b/app-modules/ai/src/Actions/CreateThread.php
@@ -40,6 +40,7 @@ use AdvisingApp\Ai\Enums\AiAssistantApplication;
 use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Settings\AiSettings;
+use App\Features\AiThreadAutoNamingFeature;
 use App\Models\Tenant;
 
 class CreateThread
@@ -48,11 +49,17 @@ class CreateThread
     {
         $assistant ??= $this->getDefaultAiAssistant($application);
 
-        $existingThread = auth()->user()->aiThreads()
-            ->whereNull('name')
+        $existingThreadQuery = auth()->user()->aiThreads()
             ->whereBelongsTo($assistant, 'assistant')
-            ->whereDoesntHave('messages')
-            ->first();
+            ->whereDoesntHave('messages');
+
+        if (AiThreadAutoNamingFeature::active()) {
+            $existingThreadQuery->whereNull('named_by_user_at');
+        } else {
+            $existingThreadQuery->whereNull('name');
+        }
+
+        $existingThread = $existingThreadQuery->first();
 
         if ($existingThread) {
             return $existingThread;
@@ -61,9 +68,19 @@ class CreateThread
         $thread = new AiThread();
         $thread->assistant()->associate($assistant);
         $thread->user()->associate(auth()->user());
+
+        if (AiThreadAutoNamingFeature::active()) {
+            $thread->name = $this->getDefaultThreadName();
+        }
+
         $thread->save();
 
         return $thread;
+    }
+
+    protected function getDefaultThreadName(): string
+    {
+        return 'New Chat ' . now()->format('n/j/y @ g:i A');
     }
 
     protected function getDefaultAiAssistant(AiAssistantApplication $application): AiAssistant

--- a/app-modules/ai/src/Events/Advisors/AdvisorThreadRenamed.php
+++ b/app-modules/ai/src/Events/Advisors/AdvisorThreadRenamed.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Ai\Events\Advisors;
+
+use AdvisingApp\Ai\Models\AiThread;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class AdvisorThreadRenamed implements ShouldBroadcastNow
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    public function __construct(
+        public AiThread $thread,
+    ) {}
+
+    public function broadcastAs(): string
+    {
+        return 'advisor-thread.renamed';
+    }
+
+    /**
+     * The frontend only uses this event as a signal to refresh the thread
+     * list, so no payload data is needed. This is kept explicit (rather than
+     * omitted) to avoid Laravel's default behavior of broadcasting every
+     * public property, which would serialize the entire thread model.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [
+            new PrivateChannel("advisor-thread-{$this->thread->getKey()}"),
+        ];
+    }
+}

--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManageThreads.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManageThreads.php
@@ -44,6 +44,7 @@ use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Rules\RestrictSuperAdmin;
 use AdvisingApp\Team\Models\Department;
+use App\Features\AiThreadAutoNamingFeature;
 use App\Models\Scopes\WithoutAnyAdmin;
 use App\Models\User;
 use Exception;
@@ -247,9 +248,13 @@ trait CanManageThreads
 
         $thread = AiThread::find($thread['id']);
 
+        $isCurrentThreadUnused = AiThreadAutoNamingFeature::active()
+            ? blank($this->thread?->named_by_user_at)
+            : blank($this->thread?->name);
+
         if (
             $this->thread &&
-            blank($this->thread->name) &&
+            $isCurrentThreadUnused &&
             (! $this->thread->messages()->exists())
         ) {
             $this->thread->delete();
@@ -323,6 +328,11 @@ trait CanManageThreads
                 }
 
                 $thread->name = $data['name'];
+
+                if (AiThreadAutoNamingFeature::active()) {
+                    $thread->named_by_user_at = now();
+                }
+
                 $thread->save();
 
                 $this->threadsWithoutAFolder = $this->getThreadsWithoutAFolder();

--- a/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManageThreads.php
+++ b/app-modules/ai/src/Filament/Pages/Assistant/Concerns/CanManageThreads.php
@@ -248,6 +248,10 @@ trait CanManageThreads
 
         $thread = AiThread::find($thread['id']);
 
+        if (! $thread) {
+            return;
+        }
+
         $isCurrentThreadUnused = AiThreadAutoNamingFeature::active()
             ? blank($this->thread?->named_by_user_at)
             : blank($this->thread?->name);

--- a/app-modules/ai/src/Jobs/Advisors/CloneAiThread.php
+++ b/app-modules/ai/src/Jobs/Advisors/CloneAiThread.php
@@ -75,7 +75,7 @@ class CloneAiThread implements ShouldQueue
         try {
             DB::beginTransaction();
 
-            $threadReplica = $this->thread->replicate(except: ['id', 'thread_id', 'folder_id', 'saved_at', 'emailed_count', 'cloned_count']);
+            $threadReplica = $this->thread->replicate(except: ['id', 'thread_id', 'folder_id', 'saved_at', 'named_by_user_at', 'emailed_count', 'cloned_count']);
             $threadReplica->saved_at = now();
 
             $threadReplica->user()->associate($this->recipient);

--- a/app-modules/ai/src/Jobs/Advisors/CloneAiThread.php
+++ b/app-modules/ai/src/Jobs/Advisors/CloneAiThread.php
@@ -81,7 +81,7 @@ class CloneAiThread implements ShouldQueue
             $threadReplica->user()->associate($this->recipient);
             $threadReplica->save();
 
-            foreach ($this->thread->messages as $message) {
+            foreach ($this->thread->messages()->oldest()->get() as $message) {
                 $messageReplica = $message->replicate(['id', 'message_id']);
                 $messageReplica->thread()->associate($threadReplica);
                 $messageReplica->save();

--- a/app-modules/ai/src/Jobs/Advisors/GenerateAiThreadName.php
+++ b/app-modules/ai/src/Jobs/Advisors/GenerateAiThreadName.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Ai\Jobs\Advisors;
 
+use AdvisingApp\Ai\Events\Advisors\AdvisorThreadRenamed;
 use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Report\Enums\TrackedEventType;
@@ -101,6 +102,8 @@ class GenerateAiThreadName implements ShouldQueue
         $this->thread->name = trim($name);
         $this->thread->saved_at = now();
         $this->thread->save();
+
+        event(new AdvisorThreadRenamed($this->thread));
 
         dispatch(new RecordTrackedEvent(
             type: TrackedEventType::AiThreadSaved,

--- a/app-modules/ai/src/Jobs/Advisors/GenerateAiThreadName.php
+++ b/app-modules/ai/src/Jobs/Advisors/GenerateAiThreadName.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Ai\Jobs\Advisors;
+
+use AdvisingApp\Ai\Models\AiMessage;
+use AdvisingApp\Ai\Models\AiThread;
+use AdvisingApp\Report\Enums\TrackedEventType;
+use AdvisingApp\Report\Jobs\RecordTrackedEvent;
+use App\Features\AiThreadAutoNamingFeature;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Throwable;
+
+class GenerateAiThreadName implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(
+        protected AiThread $thread,
+    ) {}
+
+    public function handle(): void
+    {
+        if (! AiThreadAutoNamingFeature::active()) {
+            return;
+        }
+
+        // The thread may have been renamed by the user between when this job was
+        // dispatched and when it runs, in which case it must not be overwritten.
+        if (filled($this->thread->fresh()?->named_by_user_at)) {
+            return;
+        }
+
+        $transcript = $this->thread->messages()
+            ->oldest()
+            ->get()
+            ->map(fn (AiMessage $message): string => ($message->user_id ? 'User' : 'Assistant') . ": {$message->content}")
+            ->implode(PHP_EOL . PHP_EOL);
+
+        $prompt = $this->thread->assistant->instructions . "\nThe following is a chat between you and a user:\n" . $transcript;
+
+        $aiService = $this->thread->assistant->model->getService();
+
+        try {
+            $name = $aiService->complete(
+                $prompt,
+                'Generate a title for this chat, in 5 words or less. Do not respond with any greetings or salutations, and do not include any additional information or context. Just respond with the title:',
+            );
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return;
+        }
+
+        if (filled($this->thread->fresh()?->named_by_user_at)) {
+            return;
+        }
+
+        $this->thread->name = trim($name);
+        $this->thread->saved_at = now();
+        $this->thread->save();
+
+        dispatch(new RecordTrackedEvent(
+            type: TrackedEventType::AiThreadSaved,
+            occurredAt: now(),
+        ));
+    }
+}

--- a/app-modules/ai/src/Jobs/Advisors/GenerateAiThreadName.php
+++ b/app-modules/ai/src/Jobs/Advisors/GenerateAiThreadName.php
@@ -39,8 +39,6 @@ namespace AdvisingApp\Ai\Jobs\Advisors;
 use AdvisingApp\Ai\Events\Advisors\AdvisorThreadRenamed;
 use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiThread;
-use AdvisingApp\Report\Enums\TrackedEventType;
-use AdvisingApp\Report\Jobs\RecordTrackedEvent;
 use App\Features\AiThreadAutoNamingFeature;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -56,7 +54,7 @@ class GenerateAiThreadName implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public int $tries = 3;
+    public int $tries = 1;
 
     public function __construct(
         protected AiThread $thread,
@@ -68,9 +66,12 @@ class GenerateAiThreadName implements ShouldQueue
             return;
         }
 
-        // The thread may have been renamed by the user between when this job was
-        // dispatched and when it runs, in which case it must not be overwritten.
-        if (filled($this->thread->fresh()?->named_by_user_at)) {
+        // The thread may have been renamed by the user, or deleted entirely, between
+        // when this job was dispatched and when it runs, in which case it must not be
+        // overwritten.
+        $thread = $this->thread->fresh();
+
+        if (! $thread || $thread->trashed() || filled($thread->named_by_user_at)) {
             return;
         }
 
@@ -95,19 +96,25 @@ class GenerateAiThreadName implements ShouldQueue
             return;
         }
 
-        if (filled($this->thread->fresh()?->named_by_user_at)) {
+        $name = trim($name);
+
+        if ($name === '') {
             return;
         }
 
-        $this->thread->name = trim($name);
-        $this->thread->saved_at = now();
+        $thread = $this->thread->fresh();
+
+        if (! $thread || $thread->trashed() || filled($thread->named_by_user_at)) {
+            return;
+        }
+
+        $this->thread->name = $name;
         $this->thread->save();
 
-        event(new AdvisorThreadRenamed($this->thread));
-
-        dispatch(new RecordTrackedEvent(
-            type: TrackedEventType::AiThreadSaved,
-            occurredAt: now(),
-        ));
+        try {
+            event(new AdvisorThreadRenamed($this->thread));
+        } catch (Throwable $exception) {
+            report($exception);
+        }
     }
 }

--- a/app-modules/ai/src/Jobs/Advisors/RetryAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/RetryAdvisorMessage.php
@@ -47,6 +47,7 @@ use AdvisingApp\Ai\Support\StreamingChunks\Image;
 use AdvisingApp\Ai\Support\StreamingChunks\Meta;
 use AdvisingApp\Ai\Support\StreamingChunks\Text;
 use AdvisingApp\Ai\Support\StreamingChunks\Thinking;
+use App\Features\AiThreadAutoNamingFeature;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection;
@@ -211,6 +212,14 @@ class RetryAdvisorMessage implements ShouldQueue
 
         $response->save();
         $this->thread->touch();
+
+        if (
+            AiThreadAutoNamingFeature::active() &&
+            blank($this->thread->named_by_user_at) &&
+            ($this->thread->messages()->whereNotNull('user_id')->count() === 3)
+        ) {
+            dispatch(new GenerateAiThreadName($this->thread));
+        }
     }
 
     public function tries(): int

--- a/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
@@ -49,6 +49,7 @@ use AdvisingApp\Ai\Support\StreamingChunks\Image;
 use AdvisingApp\Ai\Support\StreamingChunks\Meta;
 use AdvisingApp\Ai\Support\StreamingChunks\Text;
 use AdvisingApp\Ai\Support\StreamingChunks\Thinking;
+use App\Features\AiThreadAutoNamingFeature;
 use Filament\Forms\Components\RichEditor\RichContentRenderer;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -249,6 +250,14 @@ class SendAdvisorMessage implements ShouldQueue
                 'updated_at' => $message->created_at,
             ]);
         });
+
+        if (
+            AiThreadAutoNamingFeature::active() &&
+            blank($this->thread->named_by_user_at) &&
+            ($this->thread->messages()->whereNotNull('user_id')->count() === 3)
+        ) {
+            GenerateAiThreadName::dispatch($this->thread);
+        }
     }
 
     public function tries(): int

--- a/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
@@ -49,6 +49,8 @@ use AdvisingApp\Ai\Support\StreamingChunks\Image;
 use AdvisingApp\Ai\Support\StreamingChunks\Meta;
 use AdvisingApp\Ai\Support\StreamingChunks\Text;
 use AdvisingApp\Ai\Support\StreamingChunks\Thinking;
+use AdvisingApp\Report\Enums\TrackedEventType;
+use AdvisingApp\Report\Jobs\RecordTrackedEvent;
 use App\Features\AiThreadAutoNamingFeature;
 use Filament\Forms\Components\RichEditor\RichContentRenderer;
 use Illuminate\Bus\Queueable;
@@ -123,6 +125,16 @@ class SendAdvisorMessage implements ShouldQueue
         }
 
         $message->save();
+
+        if (blank($this->thread->saved_at)) {
+            $this->thread->saved_at = now();
+            $this->thread->save();
+
+            dispatch(new RecordTrackedEvent(
+                type: TrackedEventType::AiThreadSaved,
+                occurredAt: now(),
+            ));
+        }
 
         $aiService = $this->thread->assistant->model->getService();
 
@@ -256,7 +268,7 @@ class SendAdvisorMessage implements ShouldQueue
             blank($this->thread->named_by_user_at) &&
             ($this->thread->messages()->whereNotNull('user_id')->count() === 3)
         ) {
-            GenerateAiThreadName::dispatch($this->thread);
+            dispatch(new GenerateAiThreadName($this->thread));
         }
     }
 

--- a/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
+++ b/app-modules/ai/src/Jobs/Advisors/SendAdvisorMessage.php
@@ -126,7 +126,7 @@ class SendAdvisorMessage implements ShouldQueue
 
         $message->save();
 
-        if (blank($this->thread->saved_at)) {
+        if (AiThreadAutoNamingFeature::active() && blank($this->thread->saved_at)) {
             $this->thread->saved_at = now();
             $this->thread->save();
 

--- a/app-modules/ai/src/Models/AiThread.php
+++ b/app-modules/ai/src/Models/AiThread.php
@@ -80,6 +80,7 @@ class AiThread extends BaseModel implements HasMedia, Wireable
         'locked_at',
         'locked_reason',
         'is_preview',
+        'named_by_user_at',
     ];
 
     protected $casts = [
@@ -87,6 +88,7 @@ class AiThread extends BaseModel implements HasMedia, Wireable
         'locked_reason' => AiThreadLockedReason::class,
         'saved_at' => 'datetime',
         'is_preview' => 'boolean',
+        'named_by_user_at' => 'datetime',
     ];
 
     protected $dispatchesEvents = [
@@ -110,6 +112,8 @@ class AiThread extends BaseModel implements HasMedia, Wireable
     }
 
     /**
+     * @phpstan-impure
+     *
      * @return HasMany<AiMessage, $this>
      */
     public function messages(): HasMany

--- a/app-modules/ai/src/Services/TestAiService.php
+++ b/app-modules/ai/src/Services/TestAiService.php
@@ -45,6 +45,7 @@ use AdvisingApp\Ai\Support\StreamingChunks\Text;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Jobs\RecordTrackedEvent;
 use AdvisingApp\Research\Models\ResearchRequest;
+use App\Features\AiThreadAutoNamingFeature;
 use Closure;
 use Exception;
 use Generator;
@@ -94,8 +95,10 @@ class TestAiService implements AiService
         $message->context = fake()->paragraph();
         $message->save();
 
-        $message->thread->name = fake()->words();
-        $message->thread->save();
+        if (! AiThreadAutoNamingFeature::active()) {
+            $message->thread->name = fake()->words();
+            $message->thread->save();
+        }
 
         if ($message->wasRecentlyCreated || $message->wasChanged('content')) {
             dispatch(new RecordTrackedEvent(

--- a/app-modules/ai/tests/Tenant/Feature/Actions/CreateThreadTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Actions/CreateThreadTest.php
@@ -41,6 +41,7 @@ use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Settings\AiSettings;
+use App\Features\AiThreadAutoNamingFeature;
 use App\Models\Tenant;
 use App\Models\User;
 
@@ -65,6 +66,52 @@ it('creates a new thread', function () {
         ->assistant->toBe($assistant)
         ->user->toBe(auth()->user())
         ->wasRecentlyCreated->toBeTrue();
+});
+
+it('gives a new thread a default name stamped with the current date and time', function () {
+    AiThreadAutoNamingFeature::activate();
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $settings = app(AiSettings::class);
+    $settings->default_model = AiModel::Test;
+    $settings->save();
+
+    $now = now();
+
+    $thread = app(CreateThread::class)(AiAssistantApplication::Test, $assistant);
+
+    expect($thread->name)
+        ->toBe('New Chat ' . $now->format('n/j/y @ g:i A'))
+        ->and($thread->named_by_user_at)
+        ->toBeNull();
+});
+
+it('does not give a new thread a default name when the auto naming feature is inactive', function () {
+    AiThreadAutoNamingFeature::deactivate();
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $settings = app(AiSettings::class);
+    $settings->default_model = AiModel::Test;
+    $settings->save();
+
+    $thread = app(CreateThread::class)(AiAssistantApplication::Test, $assistant);
+
+    expect($thread->name)
+        ->toBeNull();
 });
 
 it('does not create a new thread if an empty existing one exists', function () {
@@ -175,7 +222,67 @@ it('does not match existing threads belonging to other assistants', function () 
         ->not->toBe($thread->getKey());
 });
 
-it('does not match existing saved threads (with a name)', function () {
+it('reuses an existing thread with a default name when the auto naming feature is active', function () {
+    AiThreadAutoNamingFeature::activate();
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->create([
+            'name' => 'New Chat 8/13/26 @ 7:10 AM',
+            'named_by_user_at' => null,
+        ]);
+
+    $settings = app(AiSettings::class);
+    $settings->default_model = AiModel::Test;
+    $settings->save();
+
+    $existingThread = app(CreateThread::class)(AiAssistantApplication::Test, $assistant);
+
+    expect($existingThread->getKey())
+        ->toBe($thread->getKey());
+});
+
+it('does not match existing threads that have been renamed by the user', function () {
+    AiThreadAutoNamingFeature::activate();
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->create([
+            'name' => 'Test',
+            'named_by_user_at' => now(),
+        ]);
+
+    $settings = app(AiSettings::class);
+    $settings->default_model = AiModel::Test;
+    $settings->save();
+
+    $newThread = app(CreateThread::class)(AiAssistantApplication::Test, $assistant);
+
+    expect($newThread->getKey())
+        ->not->toBe($thread->getKey());
+});
+
+it('does not match existing saved threads (with a name) when the auto naming feature is inactive', function () {
+    AiThreadAutoNamingFeature::deactivate();
+
     asSuperAdmin();
 
     $assistant = AiAssistant::factory()->create([

--- a/app-modules/ai/tests/Tenant/Feature/Actions/CreateThreadTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Actions/CreateThreadTest.php
@@ -69,8 +69,10 @@ it('creates a new thread', function () {
         ->wasRecentlyCreated->toBeTrue();
 });
 
-it('gives a new thread a default name stamped with the current date and time', function () {
-    asSuperAdmin();
+it('gives a new thread a default name stamped with the current date and time in the user\'s timezone', function () {
+    asSuperAdmin(User::factory()->create([
+        'timezone' => 'America/Chicago',
+    ]));
 
     $assistant = AiAssistant::factory()->create([
         'application' => AiAssistantApplication::Test,
@@ -91,7 +93,7 @@ it('gives a new thread a default name stamped with the current date and time', f
         $thread = app(CreateThread::class)(AiAssistantApplication::Test, $assistant);
 
         expect($thread->name)
-            ->toBe('New Chat ' . $now->format('n/j/y @ g:i A'))
+            ->toBe('New Chat ' . $now->clone()->setTimezone('America/Chicago')->format('n/j/y @ g:i A'))
             ->and($thread->named_by_user_at)
             ->toBeNull();
     } finally {

--- a/app-modules/ai/tests/Tenant/Feature/Actions/CreateThreadTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Actions/CreateThreadTest.php
@@ -41,10 +41,11 @@ use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Settings\AiSettings;
-use App\Features\AiThreadAutoNamingFeature;
 use App\Models\Tenant;
 use App\Models\User;
 
+use function Pest\Laravel\travelBack;
+use function Pest\Laravel\travelTo;
 use function Tests\asSuperAdmin;
 
 it('creates a new thread', function () {
@@ -69,8 +70,6 @@ it('creates a new thread', function () {
 });
 
 it('gives a new thread a default name stamped with the current date and time', function () {
-    AiThreadAutoNamingFeature::activate();
-
     asSuperAdmin();
 
     $assistant = AiAssistant::factory()->create([
@@ -83,35 +82,21 @@ it('gives a new thread a default name stamped with the current date and time', f
     $settings->default_model = AiModel::Test;
     $settings->save();
 
+    // Freeze time so the captured `$now` can't drift from the `now()` call
+    // inside CreateThread if the minute flips in between, which would be flaky.
     $now = now();
+    travelTo($now);
 
-    $thread = app(CreateThread::class)(AiAssistantApplication::Test, $assistant);
+    try {
+        $thread = app(CreateThread::class)(AiAssistantApplication::Test, $assistant);
 
-    expect($thread->name)
-        ->toBe('New Chat ' . $now->format('n/j/y @ g:i A'))
-        ->and($thread->named_by_user_at)
-        ->toBeNull();
-});
-
-it('does not give a new thread a default name when the auto naming feature is inactive', function () {
-    AiThreadAutoNamingFeature::deactivate();
-
-    asSuperAdmin();
-
-    $assistant = AiAssistant::factory()->create([
-        'application' => AiAssistantApplication::Test,
-        'is_default' => true,
-        'model' => AiModel::Test,
-    ]);
-
-    $settings = app(AiSettings::class);
-    $settings->default_model = AiModel::Test;
-    $settings->save();
-
-    $thread = app(CreateThread::class)(AiAssistantApplication::Test, $assistant);
-
-    expect($thread->name)
-        ->toBeNull();
+        expect($thread->name)
+            ->toBe('New Chat ' . $now->format('n/j/y @ g:i A'))
+            ->and($thread->named_by_user_at)
+            ->toBeNull();
+    } finally {
+        travelBack();
+    }
 });
 
 it('does not create a new thread if an empty existing one exists', function () {
@@ -222,38 +207,7 @@ it('does not match existing threads belonging to other assistants', function () 
         ->not->toBe($thread->getKey());
 });
 
-it('reuses an existing thread with a default name when the auto naming feature is active', function () {
-    AiThreadAutoNamingFeature::activate();
-
-    asSuperAdmin();
-
-    $assistant = AiAssistant::factory()->create([
-        'application' => AiAssistantApplication::Test,
-        'is_default' => true,
-        'model' => AiModel::Test,
-    ]);
-
-    $thread = AiThread::factory()
-        ->for($assistant, 'assistant')
-        ->for(auth()->user())
-        ->create([
-            'name' => 'New Chat 8/13/26 @ 7:10 AM',
-            'named_by_user_at' => null,
-        ]);
-
-    $settings = app(AiSettings::class);
-    $settings->default_model = AiModel::Test;
-    $settings->save();
-
-    $existingThread = app(CreateThread::class)(AiAssistantApplication::Test, $assistant);
-
-    expect($existingThread->getKey())
-        ->toBe($thread->getKey());
-});
-
 it('does not match existing threads that have been renamed by the user', function () {
-    AiThreadAutoNamingFeature::activate();
-
     asSuperAdmin();
 
     $assistant = AiAssistant::factory()->create([
@@ -268,34 +222,6 @@ it('does not match existing threads that have been renamed by the user', functio
         ->create([
             'name' => 'Test',
             'named_by_user_at' => now(),
-        ]);
-
-    $settings = app(AiSettings::class);
-    $settings->default_model = AiModel::Test;
-    $settings->save();
-
-    $newThread = app(CreateThread::class)(AiAssistantApplication::Test, $assistant);
-
-    expect($newThread->getKey())
-        ->not->toBe($thread->getKey());
-});
-
-it('does not match existing saved threads (with a name) when the auto naming feature is inactive', function () {
-    AiThreadAutoNamingFeature::deactivate();
-
-    asSuperAdmin();
-
-    $assistant = AiAssistant::factory()->create([
-        'application' => AiAssistantApplication::Test,
-        'is_default' => true,
-        'model' => AiModel::Test,
-    ]);
-
-    $thread = AiThread::factory()
-        ->for($assistant, 'assistant')
-        ->for(auth()->user())
-        ->create([
-            'name' => 'Test',
         ]);
 
     $settings = app(AiSettings::class);

--- a/app-modules/ai/tests/Tenant/Feature/Filament/Pages/AIAssistantPageTest.php
+++ b/app-modules/ai/tests/Tenant/Feature/Filament/Pages/AIAssistantPageTest.php
@@ -818,6 +818,9 @@ it('can rename a thread', function () use ($setUp) {
         'id' => $thread->getKey(),
         'name' => $name,
     ]);
+
+    expect($thread->refresh()->named_by_user_at)
+        ->not->toBeNull();
 });
 
 it('can not rename a thread without a name', function () use ($setUp) {

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/CloneAiThreadTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/CloneAiThreadTest.php
@@ -73,12 +73,12 @@ it('can clone a thread and its messages', function () {
         ->for($sender, 'user')
         ->create();
 
-    $originalMessages = $thread->messages;
+    $originalMessages = $thread->messages()->oldest()->get();
     dispatch(new CloneAiThread($thread, $sender, $recipient));
 
     $recipient->refresh();
     $clonedThread = $recipient->aiThreads()->latest()->first();
-    $clonedMessages = $clonedThread->messages;
+    $clonedMessages = $clonedThread->messages()->oldest()->get();
 
     expect($clonedThread)->not->toBeNull();
     expect($clonedThread->getKey())->not->toBe($thread->getKey());

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/CloneAiThreadTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/CloneAiThreadTest.php
@@ -103,3 +103,32 @@ it('can clone a thread and its messages', function () {
 
     Notification::assertSentTo($recipient, DatabaseNotification::class);
 });
+
+it('does not carry over the named_by_user_at state when cloning a thread', function () {
+    Notification::fake();
+
+    $sender = User::factory()->licensed(LicenseType::cases())->create();
+    $recipient = User::factory()->licensed(LicenseType::cases())->create();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->has(AiMessage::factory()->count(1), 'messages')
+        ->for($sender, 'user')
+        ->create([
+            'named_by_user_at' => now(),
+        ]);
+
+    dispatch(new CloneAiThread($thread, $sender, $recipient));
+
+    $recipient->refresh();
+    $clonedThread = $recipient->aiThreads()->latest()->first();
+
+    expect($thread->refresh()->named_by_user_at)->not->toBeNull();
+    expect($clonedThread->named_by_user_at)->toBeNull();
+});

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/GenerateAiThreadNameTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/GenerateAiThreadNameTest.php
@@ -43,7 +43,6 @@ use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Services\TestAiService;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Jobs\RecordTrackedEvent;
-use App\Features\AiThreadAutoNamingFeature;
 use Illuminate\Support\Facades\Bus;
 
 use function Tests\asSuperAdmin;
@@ -68,8 +67,6 @@ function createNamingTestThread(): AiThread
 }
 
 it('renames a thread using the AI service and marks it as saved', function () {
-    AiThreadAutoNamingFeature::activate();
-
     asSuperAdmin();
 
     Bus::fake([RecordTrackedEvent::class]);
@@ -93,8 +90,6 @@ it('renames a thread using the AI service and marks it as saved', function () {
 });
 
 it('does not rename a thread that has already been renamed by the user', function () {
-    AiThreadAutoNamingFeature::activate();
-
     asSuperAdmin();
 
     Bus::fake([RecordTrackedEvent::class]);
@@ -111,25 +106,6 @@ it('does not rename a thread that has already been renamed by the user', functio
 
     expect($thread->name)
         ->toBe('My Custom Name');
-
-    Bus::assertNotDispatched(RecordTrackedEvent::class);
-});
-
-it('does nothing when the auto naming feature is inactive', function () {
-    AiThreadAutoNamingFeature::deactivate();
-
-    asSuperAdmin();
-
-    Bus::fake([RecordTrackedEvent::class]);
-
-    $thread = createNamingTestThread();
-
-    app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
-
-    $thread->refresh();
-
-    expect($thread->name)
-        ->toBe('New Chat 8/13/26 @ 7:10 AM');
 
     Bus::assertNotDispatched(RecordTrackedEvent::class);
 });
@@ -152,8 +128,6 @@ function bindFakeAiService(Closure $complete): void
 }
 
 it('reports the exception and leaves the thread unnamed when the AI service fails', function () {
-    AiThreadAutoNamingFeature::activate();
-
     asSuperAdmin();
 
     Bus::fake([RecordTrackedEvent::class]);
@@ -177,8 +151,6 @@ it('reports the exception and leaves the thread unnamed when the AI service fail
 });
 
 it('does not rename a thread that got renamed by the user while the AI service was generating a name', function () {
-    AiThreadAutoNamingFeature::activate();
-
     asSuperAdmin();
 
     Bus::fake([RecordTrackedEvent::class]);

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/GenerateAiThreadNameTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/GenerateAiThreadNameTest.php
@@ -99,6 +99,8 @@ it('saves the name and reports the exception if broadcasting AdvisorThreadRename
 
     Exceptions::fake();
 
+    config(['broadcasting.default' => 'null']);
+
     Event::listen(AdvisorThreadRenamed::class, function (): void {
         throw new Exception('The broadcast connection is down.');
     });

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/GenerateAiThreadNameTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/GenerateAiThreadNameTest.php
@@ -36,6 +36,7 @@
 
 use AdvisingApp\Ai\Enums\AiAssistantApplication;
 use AdvisingApp\Ai\Enums\AiModel;
+use AdvisingApp\Ai\Events\Advisors\AdvisorThreadRenamed;
 use AdvisingApp\Ai\Jobs\Advisors\GenerateAiThreadName;
 use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiMessage;
@@ -44,6 +45,7 @@ use AdvisingApp\Ai\Services\TestAiService;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Jobs\RecordTrackedEvent;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
 
 use function Tests\asSuperAdmin;
 
@@ -70,6 +72,7 @@ it('renames a thread using the AI service and marks it as saved', function () {
     asSuperAdmin();
 
     Bus::fake([RecordTrackedEvent::class]);
+    Event::fake([AdvisorThreadRenamed::class]);
 
     $thread = createNamingTestThread();
 
@@ -87,12 +90,15 @@ it('renames a thread using the AI service and marks it as saved', function () {
         ->toBeNull();
 
     Bus::assertDispatched(RecordTrackedEvent::class, fn (RecordTrackedEvent $job) => $job->type === TrackedEventType::AiThreadSaved);
+
+    Event::assertDispatched(AdvisorThreadRenamed::class, fn (AdvisorThreadRenamed $event) => $event->thread->is($thread) && $event->thread->name === $thread->name);
 });
 
 it('does not rename a thread that has already been renamed by the user', function () {
     asSuperAdmin();
 
     Bus::fake([RecordTrackedEvent::class]);
+    Event::fake([AdvisorThreadRenamed::class]);
 
     $thread = createNamingTestThread();
     $thread->update([
@@ -108,6 +114,8 @@ it('does not rename a thread that has already been renamed by the user', functio
         ->toBe('My Custom Name');
 
     Bus::assertNotDispatched(RecordTrackedEvent::class);
+
+    Event::assertNotDispatched(AdvisorThreadRenamed::class);
 });
 
 /**
@@ -131,6 +139,7 @@ it('reports the exception and leaves the thread unnamed when the AI service fail
     asSuperAdmin();
 
     Bus::fake([RecordTrackedEvent::class]);
+    Event::fake([AdvisorThreadRenamed::class]);
 
     $thread = createNamingTestThread();
 
@@ -148,12 +157,15 @@ it('reports the exception and leaves the thread unnamed when the AI service fail
         ->toBeNull();
 
     Bus::assertNotDispatched(RecordTrackedEvent::class);
+
+    Event::assertNotDispatched(AdvisorThreadRenamed::class);
 });
 
 it('does not rename a thread that got renamed by the user while the AI service was generating a name', function () {
     asSuperAdmin();
 
     Bus::fake([RecordTrackedEvent::class]);
+    Event::fake([AdvisorThreadRenamed::class]);
 
     $thread = createNamingTestThread();
 
@@ -174,4 +186,6 @@ it('does not rename a thread that got renamed by the user while the AI service w
         ->toBe('Renamed By User Mid-Flight');
 
     Bus::assertNotDispatched(RecordTrackedEvent::class);
+
+    Event::assertNotDispatched(AdvisorThreadRenamed::class);
 });

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/GenerateAiThreadNameTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/GenerateAiThreadNameTest.php
@@ -1,0 +1,205 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Ai\Enums\AiAssistantApplication;
+use AdvisingApp\Ai\Enums\AiModel;
+use AdvisingApp\Ai\Jobs\Advisors\GenerateAiThreadName;
+use AdvisingApp\Ai\Models\AiAssistant;
+use AdvisingApp\Ai\Models\AiMessage;
+use AdvisingApp\Ai\Models\AiThread;
+use AdvisingApp\Ai\Services\TestAiService;
+use AdvisingApp\Report\Enums\TrackedEventType;
+use AdvisingApp\Report\Jobs\RecordTrackedEvent;
+use App\Features\AiThreadAutoNamingFeature;
+use Illuminate\Support\Facades\Bus;
+
+use function Tests\asSuperAdmin;
+
+function createNamingTestThread(): AiThread
+{
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    return AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->has(AiMessage::factory()->for(auth()->user()), relationship: 'messages')
+        ->has(AiMessage::factory()->state(['user_id' => null]), relationship: 'messages')
+        ->create([
+            'name' => 'New Chat 8/13/26 @ 7:10 AM',
+            'named_by_user_at' => null,
+        ]);
+}
+
+it('renames a thread using the AI service and marks it as saved', function () {
+    AiThreadAutoNamingFeature::activate();
+
+    asSuperAdmin();
+
+    Bus::fake([RecordTrackedEvent::class]);
+
+    $thread = createNamingTestThread();
+
+    app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
+
+    $thread->refresh();
+
+    expect($thread->name)
+        ->not->toBe('New Chat 8/13/26 @ 7:10 AM')
+        ->and($thread->name)
+        ->not->toBeEmpty()
+        ->and($thread->saved_at)
+        ->not->toBeNull()
+        ->and($thread->named_by_user_at)
+        ->toBeNull();
+
+    Bus::assertDispatched(RecordTrackedEvent::class, fn (RecordTrackedEvent $job) => $job->type === TrackedEventType::AiThreadSaved);
+});
+
+it('does not rename a thread that has already been renamed by the user', function () {
+    AiThreadAutoNamingFeature::activate();
+
+    asSuperAdmin();
+
+    Bus::fake([RecordTrackedEvent::class]);
+
+    $thread = createNamingTestThread();
+    $thread->update([
+        'name' => 'My Custom Name',
+        'named_by_user_at' => now(),
+    ]);
+
+    app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
+
+    $thread->refresh();
+
+    expect($thread->name)
+        ->toBe('My Custom Name');
+
+    Bus::assertNotDispatched(RecordTrackedEvent::class);
+});
+
+it('does nothing when the auto naming feature is inactive', function () {
+    AiThreadAutoNamingFeature::deactivate();
+
+    asSuperAdmin();
+
+    Bus::fake([RecordTrackedEvent::class]);
+
+    $thread = createNamingTestThread();
+
+    app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
+
+    $thread->refresh();
+
+    expect($thread->name)
+        ->toBe('New Chat 8/13/26 @ 7:10 AM');
+
+    Bus::assertNotDispatched(RecordTrackedEvent::class);
+});
+
+/**
+ * @param Closure(): string $complete
+ */
+function bindFakeAiService(Closure $complete): void
+{
+    app()->bind(TestAiService::class, fn () => new class ($complete) extends TestAiService {
+        public function __construct(
+            protected Closure $complete,
+        ) {}
+
+        public function complete(string $prompt, string $content, bool $shouldTrack = true): string
+        {
+            return ($this->complete)();
+        }
+    });
+}
+
+it('reports the exception and leaves the thread unnamed when the AI service fails', function () {
+    AiThreadAutoNamingFeature::activate();
+
+    asSuperAdmin();
+
+    Bus::fake([RecordTrackedEvent::class]);
+
+    $thread = createNamingTestThread();
+
+    bindFakeAiService(function (): string {
+        throw new Exception('The AI service is down.');
+    });
+
+    app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
+
+    $thread->refresh();
+
+    expect($thread->name)
+        ->toBe('New Chat 8/13/26 @ 7:10 AM')
+        ->and($thread->saved_at)
+        ->toBeNull();
+
+    Bus::assertNotDispatched(RecordTrackedEvent::class);
+});
+
+it('does not rename a thread that got renamed by the user while the AI service was generating a name', function () {
+    AiThreadAutoNamingFeature::activate();
+
+    asSuperAdmin();
+
+    Bus::fake([RecordTrackedEvent::class]);
+
+    $thread = createNamingTestThread();
+
+    bindFakeAiService(function () use ($thread): string {
+        $thread->update([
+            'name' => 'Renamed By User Mid-Flight',
+            'named_by_user_at' => now(),
+        ]);
+
+        return 'AI Generated Name';
+    });
+
+    app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
+
+    $thread->refresh();
+
+    expect($thread->name)
+        ->toBe('Renamed By User Mid-Flight');
+
+    Bus::assertNotDispatched(RecordTrackedEvent::class);
+});

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/GenerateAiThreadNameTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/GenerateAiThreadNameTest.php
@@ -42,10 +42,8 @@ use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Services\TestAiService;
-use AdvisingApp\Report\Enums\TrackedEventType;
-use AdvisingApp\Report\Jobs\RecordTrackedEvent;
-use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Exceptions;
 
 use function Tests\asSuperAdmin;
 
@@ -68,36 +66,60 @@ function createNamingTestThread(): AiThread
         ]);
 }
 
-it('renames a thread using the AI service and marks it as saved', function () {
+it('only allows a single attempt, so a broadcast failure does not trigger a billed retry', function () {
     asSuperAdmin();
 
-    Bus::fake([RecordTrackedEvent::class]);
+    expect((new GenerateAiThreadName(createNamingTestThread()))->tries)
+        ->toBe(1);
+});
+
+it('renames a thread using the AI service', function () {
+    asSuperAdmin();
+
     Event::fake([AdvisorThreadRenamed::class]);
 
     $thread = createNamingTestThread();
+
+    bindFakeAiService(fn (): string => 'AI Generated Name');
 
     app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
 
     $thread->refresh();
 
     expect($thread->name)
-        ->not->toBe('New Chat 8/13/26 @ 7:10 AM')
-        ->and($thread->name)
-        ->not->toBeEmpty()
-        ->and($thread->saved_at)
-        ->not->toBeNull()
+        ->toBe('AI Generated Name')
         ->and($thread->named_by_user_at)
         ->toBeNull();
 
-    Bus::assertDispatched(RecordTrackedEvent::class, fn (RecordTrackedEvent $job) => $job->type === TrackedEventType::AiThreadSaved);
-
     Event::assertDispatched(AdvisorThreadRenamed::class, fn (AdvisorThreadRenamed $event) => $event->thread->is($thread) && $event->thread->name === $thread->name);
+});
+
+it('saves the name and reports the exception if broadcasting AdvisorThreadRenamed fails', function () {
+    asSuperAdmin();
+
+    Exceptions::fake();
+
+    Event::listen(AdvisorThreadRenamed::class, function (): void {
+        throw new Exception('The broadcast connection is down.');
+    });
+
+    $thread = createNamingTestThread();
+
+    bindFakeAiService(fn (): string => 'AI Generated Name');
+
+    app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
+
+    $thread->refresh();
+
+    expect($thread->name)
+        ->toBe('AI Generated Name');
+
+    Exceptions::assertReported(fn (Exception $exception): bool => $exception->getMessage() === 'The broadcast connection is down.');
 });
 
 it('does not rename a thread that has already been renamed by the user', function () {
     asSuperAdmin();
 
-    Bus::fake([RecordTrackedEvent::class]);
     Event::fake([AdvisorThreadRenamed::class]);
 
     $thread = createNamingTestThread();
@@ -113,7 +135,51 @@ it('does not rename a thread that has already been renamed by the user', functio
     expect($thread->name)
         ->toBe('My Custom Name');
 
-    Bus::assertNotDispatched(RecordTrackedEvent::class);
+    Event::assertNotDispatched(AdvisorThreadRenamed::class);
+});
+
+it('does not call the AI service for a thread that was deleted before the job runs', function () {
+    asSuperAdmin();
+
+    Event::fake([AdvisorThreadRenamed::class]);
+
+    $thread = createNamingTestThread();
+
+    $wasCalled = false;
+
+    bindFakeAiService(function () use (&$wasCalled): string {
+        $wasCalled = true;
+
+        return 'AI Generated Name';
+    });
+
+    $thread->delete();
+
+    app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
+
+    expect($wasCalled)
+        ->toBeFalse();
+
+    Event::assertNotDispatched(AdvisorThreadRenamed::class);
+});
+
+it('does not rename a thread when the AI service returns a blank name', function () {
+    asSuperAdmin();
+
+    Event::fake([AdvisorThreadRenamed::class]);
+
+    $thread = createNamingTestThread();
+
+    bindFakeAiService(fn (): string => "  \n  ");
+
+    app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
+
+    $thread->refresh();
+
+    expect($thread->name)
+        ->toBe('New Chat 8/13/26 @ 7:10 AM')
+        ->and($thread->named_by_user_at)
+        ->toBeNull();
 
     Event::assertNotDispatched(AdvisorThreadRenamed::class);
 });
@@ -138,8 +204,8 @@ function bindFakeAiService(Closure $complete): void
 it('reports the exception and leaves the thread unnamed when the AI service fails', function () {
     asSuperAdmin();
 
-    Bus::fake([RecordTrackedEvent::class]);
     Event::fake([AdvisorThreadRenamed::class]);
+    Exceptions::fake();
 
     $thread = createNamingTestThread();
 
@@ -156,7 +222,7 @@ it('reports the exception and leaves the thread unnamed when the AI service fail
         ->and($thread->saved_at)
         ->toBeNull();
 
-    Bus::assertNotDispatched(RecordTrackedEvent::class);
+    Exceptions::assertReported(Exception::class);
 
     Event::assertNotDispatched(AdvisorThreadRenamed::class);
 });
@@ -164,7 +230,6 @@ it('reports the exception and leaves the thread unnamed when the AI service fail
 it('does not rename a thread that got renamed by the user while the AI service was generating a name', function () {
     asSuperAdmin();
 
-    Bus::fake([RecordTrackedEvent::class]);
     Event::fake([AdvisorThreadRenamed::class]);
 
     $thread = createNamingTestThread();
@@ -185,7 +250,30 @@ it('does not rename a thread that got renamed by the user while the AI service w
     expect($thread->name)
         ->toBe('Renamed By User Mid-Flight');
 
-    Bus::assertNotDispatched(RecordTrackedEvent::class);
+    Event::assertNotDispatched(AdvisorThreadRenamed::class);
+});
+
+it('does not rename a thread that got deleted while the AI service was generating a name', function () {
+    asSuperAdmin();
+
+    Event::fake([AdvisorThreadRenamed::class]);
+
+    $thread = createNamingTestThread();
+
+    bindFakeAiService(function () use ($thread): string {
+        $thread->delete();
+
+        return 'AI Generated Name';
+    });
+
+    app(GenerateAiThreadName::class, ['thread' => $thread])->handle();
+
+    $thread->refresh();
+
+    expect($thread->name)
+        ->toBe('New Chat 8/13/26 @ 7:10 AM')
+        ->and($thread->trashed())
+        ->toBeTrue();
 
     Event::assertNotDispatched(AdvisorThreadRenamed::class);
 });

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/RetryAdvisorMessageTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/RetryAdvisorMessageTest.php
@@ -38,11 +38,13 @@ use AdvisingApp\Ai\Enums\AiAssistantApplication;
 use AdvisingApp\Ai\Enums\AiModel;
 use AdvisingApp\Ai\Events\Advisors\AdvisorMessageChunk;
 use AdvisingApp\Ai\Events\Advisors\AdvisorMessageFinished;
+use AdvisingApp\Ai\Jobs\Advisors\GenerateAiThreadName;
 use AdvisingApp\Ai\Jobs\Advisors\RetryAdvisorMessage;
 use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiThread;
 use App\Models\User;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
 
 use function Tests\asSuperAdmin;
@@ -257,4 +259,93 @@ it('does not match messages with different content', function () {
 
     Event::assertDispatched(AdvisorMessageChunk::class);
     Event::assertDispatched(AdvisorMessageFinished::class);
+});
+
+it('dispatches GenerateAiThreadName when a retry completes the third user message', function () {
+    Bus::fake([GenerateAiThreadName::class]);
+
+    Event::fake([
+        AdvisorMessageChunk::class,
+        AdvisorMessageFinished::class,
+    ]);
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->has(AiMessage::factory()->count(2)->for(auth()->user()), 'messages')
+        ->create();
+
+    $messageContent = AiMessage::factory()->make()->content;
+
+    dispatch(new RetryAdvisorMessage($thread, $messageContent));
+
+    Bus::assertDispatchedTimes(GenerateAiThreadName::class, 1);
+});
+
+it('does not dispatch GenerateAiThreadName again for a fourth user message after a retry named the thread', function () {
+    Bus::fake([GenerateAiThreadName::class]);
+
+    Event::fake([
+        AdvisorMessageChunk::class,
+        AdvisorMessageFinished::class,
+    ]);
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->has(AiMessage::factory()->count(3)->for(auth()->user()), 'messages')
+        ->create();
+
+    $messageContent = AiMessage::factory()->make()->content;
+
+    dispatch(new RetryAdvisorMessage($thread, $messageContent));
+
+    Bus::assertNotDispatched(GenerateAiThreadName::class);
+});
+
+it('does not dispatch GenerateAiThreadName from a retry when the thread has already been renamed by the user', function () {
+    Bus::fake([GenerateAiThreadName::class]);
+
+    Event::fake([
+        AdvisorMessageChunk::class,
+        AdvisorMessageFinished::class,
+    ]);
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->has(AiMessage::factory()->count(2)->for(auth()->user()), 'messages')
+        ->create([
+            'named_by_user_at' => now(),
+        ]);
+
+    $messageContent = AiMessage::factory()->make()->content;
+
+    dispatch(new RetryAdvisorMessage($thread, $messageContent));
+
+    Bus::assertNotDispatched(GenerateAiThreadName::class);
 });

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/SendAdvisorMessageTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/SendAdvisorMessageTest.php
@@ -38,11 +38,14 @@ use AdvisingApp\Ai\Enums\AiAssistantApplication;
 use AdvisingApp\Ai\Enums\AiModel;
 use AdvisingApp\Ai\Events\Advisors\AdvisorMessageChunk;
 use AdvisingApp\Ai\Events\Advisors\AdvisorMessageFinished;
+use AdvisingApp\Ai\Jobs\Advisors\GenerateAiThreadName;
 use AdvisingApp\Ai\Jobs\Advisors\SendAdvisorMessage;
 use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Models\Prompt;
+use App\Features\AiThreadAutoNamingFeature;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
 
 use function Tests\asSuperAdmin;
@@ -135,4 +138,66 @@ it('builds smart prompt content from the editable instructions setting', functio
         ->toContain($prompt->type->title)
         ->toContain($prompt->description)
         ->toEndWith($prompt->prompt);
+});
+
+it('dispatches GenerateAiThreadName exactly once, right after the third user message and response', function () {
+    Bus::fake([GenerateAiThreadName::class]);
+
+    AiThreadAutoNamingFeature::activate();
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->create();
+
+    dispatch(new SendAdvisorMessage($thread, 'Message 1'));
+
+    Bus::assertNotDispatched(GenerateAiThreadName::class);
+
+    dispatch(new SendAdvisorMessage($thread, 'Message 2'));
+
+    Bus::assertNotDispatched(GenerateAiThreadName::class);
+
+    dispatch(new SendAdvisorMessage($thread, 'Message 3'));
+
+    Bus::assertDispatchedTimes(GenerateAiThreadName::class, 1);
+
+    dispatch(new SendAdvisorMessage($thread, 'Message 4'));
+
+    Bus::assertDispatchedTimes(GenerateAiThreadName::class, 1);
+});
+
+it('does not dispatch GenerateAiThreadName when the thread has already been renamed by the user', function () {
+    Bus::fake([GenerateAiThreadName::class]);
+
+    AiThreadAutoNamingFeature::activate();
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->create([
+            'named_by_user_at' => now(),
+        ]);
+
+    dispatch(new SendAdvisorMessage($thread, 'Message 1'));
+    dispatch(new SendAdvisorMessage($thread, 'Message 2'));
+    dispatch(new SendAdvisorMessage($thread, 'Message 3'));
+
+    Bus::assertNotDispatched(GenerateAiThreadName::class);
 });

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/SendAdvisorMessageTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/SendAdvisorMessageTest.php
@@ -143,6 +143,11 @@ it('builds smart prompt content from the editable instructions setting', functio
 it('dispatches GenerateAiThreadName exactly once, right after the third user message and response', function () {
     Bus::fake([GenerateAiThreadName::class]);
 
+    Event::fake([
+        AdvisorMessageChunk::class,
+        AdvisorMessageFinished::class,
+    ]);
+
     AiThreadAutoNamingFeature::activate();
 
     asSuperAdmin();
@@ -177,6 +182,11 @@ it('dispatches GenerateAiThreadName exactly once, right after the third user mes
 
 it('does not dispatch GenerateAiThreadName when the thread has already been renamed by the user', function () {
     Bus::fake([GenerateAiThreadName::class]);
+
+    Event::fake([
+        AdvisorMessageChunk::class,
+        AdvisorMessageFinished::class,
+    ]);
 
     AiThreadAutoNamingFeature::activate();
 

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/SendAdvisorMessageTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/SendAdvisorMessageTest.php
@@ -44,9 +44,13 @@ use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Models\Prompt;
+use AdvisingApp\Report\Enums\TrackedEventType;
+use AdvisingApp\Report\Jobs\RecordTrackedEvent;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
 
+use function Pest\Laravel\travelBack;
+use function Pest\Laravel\travelTo;
 use function Tests\asSuperAdmin;
 
 it('sends a message', function () {
@@ -205,4 +209,120 @@ it('does not dispatch GenerateAiThreadName when the thread has already been rena
     dispatch(new SendAdvisorMessage($thread, 'Message 3'));
 
     Bus::assertNotDispatched(GenerateAiThreadName::class);
+});
+
+it('sets saved_at and dispatches the AiThreadSaved tracked event when the first message is persisted', function () {
+    Bus::fake([RecordTrackedEvent::class]);
+
+    Event::fake([
+        AdvisorMessageChunk::class,
+        AdvisorMessageFinished::class,
+    ]);
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->create([
+            'saved_at' => null,
+        ]);
+
+    dispatch(new SendAdvisorMessage($thread, 'Message 1'));
+
+    expect($thread->fresh()->saved_at)
+        ->not->toBeNull();
+
+    Bus::assertDispatchedTimes(
+        fn (RecordTrackedEvent $job): bool => $job->type === TrackedEventType::AiThreadSaved,
+        1,
+    );
+});
+
+it('does not update saved_at or dispatch the AiThreadSaved tracked event again on subsequent messages', function () {
+    Bus::fake([RecordTrackedEvent::class]);
+
+    Event::fake([
+        AdvisorMessageChunk::class,
+        AdvisorMessageFinished::class,
+    ]);
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->create([
+            'saved_at' => null,
+        ]);
+
+    dispatch(new SendAdvisorMessage($thread, 'Message 1'));
+
+    $savedAt = $thread->fresh()->saved_at;
+
+    try {
+        travelTo(now()->addMinute());
+
+        dispatch(new SendAdvisorMessage($thread, 'Message 2'));
+    } finally {
+        travelBack();
+    }
+
+    expect($thread->fresh()->saved_at)
+        ->toEqual($savedAt);
+
+    Bus::assertDispatchedTimes(
+        fn (RecordTrackedEvent $job): bool => $job->type === TrackedEventType::AiThreadSaved,
+        1,
+    );
+});
+
+it('does not overwrite an already saved_at thread', function () {
+    Bus::fake([RecordTrackedEvent::class]);
+
+    Event::fake([
+        AdvisorMessageChunk::class,
+        AdvisorMessageFinished::class,
+    ]);
+
+    asSuperAdmin();
+
+    $assistant = AiAssistant::factory()->create([
+        'application' => AiAssistantApplication::Test,
+        'is_default' => true,
+        'model' => AiModel::Test,
+    ]);
+
+    $savedAt = now()->subDays(10);
+
+    $thread = AiThread::factory()
+        ->for($assistant, 'assistant')
+        ->for(auth()->user())
+        ->create([
+            'saved_at' => $savedAt,
+        ]);
+
+    $savedAt = $thread->fresh()->saved_at;
+
+    dispatch(new SendAdvisorMessage($thread, 'Message 1'));
+
+    expect($thread->fresh()->saved_at)
+        ->toEqual($savedAt);
+
+    Bus::assertNotDispatched(
+        RecordTrackedEvent::class,
+        fn (RecordTrackedEvent $job): bool => $job->type === TrackedEventType::AiThreadSaved,
+    );
 });

--- a/app-modules/ai/tests/Tenant/Jobs/Advisors/SendAdvisorMessageTest.php
+++ b/app-modules/ai/tests/Tenant/Jobs/Advisors/SendAdvisorMessageTest.php
@@ -44,7 +44,6 @@ use AdvisingApp\Ai\Models\AiAssistant;
 use AdvisingApp\Ai\Models\AiMessage;
 use AdvisingApp\Ai\Models\AiThread;
 use AdvisingApp\Ai\Models\Prompt;
-use App\Features\AiThreadAutoNamingFeature;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
 
@@ -148,8 +147,6 @@ it('dispatches GenerateAiThreadName exactly once, right after the third user mes
         AdvisorMessageFinished::class,
     ]);
 
-    AiThreadAutoNamingFeature::activate();
-
     asSuperAdmin();
 
     $assistant = AiAssistant::factory()->create([
@@ -187,8 +184,6 @@ it('does not dispatch GenerateAiThreadName when the thread has already been rena
         AdvisorMessageChunk::class,
         AdvisorMessageFinished::class,
     ]);
-
-    AiThreadAutoNamingFeature::activate();
 
     asSuperAdmin();
 

--- a/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
+++ b/app-modules/integration-open-ai/src/Services/BaseOpenAiService.php
@@ -57,6 +57,7 @@ use AdvisingApp\IntegrationOpenAi\Services\BaseOpenAiService\Concerns\InteractsW
 use AdvisingApp\IntegrationOpenAi\Services\BaseOpenAiService\Concerns\InteractsWithVectorStores;
 use AdvisingApp\Report\Enums\TrackedEventType;
 use AdvisingApp\Report\Jobs\RecordTrackedEvent;
+use App\Features\AiThreadAutoNamingFeature;
 use App\Models\User;
 use Carbon\CarbonInterface;
 use Closure;
@@ -887,25 +888,27 @@ abstract class BaseOpenAiService implements AiService
 
             throw new MessageResponseException('Failed to send a message: [' . $exception->getMessage() . '].');
         } finally {
-            try {
-                if (is_null($message->thread->name)) {
-                    $prompt = $message->context . "\nThe following is the start of a chat between you and a user:\n" . $message->content;
+            if (! AiThreadAutoNamingFeature::active()) {
+                try {
+                    if (is_null($message->thread->name)) {
+                        $prompt = $message->context . "\nThe following is the start of a chat between you and a user:\n" . $message->content;
 
-                    $message->thread->name = $this->complete($prompt, 'Generate a title for this chat, in 5 words or less. Do not respond with any greetings or salutations, and do not include any additional information or context. Just respond with the title:');
+                        $message->thread->name = $this->complete($prompt, 'Generate a title for this chat, in 5 words or less. Do not respond with any greetings or salutations, and do not include any additional information or context. Just respond with the title:');
 
-                    $message->thread->saved_at = now();
+                        $message->thread->saved_at = now();
 
-                    $message->thread->save();
+                        $message->thread->save();
 
-                    dispatch(new RecordTrackedEvent(
-                        type: TrackedEventType::AiThreadSaved,
-                        occurredAt: now(),
-                    ));
+                        dispatch(new RecordTrackedEvent(
+                            type: TrackedEventType::AiThreadSaved,
+                            occurredAt: now(),
+                        ));
+                    }
+                } catch (Exception $exception) {
+                    report($exception);
+
+                    $message->thread->name = 'Untitled Chat';
                 }
-            } catch (Exception $exception) {
-                report($exception);
-
-                $message->thread->name = 'Untitled Chat';
             }
 
             $message->context = $instructions;

--- a/app/Features/AiThreadAutoNamingFeature.php
+++ b/app/Features/AiThreadAutoNamingFeature.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class AiThreadAutoNamingFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2889

### Technical Description

> When a chat is started with no context initilally the chat title will look like this 'New Chat 8/13/26 @ 7:10 AM'.
> After three prompts and responses name will be updated based on the prompts context by AI.
> If user has already edited the chat name then AI won't update name again.

### Any deployment steps required?

> No

### Cleanup Tasks

> .cleanup-tasks/2026_08_14_ai_thread_auto_naming_feature.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
