### PR TITLE
[ADVAPP-2900]: Some Settings pages are inaccessible to users who have permission

### DIFF
--- a/app-modules/campaign/src/Filament/Pages/ManageCampaignSettings.php
+++ b/app-modules/campaign/src/Filament/Pages/ManageCampaignSettings.php
@@ -65,7 +65,7 @@ class ManageCampaignSettings extends SettingsPage
         /** @var User $user */
         $user = auth()->user();
 
-        return $user->can(['product_admin.view-any', 'product_admin.*.view', 'product_admin.*.update']);
+        return $user->can(['settings.view-any', 'settings.*.view', 'settings.*.update']);
     }
 
     public function form(Schema $schema): Schema

--- a/app-modules/campaign/tests/Tenant/Filament/Pages/ManageCampaignSettingsTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Pages/ManageCampaignSettingsTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Campaign\Filament\Pages\ManageCampaignSettings;
 use App\Models\User;
 

--- a/app-modules/campaign/tests/Tenant/Filament/Pages/ManageCampaignSettingsTest.php
+++ b/app-modules/campaign/tests/Tenant/Filament/Pages/ManageCampaignSettingsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use AdvisingApp\Campaign\Filament\Pages\ManageCampaignSettings;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+it('requires all three permissions to access', function (array $permissions, bool $accessible) {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo($permissions);
+
+    actingAs($user);
+
+    $response = get(ManageCampaignSettings::getUrl());
+
+    $accessible ? $response->assertOk() : $response->assertForbidden();
+})->with([
+    'none' => [[], false],
+    'view-any only' => [['settings.view-any'], false],
+    'view only' => [['settings.*.view'], false],
+    'update only' => [['settings.*.update'], false],
+    'view-any + view' => [['settings.view-any', 'settings.*.view'], false],
+    'view-any + update' => [['settings.view-any', 'settings.*.update'], false],
+    'view + update' => [['settings.*.view', 'settings.*.update'], false],
+    'view-any + view + update' => [['settings.view-any', 'settings.*.view', 'settings.*.update'], true],
+]);

--- a/app-modules/prospect/src/Filament/Pages/ManageProspectConversionSettings.php
+++ b/app-modules/prospect/src/Filament/Pages/ManageProspectConversionSettings.php
@@ -99,15 +99,11 @@ class ManageProspectConversionSettings extends SettingsPage
                             ->required(),
                     ]),
             ])
-            ->disabled(! auth()->user()->can('product_admin.*.update'));
+            ->disabled(! auth()->user()->can('settings.*.update'));
     }
 
     public function save(): void
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
-            return;
-        }
-
         if (! auth()->user()->can('settings.*.update')) {
             return;
         }
@@ -120,10 +116,6 @@ class ManageProspectConversionSettings extends SettingsPage
      */
     public function getFormActions(): array
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
-            return [];
-        }
-
         if (! auth()->user()->can('settings.*.update')) {
             return [];
         }

--- a/app-modules/prospect/tests/Tenant/Filament/Pages/ManageProspectConversionSettingsTest.php
+++ b/app-modules/prospect/tests/Tenant/Filament/Pages/ManageProspectConversionSettingsTest.php
@@ -112,7 +112,7 @@ it('requires proper permissions to update settings', function () {
         ])
         ->call('save');
 
-    expect($settings->estimated_average_revenue->getAmount())->toBe(Money::parseByDecimal('100', 'USD')->getAmount());
+    expect(app(ProspectConversionSettings::class)->estimated_average_revenue->getAmount())->toBe(Money::parseByDecimal('100', 'USD')->getAmount());
 
     $user->givePermissionTo('settings.*.update');
 
@@ -122,5 +122,5 @@ it('requires proper permissions to update settings', function () {
         ])
         ->call('save');
 
-    expect($settings->estimated_average_revenue->getAmount())->toBe(Money::parseByDecimal('200', 'USD')->getAmount());
+    expect(app(ProspectConversionSettings::class)->estimated_average_revenue->getAmount())->toBe(Money::parseByDecimal('200', 'USD')->getAmount());
 });

