### PR TITLE
[ADVAPP-2901]: Some users have reported they are unable to send SMS messages in Demo mode

### DIFF
--- a/app-modules/engagement/tests/Tenant/Feature/Notifications/EngagementNotificationTest.php
+++ b/app-modules/engagement/tests/Tenant/Feature/Notifications/EngagementNotificationTest.php
@@ -34,14 +34,17 @@
 </COPYRIGHT>
 */
 
+use AdvisingApp\Engagement\Enums\EngagementResponseType;
 use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\Engagement\Models\EngagementResponse;
 use AdvisingApp\Engagement\Notifications\EngagementNotification;
 use AdvisingApp\IntegrationAwsSesEventHandling\Settings\SesSettings;
 use AdvisingApp\IntegrationTwilio\Settings\TwilioSettings;
 use AdvisingApp\Notification\Enums\EmailType;
+use AdvisingApp\Notification\Enums\SmsMessagingProvider;
 use AdvisingApp\Notification\Models\EmailMessage;
 use AdvisingApp\Prospect\Models\Prospect;
+use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\Tenant;
 
 it('getEmailType returns the engagement email_type value', function () {
@@ -132,23 +135,64 @@ it('creates a proper Engagement Response for emails when demo mode is turned on'
     expect(EngagementResponse::first()->content)->toBe('Thank you for your message. Will get back to you shortly.');
 });
 
-it('creates a proper Engagement Response for SMS when demo mode is turned on', function () {
+it('creates a proper Engagement Response for SMS when demo mode is turned on', function (string $recipientClass, string $engagementFactoryState) {
     $settings = app(TwilioSettings::class);
     $settings->is_demo_mode_enabled = true;
     $settings->is_demo_auto_reply_mode_enabled = true;
     $settings->save();
 
-    $prospect = Prospect::factory()->create();
+    $recipient = $recipientClass::factory()->create();
 
     $engagement = Engagement::factory()
-        ->forProspect()
+        ->{$engagementFactoryState}()
         ->sms()
-        ->create();
+        ->create([
+            'recipient_id' => $recipient->getKey(),
+            'recipient_type' => $recipient->getMorphClass(),
+        ]);
 
     $notification = new EngagementNotification($engagement);
 
-    $prospect->notify($notification);
+    $recipient->notify($notification);
 
     expect(EngagementResponse::count())->toBe(1);
     expect(EngagementResponse::first()->content)->toBe('Thank you for your message. Will get back to you shortly.');
-});
+})->with([
+    'prospect' => [Prospect::class, 'forProspect'],
+    'student' => [Student::class, 'forStudent'],
+]);
+
+it('sends a fake auto-reply Engagement Response back from the recipient when SMS demo mode is turned on with the Telnyx provider', function (string $recipientClass, string $engagementFactoryState) {
+    $settings = app(TwilioSettings::class);
+    $settings->provider = SmsMessagingProvider::Telnyx;
+    $settings->telnyx_api_key = 'test_api_key';
+    $settings->is_demo_mode_enabled = true;
+    $settings->is_demo_auto_reply_mode_enabled = true;
+    $settings->save();
+
+    $recipient = $recipientClass::factory()->create();
+
+    $engagement = Engagement::factory()
+        ->{$engagementFactoryState}()
+        ->sms()
+        ->create([
+            'recipient_id' => $recipient->getKey(),
+            'recipient_type' => $recipient->getMorphClass(),
+        ]);
+
+    $notification = new EngagementNotification($engagement);
+
+    $recipient->notify($notification);
+
+    expect(EngagementResponse::count())->toBe(1);
+
+    $response = EngagementResponse::first();
+
+    expect($response->type)->toBe(EngagementResponseType::Sms)
+        ->and($response->sender_id)->toBe($recipient->getKey())
+        ->and($response->sender_type)->toBe($recipient->getMorphClass())
+        ->and($response->content)->toBe('Thank you for your message. Will get back to you shortly.');
+})->with([
+    'prospect' => [Prospect::class, 'forProspect'],
+    'student' => [Student::class, 'forStudent'],
+]);

--- a/app-modules/notification/src/Notifications/Channels/SmsChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/SmsChannel.php
@@ -197,10 +197,18 @@ class SmsChannel
             try {
                 if ($result->success) {
                     $smsMessage->quota_usage = $this->determineQuotaUsage($result, $smsMessage);
-                    $smsMessage->external_reference_id = match ($twilioSettings->provider) {
-                        SmsMessagingProvider::Twilio => $result->message->sid,
-                        SmsMessagingProvider::Telnyx => $result->message->id, // @phpstan-ignore property.notFound
-                    };
+
+                    if ($twilioSettings->is_demo_mode_enabled) {
+                        // In demo mode, the result is always a fake Twilio `MessageInstance`
+                        // (see the `is_demo_mode_enabled` branch above), regardless of which
+                        // provider is configured, so it only ever has a `sid` property.
+                        $smsMessage->external_reference_id = $result->message->sid;
+                    } else {
+                        $smsMessage->external_reference_id = match ($twilioSettings->provider) {
+                            SmsMessagingProvider::Twilio => $result->message->sid,
+                            SmsMessagingProvider::Telnyx => $result->message->id, // @phpstan-ignore property.notFound
+                        };
+                    }
 
                     $smsMessage->events()->create([
                         'type' => $twilioSettings->is_demo_mode_enabled

--- a/app-modules/notification/src/Notifications/Channels/SmsChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/SmsChannel.php
@@ -179,18 +179,28 @@ class SmsChannel
             } else {
                 $result = SmsChannelResultData::from([
                     'success' => true,
-                    'message' => new MessageInstance(
-                        new V2010(new MessagingBase(new Client(username: 'abc123', password: 'abc123'))),
-                        [
-                            'sid' => Str::random(),
+                    'message' => match ($twilioSettings->provider) {
+                        SmsMessagingProvider::Twilio => new MessageInstance(
+                            new V2010(new MessagingBase(new Client(username: 'abc123', password: 'abc123'))),
+                            [
+                                'sid' => Str::random(),
+                                'status' => 'delivered',
+                                'from' => $message->getFrom(),
+                                'to' => $recipientNumber,
+                                'body' => $message->getContent(),
+                                'num_segments' => 1,
+                            ],
+                            'abc123'
+                        ),
+                        SmsMessagingProvider::Telnyx => Message::constructFrom([
+                            'id' => (string) Str::uuid(),
                             'status' => 'delivered',
                             'from' => $message->getFrom(),
                             'to' => $recipientNumber,
-                            'body' => $message->getContent(),
-                            'num_segments' => 1,
-                        ],
-                        'abc123'
-                    ),
+                            'text' => $message->getContent(),
+                            'parts' => 1,
+                        ]),
+                    },
                 ]);
             }
 
@@ -198,14 +208,10 @@ class SmsChannel
                 if ($result->success) {
                     $smsMessage->quota_usage = $this->determineQuotaUsage($result, $smsMessage);
 
-                    if ($twilioSettings->is_demo_mode_enabled) {
-                        $smsMessage->external_reference_id = $result->message->sid;
-                    } else {
-                        $smsMessage->external_reference_id = match ($twilioSettings->provider) {
-                            SmsMessagingProvider::Twilio => $result->message->sid,
-                            SmsMessagingProvider::Telnyx => $result->message->id, // @phpstan-ignore property.notFound
-                        };
-                    }
+                    $smsMessage->external_reference_id = match ($twilioSettings->provider) {
+                        SmsMessagingProvider::Twilio => $result->message->sid,
+                        SmsMessagingProvider::Telnyx => $result->message->id, // @phpstan-ignore property.notFound
+                    };
 
                     $smsMessage->events()->create([
                         'type' => $twilioSettings->is_demo_mode_enabled

--- a/app-modules/notification/src/Notifications/Channels/SmsChannel.php
+++ b/app-modules/notification/src/Notifications/Channels/SmsChannel.php
@@ -199,9 +199,6 @@ class SmsChannel
                     $smsMessage->quota_usage = $this->determineQuotaUsage($result, $smsMessage);
 
                     if ($twilioSettings->is_demo_mode_enabled) {
-                        // In demo mode, the result is always a fake Twilio `MessageInstance`
-                        // (see the `is_demo_mode_enabled` branch above), regardless of which
-                        // provider is configured, so it only ever has a `sid` property.
                         $smsMessage->external_reference_id = $result->message->sid;
                     } else {
                         $smsMessage->external_reference_id = match ($twilioSettings->provider) {

--- a/app-modules/notification/tests/Tenant/Notifications/Channels/SmsChannelSmsMessageTest.php
+++ b/app-modules/notification/tests/Tenant/Notifications/Channels/SmsChannelSmsMessageTest.php
@@ -340,4 +340,31 @@ it('short-circuits with SmsOptOutException before the API call when the number i
     expect($event->type)->toBe(SmsMessageEventType::FailedDispatch)
         ->and($event->payload['error'])->toBe('Recipient phone number has opted out of SMS messages.');
 });
+
+it('records a BlockedByDemoMode event and sets an external_reference_id when demo mode is enabled with the Telnyx provider', function () {
+    $notifiable = Prospect::factory()->create();
+
+    $phoneNumber = $notifiable->phoneNumbers()->create([
+        'number' => '+13125000012',
+    ]);
+
+    PhoneNumberLookup::factory()->mobile()->create(['number' => '+13125000012']);
+
+    $notifiable->primaryPhoneNumber()->associate($phoneNumber)->save();
+
+    $settings = app()->make(TwilioSettings::class);
+    $settings->provider = SmsMessagingProvider::Telnyx;
+    $settings->telnyx_api_key = 'test_api_key';
+    $settings->is_demo_mode_enabled = true;
+    $settings->save();
+
+    $notifiable->notify(new TestSmsNotification());
+
+    $smsMessage = SmsMessage::first();
+
+    expect($smsMessage->external_reference_id)->not->toBeNull();
+
+    $event = $smsMessage->events()->first();
+    expect($event->type)->toBe(SmsMessageEventType::BlockedByDemoMode);
+});
 // TODO Add more tests for SMS Demo mode etc.


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2901

### Technical Description

> Solve the issue of users not being able to send SMS in demo mode.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
