### PR TITLE
[ADVAPP-2916]: Stop errors about Azure SSO users not having profile pictures in Azure from appearing in Sentry

### DIFF
--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -101,21 +101,21 @@ class SocialiteController extends Controller
         }
 
         if ($provider === SocialiteProvider::Azure) {
-            // Retry transient Azure failures (connection errors, rate limits, server errors) but not client errors.
-            $response = Http::withToken($socialiteUser->token)
-                ->dontTruncateExceptions()
-                ->retry(3, 500, when: function (?Throwable $exception): bool {
-                    if ($exception instanceof ConnectionException) {
-                        return true;
-                    }
+            try {
+                // Retry transient Azure failures (connection errors, rate limits, server errors) but not client errors.
+                $response = Http::withToken($socialiteUser->token)
+                    ->dontTruncateExceptions()
+                    ->retry(3, 500, when: function (?Throwable $exception): bool {
+                        if ($exception instanceof ConnectionException) {
+                            return true;
+                        }
 
-                    return $exception instanceof RequestException
-                        && ($exception->response->serverError() || $exception->response->status() === 429);
-                }, throw: false)
-                ->get('https://graph.microsoft.com/v1.0/me/photo/$value');
+                        return $exception instanceof RequestException
+                            && ($exception->response->serverError() || $exception->response->status() === 429);
+                    }, throw: false)
+                    ->get('https://graph.microsoft.com/v1.0/me/photo/$value');
 
-            if ($response->successful()) {
-                try {
+                if ($response->successful()) {
                     $mimeType = $response->header('Content-Type');
 
                     if (in_array($mimeType, ['image/png', 'image/jpeg', 'image/webp', 'image/jpg', 'image/svg+xml'])) {
@@ -134,12 +134,13 @@ class SocialiteController extends Controller
                     } else {
                         throw new InvalidUserAvatarMimeType($mimeType, $user);
                     }
-                } catch (Throwable $exception) {
-                    report($exception);
+                } elseif ($response->failed() && $response->status() !== 404) {
+                    // A 404 means the user has no Azure profile photo, which is expected and safe to ignore.
+                    report($response->toException());
                 }
-            } elseif ($response->failed() && $response->status() !== 404) {
-                // A 404 means the user has no Azure profile photo, which is expected and safe to ignore.
-                report($response->toException());
+            } catch (Throwable $exception) {
+                // Fetching the avatar is best-effort; a failure (including an exhausted-retry ConnectionException) must not block login.
+                report($exception);
             }
         }
 

--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -43,8 +43,8 @@ use App\Models\User;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
-use Illuminate\Http\Client\Response;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Http;
@@ -101,37 +101,45 @@ class SocialiteController extends Controller
         }
 
         if ($provider === SocialiteProvider::Azure) {
-            try {
-                $request = Http::withToken($socialiteUser->token)
-                    ->dontTruncateExceptions()
-                    ->retry(3, 500)
-                    ->get('https://graph.microsoft.com/v1.0/me/photo/$value')
-                    ->throwIf(fn (Response $response) => $response->failed() && $response->status() !== 404);
-
-                $mimeType = $request->header('Content-Type');
-
-                if (in_array($mimeType, ['image/png', 'image/jpeg', 'image/webp', 'image/jpg', 'image/svg+xml'])) {
-                    $extension = (new MimeTypes())->getExtensions($mimeType)[0] ?? null;
-
-                    $body = $request->body();
-
-                    if ($extension && $body) {
-                        $media = $user->addMediaFromString($body)->usingFileName(Str::uuid() . '.' . $extension)->toMediaCollection('avatar');
-
-                        if (is_null($media->created_by_id)) {
-                            $media->createdBy()->associate($user);
-                            $media->saveQuietly();
-                        }
+            // Retry transient Azure failures (connection errors, rate limits, server errors) but not client errors.
+            $response = Http::withToken($socialiteUser->token)
+                ->dontTruncateExceptions()
+                ->retry(3, 500, when: function (Throwable $exception): bool {
+                    if ($exception instanceof ConnectionException) {
+                        return true;
                     }
-                } else {
-                    throw new InvalidUserAvatarMimeType($mimeType, $user);
-                }
-            } catch (RequestException $exception) {
-                if (! str_contains($exception->getMessage(), 'Microsoft.Fast.Profile.Core.Exception.ImageNotFoundException')) {
+
+                    return $exception instanceof RequestException
+                        && ($exception->response->serverError() || $exception->response->status() === 429);
+                }, throw: false)
+                ->get('https://graph.microsoft.com/v1.0/me/photo/$value');
+
+            if ($response->successful()) {
+                try {
+                    $mimeType = $response->header('Content-Type');
+
+                    if (in_array($mimeType, ['image/png', 'image/jpeg', 'image/webp', 'image/jpg', 'image/svg+xml'])) {
+                        $extension = (new MimeTypes())->getExtensions($mimeType)[0] ?? null;
+
+                        $body = $response->body();
+
+                        if ($extension && $body) {
+                            $media = $user->addMediaFromString($body)->usingFileName(Str::uuid() . '.' . $extension)->toMediaCollection('avatar');
+
+                            if (is_null($media->created_by_id)) {
+                                $media->createdBy()->associate($user);
+                                $media->saveQuietly();
+                            }
+                        }
+                    } else {
+                        throw new InvalidUserAvatarMimeType($mimeType, $user);
+                    }
+                } catch (Throwable $exception) {
                     report($exception);
                 }
-            } catch (Throwable $exception) {
-                report($exception);
+            } elseif ($response->status() !== 404) {
+                // A 404 means the user has no Azure profile photo, which is expected and safe to ignore.
+                report($response->toException());
             }
         }
 

--- a/app-modules/authorization/src/Http/Controllers/SocialiteController.php
+++ b/app-modules/authorization/src/Http/Controllers/SocialiteController.php
@@ -104,7 +104,7 @@ class SocialiteController extends Controller
             // Retry transient Azure failures (connection errors, rate limits, server errors) but not client errors.
             $response = Http::withToken($socialiteUser->token)
                 ->dontTruncateExceptions()
-                ->retry(3, 500, when: function (Throwable $exception): bool {
+                ->retry(3, 500, when: function (?Throwable $exception): bool {
                     if ($exception instanceof ConnectionException) {
                         return true;
                     }
@@ -137,7 +137,7 @@ class SocialiteController extends Controller
                 } catch (Throwable $exception) {
                     report($exception);
                 }
-            } elseif ($response->status() !== 404) {
+            } elseif ($response->failed() && $response->status() !== 404) {
                 // A 404 means the user has no Azure profile photo, which is expected and safe to ignore.
                 report($response->toException());
             }

--- a/app-modules/authorization/tests/Tenant/Http/Controllers/SocialiteControllerTest.php
+++ b/app-modules/authorization/tests/Tenant/Http/Controllers/SocialiteControllerTest.php
@@ -123,3 +123,24 @@ it('retries and reports transient Azure failures', function (int $status) {
     'server error' => [500],
     'rate limit' => [429],
 ]);
+
+it('does not report when Azure returns a non-error response that is not successful', function () {
+    Exceptions::fake();
+
+    $user = User::factory()->external()->create();
+
+    fakeAzureSocialiteDriver($user->email);
+
+    Http::fake([
+        'graph.microsoft.com/*' => Http::response('', 302),
+    ]);
+
+    get(route('socialite.callback', ['provider' => 'azure']))
+        ->assertRedirect();
+
+    assertAuthenticatedAs($user);
+
+    Http::assertSentCount(1);
+
+    Exceptions::assertNothingReported();
+});

--- a/app-modules/authorization/tests/Tenant/Http/Controllers/SocialiteControllerTest.php
+++ b/app-modules/authorization/tests/Tenant/Http/Controllers/SocialiteControllerTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Authorization\Enums\AzureMatchingProperty;
+use AdvisingApp\Authorization\Settings\AzureSsoSettings;
+use App\Models\User;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Exceptions;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Sleep;
+use Laravel\Socialite\Facades\Socialite;
+
+use function Pest\Laravel\assertAuthenticatedAs;
+use function Pest\Laravel\get;
+
+use SocialiteProviders\Azure\User as AzureUser;
+
+function fakeAzureSocialiteDriver(string $email): void
+{
+    $socialiteUser = new AzureUser();
+    $socialiteUser->principalName = $email;
+    $socialiteUser->mail = $email;
+    $socialiteUser->token = 'fake-token';
+    $socialiteUser->name = 'External User';
+    $socialiteUser->avatar = 'https://example.com/avatar.png';
+
+    $driver = Mockery::mock();
+    $driver->shouldReceive('setConfig')->andReturnSelf(); // @phpstan-ignore method.notFound
+    $driver->shouldReceive('user')->andReturn($socialiteUser);
+
+    Socialite::shouldReceive('driver')->andReturn($driver);
+}
+
+beforeEach(function () {
+    $settings = app(AzureSsoSettings::class);
+    $settings->matching_property = AzureMatchingProperty::UserPrincipalName;
+    $settings->save();
+
+    Sleep::fake();
+});
+
+it('does not report an error when the user has no Azure profile photo', function () {
+    Exceptions::fake();
+
+    $user = User::factory()->external()->create();
+
+    fakeAzureSocialiteDriver($user->email);
+
+    Http::fake([
+        'graph.microsoft.com/*' => Http::response([
+            'error' => [
+                'code' => 'ImageNotFound',
+                'message' => "Exception of type 'Microsoft.People.Image.Common.Exceptions.ImageNotFoundException' was thrown.",
+            ],
+        ], 404),
+    ]);
+
+    get(route('socialite.callback', ['provider' => 'azure']))
+        ->assertRedirect();
+
+    assertAuthenticatedAs($user);
+
+    Http::assertSentCount(1);
+
+    Exceptions::assertNothingReported();
+
+    expect($user->refresh()->getFirstMedia('avatar'))->toBeNull();
+});
+
+it('retries and reports transient Azure failures', function (int $status) {
+    Exceptions::fake();
+
+    $user = User::factory()->external()->create();
+
+    fakeAzureSocialiteDriver($user->email);
+
+    Http::fake([
+        'graph.microsoft.com/*' => Http::response('error', $status),
+    ]);
+
+    get(route('socialite.callback', ['provider' => 'azure']))
+        ->assertRedirect();
+
+    assertAuthenticatedAs($user);
+
+    Http::assertSentCount(3);
+
+    Exceptions::assertReported(RequestException::class);
+})->with([
+    'server error' => [500],
+    'rate limit' => [429],
+]);

--- a/app-modules/authorization/tests/Tenant/Http/Controllers/SocialiteControllerTest.php
+++ b/app-modules/authorization/tests/Tenant/Http/Controllers/SocialiteControllerTest.php
@@ -37,6 +37,7 @@
 use AdvisingApp\Authorization\Enums\AzureMatchingProperty;
 use AdvisingApp\Authorization\Settings\AzureSsoSettings;
 use App\Models\User;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Http;
@@ -143,4 +144,21 @@ it('does not report when Azure returns a non-error response that is not successf
     Http::assertSentCount(1);
 
     Exceptions::assertNothingReported();
+});
+
+it('still logs the user in and reports the error when the Azure photo request fails to connect', function () {
+    Exceptions::fake();
+
+    $user = User::factory()->external()->create();
+
+    fakeAzureSocialiteDriver($user->email);
+
+    Http::fake(fn () => throw new ConnectionException('Connection timed out'));
+
+    get(route('socialite.callback', ['provider' => 'azure']))
+        ->assertRedirect();
+
+    assertAuthenticatedAs($user);
+
+    Exceptions::assertReported(ConnectionException::class);
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2916

### Technical Description

Changes the Azure profile picture retrieval process to NOT send 404 exceptions to Sentry. This is not something we can do anything about if they don't have a profile picture in Azure, so it is just noise.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
