### PR TITLE
[ADVAPP-2885]: Some users have reported that in campaigns, the population group drop‑down only shows their population groups

### DIFF
--- a/app-modules/campaign/src/Enums/GroupOwnership.php
+++ b/app-modules/campaign/src/Enums/GroupOwnership.php
@@ -34,39 +34,24 @@
 </COPYRIGHT>
 */
 
-namespace AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages;
+namespace AdvisingApp\Campaign\Enums;
 
-use AdvisingApp\Campaign\Filament\Actions\ArchiveCampaignAction;
-use AdvisingApp\Campaign\Filament\Forms\Components\PopulationGroupSelector;
-use AdvisingApp\Campaign\Filament\Resources\Campaigns\CampaignResource;
-use Filament\Actions\DeleteAction;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Toggle;
-use Filament\Resources\Pages\EditRecord;
-use Filament\Schemas\Schema;
+use Filament\Support\Contracts\HasLabel;
 
-class EditCampaign extends EditRecord
+enum GroupOwnership: string implements HasLabel
 {
-    protected static string $resource = CampaignResource::class;
+    case Mine = 'mine';
 
-    public function form(Schema $schema): Schema
-    {
-        return $schema
-            ->columns(1)
-            ->components([
-                TextInput::make('name')
-                    ->required(),
-                ...PopulationGroupSelector::make(),
-                Toggle::make('enabled')
-                    ->helperText('Toggle this off to pause the campaign; no further journey steps will run.'),
-            ]);
-    }
+    case Department = 'department';
 
-    protected function getHeaderActions(): array
+    case All = 'all';
+
+    public function getLabel(): string
     {
-        return [
-            ArchiveCampaignAction::make(),
-            DeleteAction::make(),
-        ];
+        return match ($this) {
+            self::Mine => 'My Groups',
+            self::Department => "My Department's Groups",
+            self::All => 'All Groups',
+        };
     }
 }

--- a/app-modules/campaign/src/Filament/Forms/Components/PopulationGroupSelector.php
+++ b/app-modules/campaign/src/Filament/Forms/Components/PopulationGroupSelector.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Campaign\Filament\Forms\Components;
 
+use AdvisingApp\Campaign\Enums\GroupOwnership;
 use AdvisingApp\Campaign\Models\Campaign;
 use AdvisingApp\Group\Enums\GroupModel;
 use AdvisingApp\Group\Models\Group;