--- a/app-modules/prospect/tests/Tenant/Filament/Pages/ManageProspectConversionSettingsTest.php
+++ b/app-modules/prospect/tests/Tenant/Filament/Pages/ManageProspectConversionSettingsTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Prospect\Filament\Pages\ManageProspectConversionSettings;
 use AdvisingApp\Prospect\Models\Prospect;
 use App\Models\User;

--- a/app-modules/prospect/tests/Tenant/Filament/Pages/ManageProspectConversionSettingsTest.php
+++ b/app-modules/prospect/tests/Tenant/Filament/Pages/ManageProspectConversionSettingsTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use AdvisingApp\Prospect\Filament\Pages\ManageProspectConversionSettings;
+use AdvisingApp\Prospect\Models\Prospect;
+use App\Models\User;
+use App\Settings\ProspectConversionSettings;
+use Cknow\Money\Money;
+use Filament\Actions\Testing\TestAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+
+it('requires a prospect license and the proper permission to access', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    get(ManageProspectConversionSettings::getUrl())
+        ->assertForbidden();
+
+    $user = User::factory()->licensed(Prospect::getLicenseType())->create();
+
+    actingAs($user);
+
+    get(ManageProspectConversionSettings::getUrl())
+        ->assertForbidden();
+
+    $user->givePermissionTo('settings.view-any');
+
+    get(ManageProspectConversionSettings::getUrl())
+        ->assertOk();
+});
+
+it('disables the form without the `settings.*.update` permission', function () {
+    $user = User::factory()->licensed(Prospect::getLicenseType())->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ManageProspectConversionSettings::class)
+        ->assertFormFieldDisabled('estimated_average_revenue');
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageProspectConversionSettings::class)
+        ->assertFormFieldEnabled('estimated_average_revenue');
+});
+
+it('hides the `save` action without the `settings.*.update` permission', function () {
+    $user = User::factory()->licensed(Prospect::getLicenseType())->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ManageProspectConversionSettings::class)
+        ->assertActionDoesNotExist(TestAction::make('save')->schemaComponent('form-actions', schema: 'content'));
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageProspectConversionSettings::class)
+        ->assertActionVisible(TestAction::make('save')->schemaComponent('form-actions', schema: 'content'));
+});
+
+it('requires proper permissions to update settings', function () {
+    $user = User::factory()->licensed(Prospect::getLicenseType())->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    $settings = app(ProspectConversionSettings::class);
+    $settings->estimated_average_revenue = Money::parseByDecimal('100', 'USD');
+    $settings->save();
+
+    livewire(ManageProspectConversionSettings::class)
+        ->fillForm([
+            'estimated_average_revenue' => '200.00',
+        ])
+        ->call('save');
+
+    expect($settings->estimated_average_revenue->getAmount())->toBe(Money::parseByDecimal('100', 'USD')->getAmount());
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageProspectConversionSettings::class)
+        ->fillForm([
+            'estimated_average_revenue' => '200.00',
+        ])
+        ->call('save');
+
+    expect($settings->estimated_average_revenue->getAmount())->toBe(Money::parseByDecimal('200', 'USD')->getAmount());
+});

--- a/app-modules/student-data-model/src/Filament/Pages/ManageStudentInformationSystemSettings.php
+++ b/app-modules/student-data-model/src/Filament/Pages/ManageStudentInformationSystemSettings.php
@@ -102,7 +102,7 @@ class ManageStudentInformationSystemSettings extends SettingsPage
                             ->default(EnrollmentSemesterAutoImportDefaultOrder::First)
                             ->visible(fn (Get $get): bool => $get('is_enrollment_semester_auto_import_enabled')),
                     ])
-                    ->disabled(! auth()->user()->can('product_admin.*.update')),
+                    ->disabled(! auth()->user()->can('settings.*.update')),
                 Section::make('Student Record Management')
                     ->description('If toggled, this enables direct editing of student records without relying on SIS synchronization.')
                     ->schema([
@@ -110,13 +110,13 @@ class ManageStudentInformationSystemSettings extends SettingsPage
                             ->label('Enable')
                             ->default(false),
                     ])
-                    ->disabled(! auth()->user()->can('product_admin.*.update')),
+                    ->disabled(! auth()->user()->can('settings.*.update')),
             ]);
     }
 
     public function save(): void
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (! auth()->user()->can('settings.*.update')) {
             return;
         }
 
@@ -128,7 +128,7 @@ class ManageStudentInformationSystemSettings extends SettingsPage
      */
     public function getFormActions(): array
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (! auth()->user()->can('settings.*.update')) {
             return [];
         }
 

--- a/app-modules/student-data-model/src/Filament/Resources/Students/Pages/ListStudents.php
+++ b/app-modules/student-data-model/src/Filament/Resources/Students/Pages/ListStudents.php
@@ -191,7 +191,7 @@ class ListStudents extends ListRecords
                         /** @var User $user */
                         $user = auth()->user();
 
-                        return $user->can('product_admin.*.view');
+                        return $user->can('settings.*.view');
                     }),
                 SubscribeTableAction::make(),
             ])

--- a/app-modules/student-data-model/tests/Tenant/Filament/Pages/ManageStudentInformationSystemSettingsTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Pages/ManageStudentInformationSystemSettingsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use AdvisingApp\StudentDataModel\Filament\Pages\ManageStudentInformationSystemSettings;
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Tests\asSuperAdmin;
+
+it('is gated with proper access control', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    get(ManageStudentInformationSystemSettings::getUrl())->assertForbidden();
+
+    asSuperAdmin();
+
+    get(ManageStudentInformationSystemSettings::getUrl())->assertOk();
+});

--- a/app-modules/student-data-model/tests/Tenant/Filament/Pages/ManageStudentInformationSystemSettingsTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Pages/ManageStudentInformationSystemSettingsTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\StudentDataModel\Filament\Pages\ManageStudentInformationSystemSettings;
 use App\Models\User;
 

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/Students/Pages/ListStudentsTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/Students/Pages/ListStudentsTest.php
@@ -43,6 +43,7 @@ use AdvisingApp\StudentDataModel\Settings\ManageStudentConfigurationSettings;
 use App\Models\User;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\ViewAction;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -123,6 +124,25 @@ it('the delete bulk action is gated by the delete permission', function () {
     livewire(ListStudents::class)
         ->assertOk()
         ->assertTableBulkActionVisible(DeleteBulkAction::class);
+});
+
+it('shows the view action only with the `settings.*.view` permission', function () {
+    $user = User::factory()->licensed(Student::getLicenseType())->create();
+
+    $user->givePermissionTo('student.view-any');
+    $user->givePermissionTo('student.*.view');
+
+    actingAs($user);
+
+    $student = Student::factory()->create();
+
+    livewire(ListStudents::class)
+        ->assertTableActionHidden(ViewAction::class, $student);
+
+    $user->givePermissionTo('settings.*.view');
+
+    livewire(ListStudents::class)
+        ->assertTableActionVisible(ViewAction::class, $student);
 });
 
 it('can filter students by concerns', function () {

--- a/app-modules/theme/src/Filament/Pages/ManageCollegeBrandingSettings.php
+++ b/app-modules/theme/src/Filament/Pages/ManageCollegeBrandingSettings.php
@@ -95,12 +95,12 @@ class ManageCollegeBrandingSettings extends SettingsPage
                     ->visible(fn (Get $get) => $get('is_enabled'))
                     ->required(),
             ])
-            ->disabled(! auth()->user()->can('product_admin.*.update'));
+            ->disabled(! auth()->user()->can('settings.*.update'));
     }
 
     public function save(): void
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (! auth()->user()->can('settings.*.update')) {
             return;
         }
 