@@ -48,35 +49,36 @@ use Illuminate\Database\Eloquent\Builder;
 
 class PopulationGroupSelector
 {
-    public const OWNERSHIP_MINE = 'mine';
-
-    public const OWNERSHIP_DEPARTMENT = 'department';
-
-    public const OWNERSHIP_ALL = 'all';
-
     /**
      * @return array<int, Select | ToggleButtons>
      */
     public static function make(?Closure $afterSegmentIdUpdated = null): array
     {
+        $availablePopulationTypes = self::availablePopulationTypes();
+
         $segmentIdField = Select::make('segment_id')
             ->label('Population Group')
             ->options(function (Get $get) {
                 $populationType = $get('population_type');
-                $groupOwnership = $get('group_ownership');
+                $groupOwnership = $get->enum('group_ownership', GroupOwnership::class, isNullable: true);
 
                 if (blank($populationType) || blank($groupOwnership)) {
+                    return [];
+                }
+
+                // Group Ownership is client-side state, so "All" must be re-authorized here rather than trusted from the form.
+                if (($groupOwnership === GroupOwnership::All) && auth()->user()->cannot('group.view-any') && auth()->user()->cannot('group.*.view')) {
                     return [];
                 }
 
                 $query = Group::query()->where('model', $populationType);
 
                 match ($groupOwnership) {
-                    self::OWNERSHIP_MINE => $query->where('user_id', auth()->id()),
-                    self::OWNERSHIP_DEPARTMENT => $query->whereHas('user', function (Builder $query) {
+                    GroupOwnership::Mine => $query->where('user_id', auth()->id()),
+                    GroupOwnership::Department => $query->whereHas('user', function (Builder $query) {
                         $query->whereRelation('department.users', 'id', auth()->id());
                     }),
-                    default => null,
+                    GroupOwnership::All => null,
                 };
 
                 return $query->pluck('name', 'id');
@@ -92,26 +94,29 @@ class PopulationGroupSelector
         return [
             ToggleButtons::make('population_type')
                 ->label('Population Type')
-                ->options([
-                    GroupModel::Student->value => 'Students',
-                    GroupModel::Prospect->value => 'Prospects',
-                ])
+                ->options(collect($availablePopulationTypes)->mapWithKeys(fn (GroupModel $type) => [
+                    $type->value => $type === GroupModel::Student ? 'Students' : 'Prospects',
+                ]))
                 ->inline()
                 ->live()
                 ->dehydrated(false)
                 ->required()
-                ->afterStateHydrated(fn (Set $set, ?Campaign $record) => $set('population_type', ($record?->group->model ?? GroupModel::default())->value))
+                ->hidden(count($availablePopulationTypes) <= 1)
+                ->afterStateHydrated(fn (Set $set, ?Campaign $record) => $set(
+                    'population_type',
+                    self::defaultPopulationType($record, $availablePopulationTypes),
+                ))
                 ->afterStateUpdated(fn (Set $set) => $set('segment_id', null)),
             ToggleButtons::make('group_ownership')
                 ->label('Group Ownership')
                 ->options(function () {
                     $options = [
-                        self::OWNERSHIP_MINE => 'My Groups',
-                        self::OWNERSHIP_DEPARTMENT => "My Department's Groups",
+                        GroupOwnership::Mine->value => GroupOwnership::Mine->getLabel(),
+                        GroupOwnership::Department->value => GroupOwnership::Department->getLabel(),
                     ];
 
                     if (auth()->user()->canAny(['group.view-any', 'group.*.view'])) {
-                        $options[self::OWNERSHIP_ALL] = 'All Groups';
+                        $options[GroupOwnership::All->value] = GroupOwnership::All->getLabel();
                     }
 
                     return $options;
@@ -126,24 +131,55 @@ class PopulationGroupSelector
         ];
     }
 
+    /**
+     * @return array<GroupModel>
+     */
+    private static function availablePopulationTypes(): array
+    {
+        return collect(GroupModel::cases())
+            ->filter(fn (GroupModel $type) => auth()->user()->hasLicense($type->class()::getLicenseType()))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  array<GroupModel>  $availablePopulationTypes
+     */
+    private static function defaultPopulationType(?Campaign $record, array $availablePopulationTypes): ?string
+    {
+        $currentType = $record?->group->model;
+
+        if ($currentType && in_array($currentType, $availablePopulationTypes, true)) {
+            return $currentType->value;
+        }
+
+        $default = GroupModel::default();
+
+        if (in_array($default, $availablePopulationTypes, true)) {
+            return $default->value;
+        }
+
+        return ($availablePopulationTypes[0] ?? null)?->value;
+    }
+
     private static function defaultGroupOwnership(?Campaign $record): string
     {
         $group = $record?->group;
 
         if (! $group) {
-            return self::OWNERSHIP_MINE;
+            return GroupOwnership::Mine->value;
         }
 
         if ($group->user_id === auth()->id()) {
-            return self::OWNERSHIP_MINE;
+            return GroupOwnership::Mine->value;
         }
 
         $currentUserDepartmentId = auth()->user()?->team_id;
 
         if (filled($currentUserDepartmentId) && $group->user?->team_id === $currentUserDepartmentId) {
-            return self::OWNERSHIP_DEPARTMENT;
+            return GroupOwnership::Department->value;
         }
 
-        return self::OWNERSHIP_ALL;
+        return GroupOwnership::All->value;
     }
 }

--- a/app-modules/campaign/src/Filament/Forms/Components/PopulationGroupSelector.php
+++ b/app-modules/campaign/src/Filament/Forms/Components/PopulationGroupSelector.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Campaign\Filament\Forms\Components;
+
+use AdvisingApp\Campaign\Models\Campaign;
+use AdvisingApp\Group\Enums\GroupModel;
+use AdvisingApp\Group\Models\Group;
+use Closure;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\ToggleButtons;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Illuminate\Database\Eloquent\Builder;
+
+class PopulationGroupSelector
+{
+    public const OWNERSHIP_MINE = 'mine';
+
+    public const OWNERSHIP_DEPARTMENT = 'department';
+
+    public const OWNERSHIP_ALL = 'all';
+
+    /**
+     * @return array<int, Select | ToggleButtons>
+     */
+    public static function make(?Closure $afterSegmentIdUpdated = null): array
+    {
+        $segmentIdField = Select::make('segment_id')
+            ->label('Population Group')
+            ->options(function (Get $get) {
+                $populationType = $get('population_type');
+                $groupOwnership = $get('group_ownership');
+
+                if (blank($populationType) || blank($groupOwnership)) {
+                    return [];
+                }
+
+                $query = Group::query()->where('model', $populationType);
+
+                match ($groupOwnership) {
+                    self::OWNERSHIP_MINE => $query->where('user_id', auth()->id()),
+                    self::OWNERSHIP_DEPARTMENT => $query->whereHas('user', function (Builder $query) {
+                        $query->whereRelation('department.users', 'id', auth()->id());
+                    }),
+                    default => null,
+                };
+
+                return $query->pluck('name', 'id');
+            })
+            ->searchable()
+            ->required()
+            ->live();
+
+        if ($afterSegmentIdUpdated) {
+            $segmentIdField->afterStateUpdated($afterSegmentIdUpdated);
+        }
+
+        return [
+            ToggleButtons::make('population_type')
+                ->label('Population Type')
+                ->options([
+                    GroupModel::Student->value => 'Students',
+                    GroupModel::Prospect->value => 'Prospects',
+                ])
+                ->inline()
+                ->live()
+                ->dehydrated(false)
+                ->required()
+                ->afterStateHydrated(fn (Set $set, ?Campaign $record) => $set('population_type', ($record?->group->model ?? GroupModel::default())->value))
+                ->afterStateUpdated(fn (Set $set) => $set('segment_id', null)),
+            ToggleButtons::make('group_ownership')
+                ->label('Group Ownership')
+                ->options(function () {
+                    $options = [
+                        self::OWNERSHIP_MINE => 'My Groups',
+                        self::OWNERSHIP_DEPARTMENT => "My Department's Groups",
+                    ];
+
+                    if (auth()->user()->canAny(['group.view-any', 'group.*.view'])) {
+                        $options[self::OWNERSHIP_ALL] = 'All Groups';
+                    }
+
+                    return $options;
+                })
+                ->inline()
+                ->live()
+                ->dehydrated(false)
+                ->required()
+                ->afterStateHydrated(fn (Set $set, ?Campaign $record) => $set('group_ownership', self::defaultGroupOwnership($record)))
+                ->afterStateUpdated(fn (Set $set) => $set('segment_id', null)),
+            $segmentIdField,
+        ];
+    }
+
+    private static function defaultGroupOwnership(?Campaign $record): string
+    {
+        $group = $record?->group;
+
+        if (! $group) {
+            return self::OWNERSHIP_MINE;
+        }
+
+        if ($group->user_id === auth()->id()) {
+            return self::OWNERSHIP_MINE;
+        }
+
+        $currentUserDepartmentId = auth()->user()?->team_id;
+
+        if (filled($currentUserDepartmentId) && $group->user?->team_id === $currentUserDepartmentId) {
+            return self::OWNERSHIP_DEPARTMENT;
+        }
+
+        return self::OWNERSHIP_ALL;
+    }
+}

--- a/app-modules/campaign/src/Filament/Forms/Components/PopulationGroupSelector.php
+++ b/app-modules/campaign/src/Filament/Forms/Components/PopulationGroupSelector.php
@@ -102,6 +102,8 @@ class PopulationGroupSelector
                 ->dehydrated(false)
                 ->required()
                 ->hidden(count($availablePopulationTypes) <= 1)
+                ->disabled(fn (?Campaign $record) => $record !== null)
+                ->helperText(fn (?Campaign $record) => $record !== null ? 'The population type cannot be changed once a campaign has been created.' : null)
                 ->afterStateHydrated(fn (Set $set, ?Campaign $record) => $set(
                     'population_type',
                     self::defaultPopulationType($record, $availablePopulationTypes),

--- a/app-modules/campaign/src/Filament/Forms/Components/PopulationGroupSelector.php
+++ b/app-modules/campaign/src/Filament/Forms/Components/PopulationGroupSelector.php
@@ -46,6 +46,7 @@ use Filament\Forms\Components\ToggleButtons;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
 
 class PopulationGroupSelector
 {
@@ -58,8 +59,8 @@ class PopulationGroupSelector
 
         $segmentIdField = Select::make('segment_id')
             ->label('Population Group')
-            ->options(function (Get $get) {
-                $populationType = $get('population_type');
+            ->options(function (Get $get, ?Campaign $record) {
+                $populationType = self::authoritativePopulationType($record, $get);
                 $groupOwnership = $get->enum('group_ownership', GroupOwnership::class, isNullable: true);
 
                 if (blank($populationType) || blank($groupOwnership)) {
@@ -71,17 +72,37 @@ class PopulationGroupSelector
                     return [];
                 }
 
+                $currentUserDepartmentId = auth()->user()?->team_id;
+
                 $query = Group::query()->where('model', $populationType);
 
                 match ($groupOwnership) {
                     GroupOwnership::Mine => $query->where('user_id', auth()->id()),
-                    GroupOwnership::Department => $query->whereHas('user', function (Builder $query) {
-                        $query->whereRelation('department.users', 'id', auth()->id());
+                    GroupOwnership::Department => $query->whereHas('user', function (Builder $query) use ($currentUserDepartmentId) {
+                        $query->when(
+                            filled($currentUserDepartmentId),
+                            fn (Builder $query) => $query->where('team_id', $currentUserDepartmentId),
+                            fn (Builder $query) => $query->whereRaw('1 = 0'),
+                        );
                     }),
                     GroupOwnership::All => null,
                 };
 
-                return $query->pluck('name', 'id');
+                return $query->orderBy('name')->pluck('name', 'id');
+            })
+            ->rule(function (Get $get, ?Campaign $record): Closure {
+                return function (string $attribute, mixed $value, Closure $fail) use ($get, $record) {
+                    $populationType = self::authoritativePopulationType($record, $get);
+
+                    if (blank($populationType) || blank($value)) {
+                        return;
+                    }
+
+                    // Population Type and the selected group are re-validated here in case either was tampered with via Livewire state.
+                    if (! Group::query()->where('model', $populationType)->whereKey($value)->exists()) {
+                        $fail('The selected population group does not match the campaign\'s population type.');
+                    }
+                };
             })
             ->searchable()
             ->required()
@@ -95,7 +116,7 @@ class PopulationGroupSelector
             ToggleButtons::make('population_type')
                 ->label('Population Type')
                 ->options(collect($availablePopulationTypes)->mapWithKeys(fn (GroupModel $type) => [
-                    $type->value => $type === GroupModel::Student ? 'Students' : 'Prospects',
+                    $type->value => Str::ucfirst($type->getPluralLabel()),
                 ]))
                 ->inline()
                 ->live()
@@ -162,6 +183,11 @@ class PopulationGroupSelector
         }
 
         return ($availablePopulationTypes[0] ?? null)?->value;
+    }
+
+    private static function authoritativePopulationType(?Campaign $record, Get $get): ?string
+    {
+        return $record?->group->model->value ?? $get('population_type');
     }
 
     private static function defaultGroupOwnership(?Campaign $record): string

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
@@ -98,6 +98,7 @@ class CreateCampaign extends CreateRecord
     {
         return [
             Step::make('Campaign Details')
+                ->columns(1)
                 ->schema([
                     TextInput::make('name')
                         ->autocomplete(false)

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
@@ -109,7 +109,7 @@ class CreateCampaign extends CreateRecord
                         ->options(function () {
                             $query = Group::query();
 
-                            if (auth()->user()->cannot('group.*.view')) {
+                            if (auth()->user()->cannot(['group.view-any', 'group.*.view'])) {
                                 $query->whereHas('user', function (EloquentBuilder $query) {
                                     $query->whereKey(auth()->id())->orWhereRelation('department.users', 'id', auth()->id());
                                 });

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
@@ -109,7 +109,7 @@ class CreateCampaign extends CreateRecord
                         ->options(function () {
                             $query = Group::query();
 
-                            if (auth()->user()->cannot(['group.view-any', 'group.*.view'])) {
+                            if (! auth()->user()->canAny(['group.view-any', 'group.*.view'])) {
                                 $query->whereHas('user', function (EloquentBuilder $query) {
                                     $query->whereKey(auth()->id())->orWhereRelation('department.users', 'id', auth()->id());
                                 });

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
@@ -107,11 +107,15 @@ class CreateCampaign extends CreateRecord
                     Select::make('segment_id')
                         ->label('Population Group')
                         ->options(function () {
-                            return Group::query()
-                                ->whereHas('user', function (EloquentBuilder $query) {
+                            $query = Group::query();
+
+                            if (auth()->user()->cannot('group.*.view')) {
+                                $query->whereHas('user', function (EloquentBuilder $query) {
                                     $query->whereKey(auth()->id())->orWhereRelation('department.users', 'id', auth()->id());
-                                })
-                                ->pluck('name', 'id');
+                                });
+                            }
+
+                            return $query->pluck('name', 'id');
                         })
                         ->searchable()
                         ->required()

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/CreateCampaign.php
@@ -38,13 +38,12 @@ namespace AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages;
 
 use AdvisingApp\Campaign\Enums\CampaignActionType;
 use AdvisingApp\Campaign\Filament\Blocks\CampaignActionBlock;
+use AdvisingApp\Campaign\Filament\Forms\Components\PopulationGroupSelector;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\CampaignResource;
 use AdvisingApp\Campaign\Models\Campaign;
-use AdvisingApp\Group\Models\Group;
 use Carbon\Carbon;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Builder;
-use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\ViewField;
@@ -53,7 +52,6 @@ use Filament\Resources\Pages\CreateRecord\Concerns\HasWizard;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Components\Wizard\Step;
 use Filament\Support\Enums\Width;
-use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 
@@ -104,25 +102,9 @@ class CreateCampaign extends CreateRecord
                     TextInput::make('name')
                         ->autocomplete(false)
                         ->required(),
-                    Select::make('segment_id')
-                        ->label('Population Group')
-                        ->options(function () {
-                            $query = Group::query();
-
-                            if (! auth()->user()->canAny(['group.view-any', 'group.*.view'])) {
-                                $query->whereHas('user', function (EloquentBuilder $query) {
-                                    $query->whereKey(auth()->id())->orWhereRelation('department.users', 'id', auth()->id());
-                                });
-                            }
-
-                            return $query->pluck('name', 'id');
-                        })
-                        ->searchable()
-                        ->required()
-                        ->live()
-                        ->afterStateUpdated(function (Set $set) {
-                            $set('actions', []);
-                        }),
+                    ...PopulationGroupSelector::make(function (Set $set) {
+                        $set('actions', []);
+                    }),
                 ]),
             Step::make('Define Journey')
                 ->schema([

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
@@ -52,6 +52,7 @@ class EditCampaign extends EditRecord
     public function form(Schema $schema): Schema
     {
         return $schema
+            ->columns(1)
             ->components([
                 TextInput::make('name')
                     ->required(),

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
@@ -60,11 +60,15 @@ class EditCampaign extends EditRecord
                 Select::make('segment_id')
                     ->label('Population Group')
                     ->options(function () {
-                        return Group::query()
-                            ->whereHas('user', function (Builder $query) {
+                        $query = Group::query();
+
+                        if (auth()->user()->cannot('group.*.view')) {
+                            $query->whereHas('user', function (Builder $query) {
                                 $query->whereKey(auth()->id())->orWhereRelation('department.users', 'id', auth()->id());
-                            })
-                            ->pluck('name', 'id');
+                            });
+                        }
+
+                        return $query->pluck('name', 'id');
                     })
                     ->searchable()
                     ->required(),

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
@@ -57,7 +57,8 @@ class EditCampaign extends EditRecord
                 TextInput::make('name')
                     ->required(),
                 ...PopulationGroupSelector::make(),
-                Toggle::make('enabled'),
+                Toggle::make('enabled')
+                    ->helperText('Toggle this off to set your campaign to a draft state.'),
             ]);
     }
 

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
@@ -37,15 +37,13 @@
 namespace AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages;
 
 use AdvisingApp\Campaign\Filament\Actions\ArchiveCampaignAction;
+use AdvisingApp\Campaign\Filament\Forms\Components\PopulationGroupSelector;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\CampaignResource;
-use AdvisingApp\Group\Models\Group;
 use Filament\Actions\DeleteAction;
-use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Schemas\Schema;
-use Illuminate\Database\Eloquent\Builder;
 
 class EditCampaign extends EditRecord
 {
@@ -57,21 +55,7 @@ class EditCampaign extends EditRecord
             ->components([
                 TextInput::make('name')
                     ->required(),
-                Select::make('segment_id')
-                    ->label('Population Group')
-                    ->options(function () {
-                        $query = Group::query();
-
-                        if (! auth()->user()->canAny(['group.view-any', 'group.*.view'])) {
-                            $query->whereHas('user', function (Builder $query) {
-                                $query->whereKey(auth()->id())->orWhereRelation('department.users', 'id', auth()->id());
-                            });
-                        }
-
-                        return $query->pluck('name', 'id');
-                    })
-                    ->searchable()
-                    ->required(),
+                ...PopulationGroupSelector::make(),
                 Toggle::make('enabled'),
             ]);
     }

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
@@ -62,7 +62,7 @@ class EditCampaign extends EditRecord
                     ->options(function () {
                         $query = Group::query();
 
-                        if (auth()->user()->cannot(['group.view-any', 'group.*.view'])) {
+                        if (! auth()->user()->canAny(['group.view-any', 'group.*.view'])) {
                             $query->whereHas('user', function (Builder $query) {
                                 $query->whereKey(auth()->id())->orWhereRelation('department.users', 'id', auth()->id());
                             });

--- a/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
+++ b/app-modules/campaign/src/Filament/Resources/Campaigns/Pages/EditCampaign.php
@@ -62,7 +62,7 @@ class EditCampaign extends EditRecord
                     ->options(function () {
                         $query = Group::query();
 
-                        if (auth()->user()->cannot('group.*.view')) {
+                        if (auth()->user()->cannot(['group.view-any', 'group.*.view'])) {
                             $query->whereHas('user', function (Builder $query) {
                                 $query->whereKey(auth()->id())->orWhereRelation('department.users', 'id', auth()->id());
                             });

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\Campaign\Tests\Tenant\Filament\Resources\Campaigns\Pages;
 
 use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\Campaign\Enums\GroupOwnership;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\CreateCampaign;
 use AdvisingApp\Group\Enums\GroupModel;
 use AdvisingApp\Group\Models\Group;
@@ -154,7 +155,7 @@ it('hides the All Groups ownership option for users without the group.*.view or 
     livewire(CreateCampaign::class)
         ->assertFormFieldExists(
             'group_ownership',
-            fn (ToggleButtons $field) => ! array_key_exists('all', $field->getOptions()),
+            fn (ToggleButtons $field) => ! array_key_exists(GroupOwnership::All->value, $field->getOptions()),
         );
 });
 
@@ -170,7 +171,7 @@ it('rejects a manually supplied All Groups ownership value for users without the
     $otherUsersGroup = Group::factory()->student()->create();
 
     livewire(CreateCampaign::class)
-        ->fillForm(['group_ownership' => 'all'])
+        ->fillForm(['group_ownership' => GroupOwnership::All->value])
         ->assertFormFieldExists(
             'segment_id',
             function (Select $field) use ($otherUsersGroup) {
@@ -196,7 +197,7 @@ it('offers every population group of the selected type when the All Groups owner
     livewire(CreateCampaign::class)
         ->fillForm([
             'population_type' => GroupModel::Student->value,
-            'group_ownership' => 'all',
+            'group_ownership' => GroupOwnership::All->value,
         ])
         ->assertFormFieldExists(
             'segment_id',
@@ -226,7 +227,7 @@ it('offers only the groups belonging to the user\'s department when the My Depar
     livewire(CreateCampaign::class)
         ->fillForm([
             'population_type' => GroupModel::Student->value,
-            'group_ownership' => 'department',
+            'group_ownership' => GroupOwnership::Department->value,
         ])
         ->assertFormFieldExists(
             'segment_id',
@@ -297,6 +298,6 @@ it('clears the selected population group when the group ownership changes', func
     livewire(CreateCampaign::class)
         ->fillForm(['segment_id' => $studentGroup->getKey()])
         ->assertSchemaStateSet(['segment_id' => $studentGroup->getKey()])
-        ->fillForm(['group_ownership' => 'all'])
+        ->fillForm(['group_ownership' => GroupOwnership::All->value])
         ->assertSchemaStateSet(['segment_id' => null]);
 });

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
@@ -112,6 +112,11 @@ it('requires population group on campaign creation', function () {
         ]);
 });
 
+it('allows the population type to be changed when creating a campaign', function () {
+    livewire(CreateCampaign::class)
+        ->assertFormFieldEnabled('population_type');
+});
+
 it('only offers the user\'s own population groups by default when they lack the group.*.view permission', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
     $user->givePermissionTo('campaign.view-any');

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
@@ -121,13 +121,16 @@ it('only offers the user\'s own population groups by default when they lack the 
 
     actingAs($user);
 
+    $ownGroup = Group::factory()->student()->create(['user_id' => $user->id]);
     $otherUsersGroup = Group::factory()->student()->create();
 
     livewire(CreateCampaign::class)
         ->assertFormFieldExists(
             'segment_id',
-            function (Select $field) use ($otherUsersGroup) {
-                expect($field->getOptions())->not->toHaveKey($otherUsersGroup->getKey());
+            function (Select $field) use ($ownGroup, $otherUsersGroup) {
+                expect($field->getOptions())
+                    ->toHaveKey($ownGroup->getKey())
+                    ->not->toHaveKey($otherUsersGroup->getKey());
 
                 return true;
             },
@@ -147,6 +150,29 @@ it('hides the All Groups ownership option for users without the group.*.view or 
         ->assertFormFieldExists(
             'group_ownership',
             fn (ToggleButtons $field) => ! array_key_exists('all', $field->getOptions()),
+        );
+});
+
+it('rejects a manually supplied All Groups ownership value for users without the group.*.view or group.view-any permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('campaign.view-any');
+    $user->givePermissionTo('campaign.create');
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    actingAs($user);
+
+    $otherUsersGroup = Group::factory()->student()->create();
+
+    livewire(CreateCampaign::class)
+        ->fillForm(['group_ownership' => 'all'])
+        ->assertFormFieldExists(
+            'segment_id',
+            function (Select $field) use ($otherUsersGroup) {
+                expect($field->getOptions())->not->toHaveKey($otherUsersGroup->getKey());
+
+                return true;
+            },
         );
 });
 
@@ -221,6 +247,29 @@ it('filters the population group options by the selected population type', funct
                 expect($field->getOptions())
                     ->toHaveKey($prospectGroup->getKey())
                     ->not->toHaveKey($studentGroup->getKey());
+
+                return true;
+            },
+        );
+});
+
+it('hides the Population Type toggle and defaults to Prospects for a user only licensed for prospects', function () {
+    $user = User::factory()->licensed(LicenseType::RecruitmentCrm)->create();
+    $user->givePermissionTo('campaign.view-any');
+    $user->givePermissionTo('campaign.create');
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    actingAs($user);
+
+    $prospectGroup = Group::factory()->prospect()->create(['user_id' => $user->id]);
+
+    livewire(CreateCampaign::class)
+        ->assertFormFieldHidden('population_type')
+        ->assertFormFieldExists(
+            'segment_id',
+            function (Select $field) use ($prospectGroup) {
+                expect($field->getOptions())->toHaveKey($prospectGroup->getKey());
 
                 return true;
             },

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
@@ -36,6 +36,7 @@
 
 namespace AdvisingApp\Campaign\Tests\Tenant\Filament\Resources\Campaigns\Pages;
 
+use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\CreateCampaign;
 use AdvisingApp\Group\Enums\GroupModel;
 use AdvisingApp\Group\Models\Group;
@@ -46,7 +47,10 @@ use AdvisingApp\Interaction\Models\InteractionOutcome;
 use AdvisingApp\Interaction\Models\InteractionRelation;
 use AdvisingApp\Interaction\Models\InteractionStatus;
 use AdvisingApp\Interaction\Models\InteractionType;
+use App\Models\User;
+use Filament\Forms\Components\Select;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function Tests\asSuperAdmin;
 
@@ -101,4 +105,37 @@ it('requires population group on campaign creation', function () {
         ->assertHasFormErrors([
             'segment_id' => 'required',
         ]);
+});
+
+it('only offers the user\'s own and department\'s population groups when they lack the group.*.view permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('campaign.view-any');
+    $user->givePermissionTo('campaign.create');
+
+    actingAs($user);
+
+    $otherUsersGroup = Group::factory()->create();
+
+    livewire(CreateCampaign::class)
+        ->assertFormFieldExists(
+            'segment_id',
+            fn (Select $field) => ! array_key_exists($otherUsersGroup->getKey(), $field->getOptions()),
+        );
+});
+
+it('offers every population group when the user has the group.*.view permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('campaign.view-any');
+    $user->givePermissionTo('campaign.create');
+    $user->givePermissionTo('group.*.view');
+
+    actingAs($user);
+
+    $otherUsersGroup = Group::factory()->create();
+
+    livewire(CreateCampaign::class)
+        ->assertFormFieldExists(
+            'segment_id',
+            fn (Select $field) => array_key_exists($otherUsersGroup->getKey(), $field->getOptions()),
+        );
 });

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
@@ -64,7 +64,7 @@ beforeEach(function () {
 });
 
 it('clears journey steps when the population group is changed', function (GroupModel $newPopulationModel) {
-    $studentGroup = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => auth()->id()]);
+    $studentGroup = Group::factory()->student()->create(['user_id' => auth()->id()]);
     $newGroup = Group::factory()->create(['model' => $newPopulationModel, 'user_id' => auth()->id()]);
 
     livewire(CreateCampaign::class)
@@ -121,7 +121,7 @@ it('only offers the user\'s own population groups by default when they lack the 
 
     actingAs($user);
 
-    $otherUsersGroup = Group::factory()->create(['model' => GroupModel::default()]);
+    $otherUsersGroup = Group::factory()->student()->create();
 
     livewire(CreateCampaign::class)
         ->assertFormFieldExists(
@@ -160,7 +160,7 @@ it('offers every population group of the selected type when the All Groups owner
 
     actingAs($user);
 
-    $otherUsersGroup = Group::factory()->create(['model' => GroupModel::Student]);
+    $otherUsersGroup = Group::factory()->student()->create();
 
     livewire(CreateCampaign::class)
         ->fillForm([
@@ -187,8 +187,8 @@ it('offers only the groups belonging to the user\'s department when the My Depar
     app(PermissionRegistrar::class)->forgetCachedPermissions();
 
     $colleague = User::factory()->create(['team_id' => $department->id]);
-    $colleaguesGroup = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => $colleague->id]);
-    $outsidersGroup = Group::factory()->create(['model' => GroupModel::Student]);
+    $colleaguesGroup = Group::factory()->student()->create(['user_id' => $colleague->id]);
+    $outsidersGroup = Group::factory()->student()->create();
 
     actingAs($user);
 
@@ -210,8 +210,8 @@ it('offers only the groups belonging to the user\'s department when the My Depar
 });
 
 it('filters the population group options by the selected population type', function () {
-    $studentGroup = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => auth()->id()]);
-    $prospectGroup = Group::factory()->create(['model' => GroupModel::Prospect, 'user_id' => auth()->id()]);
+    $studentGroup = Group::factory()->student()->create(['user_id' => auth()->id()]);
+    $prospectGroup = Group::factory()->prospect()->create(['user_id' => auth()->id()]);
 
     livewire(CreateCampaign::class)
         ->fillForm(['population_type' => GroupModel::Prospect->value])
@@ -228,7 +228,7 @@ it('filters the population group options by the selected population type', funct
 });
 
 it('clears the selected population group when the population type changes', function () {
-    $studentGroup = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => auth()->id()]);
+    $studentGroup = Group::factory()->student()->create(['user_id' => auth()->id()]);
 
     livewire(CreateCampaign::class)
         ->fillForm(['segment_id' => $studentGroup->getKey()])
@@ -238,7 +238,7 @@ it('clears the selected population group when the population type changes', func
 });
 
 it('clears the selected population group when the group ownership changes', function () {
-    $studentGroup = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => auth()->id()]);
+    $studentGroup = Group::factory()->student()->create(['user_id' => auth()->id()]);
 
     livewire(CreateCampaign::class)
         ->fillForm(['segment_id' => $studentGroup->getKey()])

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
@@ -47,8 +47,10 @@ use AdvisingApp\Interaction\Models\InteractionOutcome;
 use AdvisingApp\Interaction\Models\InteractionRelation;
 use AdvisingApp\Interaction\Models\InteractionStatus;
 use AdvisingApp\Interaction\Models\InteractionType;
+use AdvisingApp\Team\Models\Department;
 use App\Models\User;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\ToggleButtons;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -110,7 +112,7 @@ it('requires population group on campaign creation', function () {
         ]);
 });
 
-it('only offers the user\'s own and department\'s population groups when they lack the group.*.view permission', function () {
+it('only offers the user\'s own population groups by default when they lack the group.*.view permission', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
     $user->givePermissionTo('campaign.view-any');
     $user->givePermissionTo('campaign.create');
@@ -119,7 +121,7 @@ it('only offers the user\'s own and department\'s population groups when they la
 
     actingAs($user);
 
-    $otherUsersGroup = Group::factory()->create();
+    $otherUsersGroup = Group::factory()->create(['model' => GroupModel::default()]);
 
     livewire(CreateCampaign::class)
         ->assertFormFieldExists(
@@ -132,7 +134,23 @@ it('only offers the user\'s own and department\'s population groups when they la
         );
 });
 
-it('offers every population group when the user has the group.*.view permission', function () {
+it('hides the All Groups ownership option for users without the group.*.view or group.view-any permission', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('campaign.view-any');
+    $user->givePermissionTo('campaign.create');
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    actingAs($user);
+
+    livewire(CreateCampaign::class)
+        ->assertFormFieldExists(
+            'group_ownership',
+            fn (ToggleButtons $field) => ! array_key_exists('all', $field->getOptions()),
+        );
+});
+
+it('offers every population group of the selected type when the All Groups ownership option is selected', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
     $user->givePermissionTo('campaign.view-any');
     $user->givePermissionTo('campaign.create');
@@ -142,9 +160,13 @@ it('offers every population group when the user has the group.*.view permission'
 
     actingAs($user);
 
-    $otherUsersGroup = Group::factory()->create();
+    $otherUsersGroup = Group::factory()->create(['model' => GroupModel::Student]);
 
     livewire(CreateCampaign::class)
+        ->fillForm([
+            'population_type' => GroupModel::Student->value,
+            'group_ownership' => 'all',
+        ])
         ->assertFormFieldExists(
             'segment_id',
             function (Select $field) use ($otherUsersGroup) {
@@ -153,4 +175,74 @@ it('offers every population group when the user has the group.*.view permission'
                 return true;
             },
         );
+});
+
+it('offers only the groups belonging to the user\'s department when the My Department\'s Groups ownership option is selected', function () {
+    $department = Department::factory()->create();
+
+    $user = User::factory()->licensed(LicenseType::cases())->create(['team_id' => $department->id]);
+    $user->givePermissionTo('campaign.view-any');
+    $user->givePermissionTo('campaign.create');
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    $colleague = User::factory()->create(['team_id' => $department->id]);
+    $colleaguesGroup = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => $colleague->id]);
+    $outsidersGroup = Group::factory()->create(['model' => GroupModel::Student]);
+
+    actingAs($user);
+
+    livewire(CreateCampaign::class)
+        ->fillForm([
+            'population_type' => GroupModel::Student->value,
+            'group_ownership' => 'department',
+        ])
+        ->assertFormFieldExists(
+            'segment_id',
+            function (Select $field) use ($colleaguesGroup, $outsidersGroup) {
+                expect($field->getOptions())
+                    ->toHaveKey($colleaguesGroup->getKey())
+                    ->not->toHaveKey($outsidersGroup->getKey());
+
+                return true;
+            },
+        );
+});
+
+it('filters the population group options by the selected population type', function () {
+    $studentGroup = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => auth()->id()]);
+    $prospectGroup = Group::factory()->create(['model' => GroupModel::Prospect, 'user_id' => auth()->id()]);
+
+    livewire(CreateCampaign::class)
+        ->fillForm(['population_type' => GroupModel::Prospect->value])
+        ->assertFormFieldExists(
+            'segment_id',
+            function (Select $field) use ($studentGroup, $prospectGroup) {
+                expect($field->getOptions())
+                    ->toHaveKey($prospectGroup->getKey())
+                    ->not->toHaveKey($studentGroup->getKey());
+
+                return true;
+            },
+        );
+});
+
+it('clears the selected population group when the population type changes', function () {
+    $studentGroup = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => auth()->id()]);
+
+    livewire(CreateCampaign::class)
+        ->fillForm(['segment_id' => $studentGroup->getKey()])
+        ->assertSchemaStateSet(['segment_id' => $studentGroup->getKey()])
+        ->fillForm(['population_type' => GroupModel::Prospect->value])
+        ->assertSchemaStateSet(['segment_id' => null]);
+});
+
+it('clears the selected population group when the group ownership changes', function () {
+    $studentGroup = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => auth()->id()]);
+
+    livewire(CreateCampaign::class)
+        ->fillForm(['segment_id' => $studentGroup->getKey()])
+        ->assertSchemaStateSet(['segment_id' => $studentGroup->getKey()])
+        ->fillForm(['group_ownership' => 'all'])
+        ->assertSchemaStateSet(['segment_id' => null]);
 });

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/CreateCampaignTest.php
@@ -52,6 +52,9 @@ use Filament\Forms\Components\Select;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
+
+use Spatie\Permission\PermissionRegistrar;
+
 use function Tests\asSuperAdmin;
 
 beforeEach(function () {
@@ -112,6 +115,8 @@ it('only offers the user\'s own and department\'s population groups when they la
     $user->givePermissionTo('campaign.view-any');
     $user->givePermissionTo('campaign.create');
 
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
     actingAs($user);
 
     $otherUsersGroup = Group::factory()->create();
@@ -119,7 +124,11 @@ it('only offers the user\'s own and department\'s population groups when they la
     livewire(CreateCampaign::class)
         ->assertFormFieldExists(
             'segment_id',
-            fn (Select $field) => ! array_key_exists($otherUsersGroup->getKey(), $field->getOptions()),
+            function (Select $field) use ($otherUsersGroup) {
+                expect($field->getOptions())->not->toHaveKey($otherUsersGroup->getKey());
+
+                return true;
+            },
         );
 });
 
@@ -129,6 +138,8 @@ it('offers every population group when the user has the group.*.view permission'
     $user->givePermissionTo('campaign.create');
     $user->givePermissionTo('group.*.view');
 
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
     actingAs($user);
 
     $otherUsersGroup = Group::factory()->create();
@@ -136,6 +147,10 @@ it('offers every population group when the user has the group.*.view permission'
     livewire(CreateCampaign::class)
         ->assertFormFieldExists(
             'segment_id',
-            fn (Select $field) => array_key_exists($otherUsersGroup->getKey(), $field->getOptions()),
+            function (Select $field) use ($otherUsersGroup) {
+                expect($field->getOptions())->toHaveKey($otherUsersGroup->getKey());
+
+                return true;
+            },
         );
 });

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\Campaign\Tests\Tenant\Filament\Resources\Campaigns\Pages;
 
 use AdvisingApp\Authorization\Enums\LicenseType;
+use AdvisingApp\Campaign\Enums\GroupOwnership;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\EditCampaign;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\ListCampaigns;
 use AdvisingApp\Campaign\Models\Campaign;
@@ -182,7 +183,7 @@ test('group ownership and population type are pre-selected to match a group the 
     livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
         ->assertSchemaStateSet([
             'population_type' => GroupModel::Prospect->value,
-            'group_ownership' => 'mine',
+            'group_ownership' => GroupOwnership::Mine->value,
         ]);
 });
 
@@ -206,7 +207,7 @@ test('group ownership is pre-selected to My Department\'s Groups when the group 
     livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
         ->assertSchemaStateSet([
             'population_type' => GroupModel::Student->value,
-            'group_ownership' => 'department',
+            'group_ownership' => GroupOwnership::Department->value,
         ]);
 });
 
@@ -225,7 +226,7 @@ test('group ownership is pre-selected to All Groups when the group is neither th
 
     livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
         ->assertSchemaStateSet([
-            'group_ownership' => 'all',
+            'group_ownership' => GroupOwnership::All->value,
         ]);
 });
 
@@ -236,4 +237,23 @@ test('population type cannot be changed when editing an existing campaign', func
 
     livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
         ->assertFormFieldDisabled('population_type');
+});
+
+test('rejects a segment_id that does not match the campaign\'s original population type, even when population_type is tampered with via form state', function () {
+    asSuperAdmin();
+
+    $studentGroup = Group::factory()->student()->create();
+    $campaign = Campaign::factory()->enabled()->create(['segment_id' => $studentGroup->id]);
+
+    $prospectGroup = Group::factory()->prospect()->create();
+
+    livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
+        ->fillForm([
+            'population_type' => GroupModel::Prospect->value,
+            'segment_id' => $prospectGroup->getKey(),
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['segment_id']);
+
+    expect($campaign->fresh()->segment_id)->toBe($studentGroup->getKey());
 });

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
@@ -176,7 +176,7 @@ test('group ownership and population type are pre-selected to match a group the 
 
     actingAs($user);
 
-    $group = Group::factory()->create(['model' => GroupModel::Prospect, 'user_id' => $user->id]);
+    $group = Group::factory()->prospect()->create(['user_id' => $user->id]);
     $campaign = Campaign::factory()->enabled()->create(['segment_id' => $group->id]);
 
     livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
@@ -198,7 +198,7 @@ test('group ownership is pre-selected to My Department\'s Groups when the group 
     app(PermissionRegistrar::class)->forgetCachedPermissions();
 
     $colleague = User::factory()->create(['team_id' => $department->id]);
-    $group = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => $colleague->id]);
+    $group = Group::factory()->student()->create(['user_id' => $colleague->id]);
     $campaign = Campaign::factory()->enabled()->create(['segment_id' => $group->id]);
 
     actingAs($user);

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
@@ -40,7 +40,9 @@ use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\EditCampaign;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\ListCampaigns;
 use AdvisingApp\Campaign\Models\Campaign;
+use AdvisingApp\Group\Enums\GroupModel;
 use AdvisingApp\Group\Models\Group;
+use AdvisingApp\Team\Models\Department;
 use App\Models\User;
 use Filament\Forms\Components\Select;
 
@@ -136,7 +138,7 @@ test('archive action redirects to index after archiving', function () {
         ->assertRedirect(ListCampaigns::getUrl());
 });
 
-test('population group select offers every group the user has permission to view, not just their own or department\'s', function () {
+test('population group select offers every group of the appropriate type once the All Groups ownership is inferred', function () {
     $user = User::factory()->licensed(LicenseType::cases())->create();
     $user->givePermissionTo('campaign.view-any');
     $user->givePermissionTo('campaign.*.view');
@@ -148,7 +150,7 @@ test('population group select offers every group the user has permission to view
     actingAs($user);
 
     $campaign = Campaign::factory()->enabled()->create();
-    $otherUsersGroup = Group::factory()->create();
+    $otherUsersGroup = Group::factory()->create(['model' => $campaign->group->model]);
 
     livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
         ->assertFormFieldExists(
@@ -161,4 +163,68 @@ test('population group select offers every group the user has permission to view
                 return true;
             },
         );
+});
+
+test('group ownership and population type are pre-selected to match a group the user owns', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('campaign.view-any');
+    $user->givePermissionTo('campaign.*.view');
+    $user->givePermissionTo('campaign.*.update');
+    $user->givePermissionTo('group.*.view');
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    actingAs($user);
+
+    $group = Group::factory()->create(['model' => GroupModel::Prospect, 'user_id' => $user->id]);
+    $campaign = Campaign::factory()->enabled()->create(['segment_id' => $group->id]);
+
+    livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
+        ->assertSchemaStateSet([
+            'population_type' => GroupModel::Prospect->value,
+            'group_ownership' => 'mine',
+        ]);
+});
+
+test('group ownership is pre-selected to My Department\'s Groups when the group belongs to a department colleague', function () {
+    $department = Department::factory()->create();
+
+    $user = User::factory()->licensed(LicenseType::cases())->create(['team_id' => $department->id]);
+    $user->givePermissionTo('campaign.view-any');
+    $user->givePermissionTo('campaign.*.view');
+    $user->givePermissionTo('campaign.*.update');
+    $user->givePermissionTo('group.*.view');
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    $colleague = User::factory()->create(['team_id' => $department->id]);
+    $group = Group::factory()->create(['model' => GroupModel::Student, 'user_id' => $colleague->id]);
+    $campaign = Campaign::factory()->enabled()->create(['segment_id' => $group->id]);
+
+    actingAs($user);
+
+    livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
+        ->assertSchemaStateSet([
+            'population_type' => GroupModel::Student->value,
+            'group_ownership' => 'department',
+        ]);
+});
+
+test('group ownership is pre-selected to All Groups when the group is neither the user\'s own nor their department\'s', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('campaign.view-any');
+    $user->givePermissionTo('campaign.*.view');
+    $user->givePermissionTo('campaign.*.update');
+    $user->givePermissionTo('group.*.view');
+
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+    actingAs($user);
+
+    $campaign = Campaign::factory()->enabled()->create();
+
+    livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
+        ->assertSchemaStateSet([
+            'group_ownership' => 'all',
+        ]);
 });

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
@@ -46,6 +46,9 @@ use Filament\Forms\Components\Select;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
+
+use Spatie\Permission\PermissionRegistrar;
+
 use function Tests\asSuperAdmin;
 
 test('archive action is visible on edit page', function () {
@@ -140,6 +143,8 @@ test('population group select offers every group the user has permission to view
     $user->givePermissionTo('campaign.*.update');
     $user->givePermissionTo('group.*.view');
 
+    app(PermissionRegistrar::class)->forgetCachedPermissions();
+
     actingAs($user);
 
     $campaign = Campaign::factory()->enabled()->create();
@@ -148,7 +153,12 @@ test('population group select offers every group the user has permission to view
     livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
         ->assertFormFieldExists(
             'segment_id',
-            fn (Select $field) => array_key_exists($otherUsersGroup->getKey(), $field->getOptions())
-                && array_key_exists($campaign->segment_id, $field->getOptions()),
+            function (Select $field) use ($otherUsersGroup, $campaign) {
+                expect($field->getOptions())
+                    ->toHaveKey($otherUsersGroup->getKey())
+                    ->toHaveKey($campaign->segment_id);
+
+                return true;
+            },
         );
 });

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
@@ -40,7 +40,9 @@ use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\EditCampaign;
 use AdvisingApp\Campaign\Filament\Resources\Campaigns\Pages\ListCampaigns;
 use AdvisingApp\Campaign\Models\Campaign;
+use AdvisingApp\Group\Models\Group;
 use App\Models\User;
+use Filament\Forms\Components\Select;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -129,4 +131,24 @@ test('archive action redirects to index after archiving', function () {
     livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
         ->callAction('archive')
         ->assertRedirect(ListCampaigns::getUrl());
+});
+
+test('population group select offers every group the user has permission to view, not just their own or department\'s', function () {
+    $user = User::factory()->licensed(LicenseType::cases())->create();
+    $user->givePermissionTo('campaign.view-any');
+    $user->givePermissionTo('campaign.*.view');
+    $user->givePermissionTo('campaign.*.update');
+    $user->givePermissionTo('group.*.view');
+
+    actingAs($user);
+
+    $campaign = Campaign::factory()->enabled()->create();
+    $otherUsersGroup = Group::factory()->create();
+
+    livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
+        ->assertFormFieldExists(
+            'segment_id',
+            fn (Select $field) => array_key_exists($otherUsersGroup->getKey(), $field->getOptions())
+                && array_key_exists($campaign->segment_id, $field->getOptions()),
+        );
 });

--- a/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Resources/Campaigns/Pages/EditCampaignTest.php
@@ -228,3 +228,12 @@ test('group ownership is pre-selected to All Groups when the group is neither th
             'group_ownership' => 'all',
         ]);
 });
+
+test('population type cannot be changed when editing an existing campaign', function () {
+    asSuperAdmin();
+
+    $campaign = Campaign::factory()->enabled()->create();
+
+    livewire(EditCampaign::class, ['record' => $campaign->getRouteKey()])
+        ->assertFormFieldDisabled('population_type');
+});

--- a/app-modules/group/database/factories/GroupFactory.php
+++ b/app-modules/group/database/factories/GroupFactory.php
@@ -73,4 +73,18 @@ class GroupFactory extends Factory
             'type' => GroupType::Static,
         ]);
     }
+
+    public function student(): self
+    {
+        return $this->state([
+            'model' => GroupModel::Student,
+        ]);
+    }
+
+    public function prospect(): self
+    {
+        return $this->state([
+            'model' => GroupModel::Prospect,
+        ]);
+    }
 }


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2885

### Technical Description

> Some users have reported that in campaigns, the population group drop‑down only shows their population groups

### Any deployment steps required?

> NO

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