@@ -126,7 +126,7 @@ class ManageCollegeBrandingSettings extends SettingsPage
      */
     public function getFormActions(): array
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (! auth()->user()->can('settings.*.update')) {
             return [];
         }
 

--- a/app-modules/theme/tests/Tenant/Filament/Pages/ManageCollegeBrandingSettingsTest.php
+++ b/app-modules/theme/tests/Tenant/Filament/Pages/ManageCollegeBrandingSettingsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use AdvisingApp\Theme\Filament\Pages\ManageCollegeBrandingSettings;
+use App\Models\User;
+use App\Settings\CollegeBrandingSettings;
+use CanyonGBS\Common\Enums\Color;
+use Filament\Actions\Testing\TestAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+
+it('requires proper permissions to access', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    get(ManageCollegeBrandingSettings::getUrl())
+        ->assertForbidden();
+
+    $user->givePermissionTo('settings.view-any');
+
+    get(ManageCollegeBrandingSettings::getUrl())
+        ->assertOk();
+});
+
+it('disables the form without the `settings.*.update` permission', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ManageCollegeBrandingSettings::class)
+        ->assertFormFieldDisabled('is_enabled')
+        ->assertFormFieldDisabled('dismissible')
+        ->assertFormFieldDisabled('college_text')
+        ->assertFormFieldDisabled('color');
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageCollegeBrandingSettings::class)
+        ->assertFormFieldEnabled('is_enabled')
+        ->assertFormFieldEnabled('dismissible')
+        ->assertFormFieldEnabled('college_text')
+        ->assertFormFieldEnabled('color');
+});
+
+it('hides the `save` action without the `settings.*.update` permission', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ManageCollegeBrandingSettings::class)
+        ->assertActionDoesNotExist(TestAction::make('save')->schemaComponent('form-actions', schema: 'content'));
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageCollegeBrandingSettings::class)
+        ->assertActionVisible(TestAction::make('save')->schemaComponent('form-actions', schema: 'content'));
+});
+
+it('requires proper permissions to update settings', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    $settings = app(CollegeBrandingSettings::class);
+    $settings->is_enabled = true;
+    $settings->dismissible = true;
+    $settings->college_text = 'Existing College Text';
+    $settings->color = Color::Blue;
+    $settings->save();
+
+    livewire(ManageCollegeBrandingSettings::class)
+        ->fillForm([
+            'is_enabled' => true,
+            'dismissible' => false,
+            'college_text' => 'New College Text',
+            'color' => Color::Red->value,
+        ])
+        ->call('save');
+
+    expect($settings->college_text)->toBe('Existing College Text')
+        ->and($settings->color)->toBe(Color::Blue);
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageCollegeBrandingSettings::class)
+        ->fillForm([
+            'is_enabled' => true,
+            'dismissible' => false,
+            'college_text' => 'New College Text',
+            'color' => Color::Red->value,
+        ])
+        ->call('save');
+
+    expect($settings->college_text)->toBe('New College Text')
+        ->and($settings->color)->toBe(Color::Red);
+});

--- a/app-modules/theme/tests/Tenant/Filament/Pages/ManageCollegeBrandingSettingsTest.php
+++ b/app-modules/theme/tests/Tenant/Filament/Pages/ManageCollegeBrandingSettingsTest.php
@@ -116,6 +116,8 @@ it('requires proper permissions to update settings', function () {
         ])
         ->call('save');
 
+    $settings = app(CollegeBrandingSettings::class);
+
     expect($settings->college_text)->toBe('Existing College Text')
         ->and($settings->color)->toBe(Color::Blue);
 
@@ -129,6 +131,8 @@ it('requires proper permissions to update settings', function () {
             'color' => Color::Red->value,
         ])
         ->call('save');
+
+    $settings = app(CollegeBrandingSettings::class);
 
     expect($settings->college_text)->toBe('New College Text')
         ->and($settings->color)->toBe(Color::Red);

--- a/app-modules/theme/tests/Tenant/Filament/Pages/ManageCollegeBrandingSettingsTest.php
+++ b/app-modules/theme/tests/Tenant/Filament/Pages/ManageCollegeBrandingSettingsTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Theme\Filament\Pages\ManageCollegeBrandingSettings;
 use App\Models\User;
 use App\Settings\CollegeBrandingSettings;

--- a/app/Filament/Pages/ManageDisplaySettings.php
+++ b/app/Filament/Pages/ManageDisplaySettings.php
@@ -70,12 +70,12 @@ class ManageDisplaySettings extends SettingsPage
                 TimezoneSelect::make('timezone')
                     ->helperText('Default: ' . config('app.timezone')),
             ])
-            ->disabled(! auth()->user()->can('product_admin.*.update'));
+            ->disabled(! auth()->user()->can('settings.*.update'));
     }
 
     public function save(): void
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (! auth()->user()->can('settings.*.update')) {
             return;
         }
 
@@ -87,7 +87,7 @@ class ManageDisplaySettings extends SettingsPage
      */
     public function getFormActions(): array
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (! auth()->user()->can('settings.*.update')) {
             return [];
         }
 

--- a/app/Filament/Pages/ManageInstitutionDetailsSettings.php
+++ b/app/Filament/Pages/ManageInstitutionDetailsSettings.php
@@ -97,12 +97,12 @@ class ManageInstitutionDetailsSettings extends SettingsPage
                     )
                     ->columnSpanFull(),
             ])
-            ->disabled(! auth()->user()->can('product_admin.*.update'));
+            ->disabled(! auth()->user()->can('settings.*.update'));
     }
 
     public function save(): void
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (! auth()->user()->can('settings.*.update')) {
             return;
         }
 
@@ -111,7 +111,7 @@ class ManageInstitutionDetailsSettings extends SettingsPage
 
     public function getFormActions(): array
     {
-        if (! auth()->user()->can('product_admin.*.update')) {
+        if (! auth()->user()->can('settings.*.update')) {
             return [];
         }
 

--- a/tests/Tenant/Feature/Filament/Pages/ManageDisplaySettingsTest.php
+++ b/tests/Tenant/Feature/Filament/Pages/ManageDisplaySettingsTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Filament\Pages\ManageDisplaySettings;
 use App\Models\User;
 use App\Settings\DisplaySettings;

--- a/tests/Tenant/Feature/Filament/Pages/ManageDisplaySettingsTest.php
+++ b/tests/Tenant/Feature/Filament/Pages/ManageDisplaySettingsTest.php
@@ -103,7 +103,7 @@ it('requires proper permissions to update settings', function () {
         ])
         ->call('save');
 
-    expect($settings->timezone)->toBe('America/Chicago');
+    expect(app(DisplaySettings::class)->timezone)->toBe('America/Chicago');
 
     $user->givePermissionTo('settings.*.update');
 
@@ -113,5 +113,5 @@ it('requires proper permissions to update settings', function () {
         ])
         ->call('save');
 
-    expect($settings->timezone)->toBe('America/New_York');
+    expect(app(DisplaySettings::class)->timezone)->toBe('America/New_York');
 });

--- a/tests/Tenant/Feature/Filament/Pages/ManageDisplaySettingsTest.php
+++ b/tests/Tenant/Feature/Filament/Pages/ManageDisplaySettingsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Filament\Pages\ManageDisplaySettings;
+use App\Models\User;
+use App\Settings\DisplaySettings;
+use Filament\Actions\Testing\TestAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+
+it('requires proper permissions to access', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    get(ManageDisplaySettings::getUrl())
+        ->assertForbidden();
+
+    $user->givePermissionTo('settings.view-any');
+
+    get(ManageDisplaySettings::getUrl())
+        ->assertOk();
+});
+
+it('disables the form without the `settings.*.update` permission', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ManageDisplaySettings::class)
+        ->assertFormFieldDisabled('timezone');
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageDisplaySettings::class)
+        ->assertFormFieldEnabled('timezone');
+});
+
+it('hides the `save` action without the `settings.*.update` permission', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ManageDisplaySettings::class)
+        ->assertActionDoesNotExist(TestAction::make('save')->schemaComponent('form-actions', schema: 'content'));
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageDisplaySettings::class)
+        ->assertActionVisible(TestAction::make('save')->schemaComponent('form-actions', schema: 'content'));
+});
+
+it('requires proper permissions to update settings', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    $settings = app(DisplaySettings::class);
+    $settings->timezone = 'America/Chicago';
+    $settings->save();
+
+    livewire(ManageDisplaySettings::class)
+        ->fillForm([
+            'timezone' => 'America/New_York',
+        ])
+        ->call('save');
+
+    expect($settings->timezone)->toBe('America/Chicago');
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageDisplaySettings::class)
+        ->fillForm([
+            'timezone' => 'America/New_York',
+        ])
+        ->call('save');
+
+    expect($settings->timezone)->toBe('America/New_York');
+});

--- a/tests/Tenant/Feature/Filament/Pages/ManageInstitutionDetailsSettingsTest.php
+++ b/tests/Tenant/Feature/Filament/Pages/ManageInstitutionDetailsSettingsTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Filament\Pages\ManageInstitutionDetailsSettings;
 use App\Models\User;
 use App\Settings\InstitutionDetailsSettings;

--- a/tests/Tenant/Feature/Filament/Pages/ManageInstitutionDetailsSettingsTest.php
+++ b/tests/Tenant/Feature/Filament/Pages/ManageInstitutionDetailsSettingsTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use App\Filament\Pages\ManageInstitutionDetailsSettings;
+use App\Models\User;
+use App\Settings\InstitutionDetailsSettings;
+use Filament\Actions\Testing\TestAction;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+
+it('requires proper permissions to access', function () {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    get(ManageInstitutionDetailsSettings::getUrl())
+        ->assertForbidden();
+
+    $user->givePermissionTo('settings.view-any');
+
+    get(ManageInstitutionDetailsSettings::getUrl())
+        ->assertOk();
+});
+
+it('disables the form without the `settings.*.update` permission', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ManageInstitutionDetailsSettings::class)
+        ->assertFormFieldDisabled('ipeds_id')
+        ->assertFormFieldDisabled('name')
+        ->assertFormFieldDisabled('dark_logo')
+        ->assertFormFieldDisabled('light_logo');
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageInstitutionDetailsSettings::class)
+        ->assertFormFieldEnabled('ipeds_id')
+        ->assertFormFieldEnabled('name')
+        ->assertFormFieldEnabled('dark_logo')
+        ->assertFormFieldEnabled('light_logo');
+});
+
+it('hides the `save` action without the `settings.*.update` permission', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    livewire(ManageInstitutionDetailsSettings::class)
+        ->assertActionDoesNotExist(TestAction::make('save')->schemaComponent('form-actions', schema: 'content'));
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageInstitutionDetailsSettings::class)
+        ->assertActionVisible(TestAction::make('save')->schemaComponent('form-actions', schema: 'content'));
+});
+
+it('requires proper permissions to update settings', function () {
+    $user = User::factory()->create();
+
+    $user->givePermissionTo('settings.view-any');
+    actingAs($user);
+
+    $settings = app(InstitutionDetailsSettings::class);
+    $settings->name = 'Existing Institution Name';
+    $settings->save();
+
+    livewire(ManageInstitutionDetailsSettings::class)
+        ->fillForm([
+            'name' => 'New Institution Name',
+        ])
+        ->call('save');
+
+    expect($settings->name)->toBe('Existing Institution Name');
+
+    $user->givePermissionTo('settings.*.update');
+
+    livewire(ManageInstitutionDetailsSettings::class)
+        ->fillForm([
+            'name' => 'New Institution Name',
+        ])
+        ->call('save');
+
+    expect($settings->name)->toBe('New Institution Name');
+});

--- a/tests/Tenant/Feature/Filament/Pages/ManageInstitutionDetailsSettingsTest.php
+++ b/tests/Tenant/Feature/Filament/Pages/ManageInstitutionDetailsSettingsTest.php
@@ -109,7 +109,7 @@ it('requires proper permissions to update settings', function () {
         ])
         ->call('save');
 
-    expect($settings->name)->toBe('Existing Institution Name');
+    expect(app(InstitutionDetailsSettings::class)->name)->toBe('Existing Institution Name');
 
     $user->givePermissionTo('settings.*.update');
 
@@ -119,5 +119,5 @@ it('requires proper permissions to update settings', function () {
         ])
         ->call('save');
 
-    expect($settings->name)->toBe('New Institution Name');
+    expect(app(InstitutionDetailsSettings::class)->name)->toBe('New Institution Name');
 });

--- a/tests/Tenant/Unit/ArchTest.php
+++ b/tests/Tenant/Unit/ArchTest.php
@@ -41,6 +41,7 @@ use Illuminate\Support\Collection;
 use InterNACHI\Modular\Support\ModuleConfig;
 use InterNACHI\Modular\Support\ModuleRegistry;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
 $legacyV4UuidModels = require __DIR__ . '/legacy-v4-uuid-models.php';
@@ -86,4 +87,32 @@ test('Legacy models must not use HasUuids (UUIDv7)', function () {
             "Class [{$class}] uses HasUuids (UUIDv7) directly. Legacy models must use HasVersion4Uuids instead.",
         );
     }
+});
+
+test('product_admin. permission strings only appear in database/migrations', function () {
+    $basePath = dirname(__DIR__, 3);
+
+    $finder = Finder::create()
+        ->in($basePath)
+        ->exclude([
+            '.cache',
+            'bootstrap/cache',
+            'storage',
+            'vendor',
+            'node_modules',
+            'database/migrations',
+        ])
+        ->notPath([
+            'database/migrations',
+            'tests/Tenant/Unit/ArchTest.php',
+        ])
+        ->ignoreDotFiles(false)
+        ->ignoreVCS(true)
+        ->contains('product_admin.');
+
+    Assert::assertEmpty(
+        iterator_to_array($finder),
+        "The permission string [product_admin.] should only appear in database/migrations, but was found in: \n" .
+            implode("\n", array_map(fn (SplFileInfo $file) => $file->getRelativePathname(), iterator_to_array($finder))),
+    );
 });

--- a/tests/Tenant/Unit/ArchTest.php
+++ b/tests/Tenant/Unit/ArchTest.php
@@ -110,9 +110,11 @@ test('product_admin. permission strings only appear in database/migrations', fun
         ->ignoreVCS(true)
         ->contains('product_admin.');
 
+      $matches = iterator_to_array($finder);
+
     Assert::assertEmpty(
-        iterator_to_array($finder),
+        $matches,
         "The permission string [product_admin.] should only appear in database/migrations, but was found in: \n" .
-            implode("\n", array_map(fn (SplFileInfo $file) => $file->getRelativePathname(), iterator_to_array($finder))),
+            implode("\n", array_map(fn (SplFileInfo $file) => $file->getRelativePathname(), $matches)),
     );
 });

--- a/tests/Tenant/Unit/ArchTest.php
+++ b/tests/Tenant/Unit/ArchTest.php
@@ -110,7 +110,7 @@ test('product_admin. permission strings only appear in database/migrations', fun
         ->ignoreVCS(true)
         ->contains('product_admin.');
 
-      $matches = iterator_to_array($finder);
+    $matches = iterator_to_array($finder);
 
     Assert::assertEmpty(
         $matches,


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2900

### Technical Description

Ensure product_admin permissions are fully replaced with settings permissions; add tests

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
