### PR TITLE
[ADVAPP-2940]: Prevent duplicate survey names

### DIFF
--- a/.cleanup-tasks/2026_09_01_rename_surveys_duplicate_name.md
+++ b/.cleanup-tasks/2026_09_01_rename_surveys_duplicate_name.md
@@ -1,0 +1,19 @@
+---
+title: Rename Surveys Duplicate Name
+created: 2026-09-01
+---
+
+## Feature Flags
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+Once the migration has run in every environment, remove the one-off duplicate-renaming step
+from `up()`. Delete only the `$this->fixDuplicates()` call and the `FixesDuplicateNames`
+trait import — the surrounding schema changes (drop the old constraint, convert the column to
+citext, create the partial unique index) are permanent and must stay.
+
+- `app-modules/survey/database/migrations/2026_09_01_122143_convert_surveys_name_to_citext.php`
+
+- If no other migration uses `FixesDuplicateNames` (`database/migrations/Concerns/FixesDuplicateNames.php`), restore its `// @phpstan-ignore trait.unused` annotation.

--- a/.cleanup-tasks/2026_09_01_rename_surveys_duplicate_name.md
+++ b/.cleanup-tasks/2026_09_01_rename_surveys_duplicate_name.md
@@ -9,11 +9,4 @@ created: 2026-09-01
 
 ## Additional Cleanup
 
-Once the migration has run in every environment, remove the one-off duplicate-renaming step
-from `up()`. Delete only the `$this->fixDuplicates()` call and the `FixesDuplicateNames`
-trait import — the surrounding schema changes (drop the old constraint, convert the column to
-citext, create the partial unique index) are permanent and must stay.
-
-- `app-modules/survey/database/migrations/2026_09_01_122143_convert_surveys_name_to_citext.php`
-
-- If no other migration uses `FixesDuplicateNames` (`database/migrations/Concerns/FixesDuplicateNames.php`), restore its `// @phpstan-ignore trait.unused` annotation.
+Search for `TODO: Cleanup Task SurveyCitextCleanup`

--- a/app-modules/survey/database/migrations/2026_09_01_122143_convert_surveys_name_to_citext.php
+++ b/app-modules/survey/database/migrations/2026_09_01_122143_convert_surveys_name_to_citext.php
@@ -42,12 +42,14 @@ use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
 return new class () extends Migration {
+    // TODO: Cleanup Task SurveyCitextCleanup - remove FixesDuplicateNames trait & usages (if no other migration uses it, restore its `// @phpstan-ignore trait.unused` annotation)
     use FixesDuplicateNames;
 
     protected string $table = 'surveys';
 
     protected string $column = 'name';
 
+    // TODO: Cleanup Task SurveyCitextCleanup - remove $chunkSize and $usesSoftDeletes
     protected int $chunkSize = 500;
 
     protected bool $usesSoftDeletes = true;
@@ -61,6 +63,7 @@ return new class () extends Migration {
                 $table->dropUnique($this->uniqueConstraint);
             });
 
+            // TODO: Cleanup Task SurveyCitextCleanup - remove the $this->fixDuplicates() call (the surrounding schema changes are permanent)
             $this->fixDuplicates();
 
             DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");

--- a/app-modules/survey/database/migrations/2026_09_01_122143_convert_surveys_name_to_citext.php
+++ b/app-modules/survey/database/migrations/2026_09_01_122143_convert_surveys_name_to_citext.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Database\Migrations\Concerns\FixesDuplicateNames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    use FixesDuplicateNames;
+
+    protected string $table = 'surveys';
+
+    protected string $column = 'name';
+
+    protected int $chunkSize = 500;
+
+    protected bool $usesSoftDeletes = true;
+
+    private string $uniqueConstraint = 'surveys_name_unique';
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUnique($this->uniqueConstraint);
+            });
+
+            $this->fixDuplicates();
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->uniqueIndex([$this->column], $this->uniqueConstraint)
+                    ->where(fn (Builder $condition) => $condition->whereNull('deleted_at'));
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUniqueIndex($this->uniqueConstraint);
+
+                $table->unique([$this->column], $this->uniqueConstraint);
+            });
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+        });
+    }
+};

--- a/app-modules/survey/database/migrations/2026_09_01_122143_convert_surveys_name_to_citext.php
+++ b/app-modules/survey/database/migrations/2026_09_01_122143_convert_surveys_name_to_citext.php
@@ -42,7 +42,7 @@ use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
 use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
 
 return new class () extends Migration {
-    // TODO: Cleanup Task SurveyCitextCleanup - remove FixesDuplicateNames trait & usages (if no other migration uses it, restore its `// @phpstan-ignore trait.unused` annotation)
+    // TODO: Cleanup Task SurveyCitextCleanup - remove FixesDuplicateNames trait & usages (if no other migration uses it, restore its trait.unused ignore annotation)
     use FixesDuplicateNames;
 
     protected string $table = 'surveys';

--- a/app-modules/survey/src/Filament/Resources/Surveys/Pages/Concerns/HasSharedFormConfiguration.php
+++ b/app-modules/survey/src/Filament/Resources/Surveys/Pages/Concerns/HasSharedFormConfiguration.php
@@ -57,6 +57,7 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Validation\Rules\Unique;
 
 trait HasSharedFormConfiguration
 {
@@ -70,7 +71,10 @@ trait HasSharedFormConfiguration
                 ->required()
                 ->string()
                 ->maxLength(255)
-                ->unique(ignoreRecord: true)
+                ->unique(
+                    ignoreRecord: true,
+                    modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                )
                 ->autocomplete(false)
                 ->columnSpanFull(),
             Textarea::make('description')

--- a/app-modules/survey/src/Filament/Resources/Surveys/Pages/ListSurveys.php
+++ b/app-modules/survey/src/Filament/Resources/Surveys/Pages/ListSurveys.php
@@ -51,6 +51,7 @@ use Filament\Resources\Pages\ListRecords;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Validation\Rules\Unique;
 
 class ListSurveys extends ListRecords
 {
@@ -83,7 +84,13 @@ class ListSurveys extends ListRecords
                         return $schema->components([
                             TextInput::make('name')
                                 ->label('Name')
-                                ->required(),
+                                ->required()
+                                ->string()
+                                ->maxLength(255)
+                                ->unique(
+                                    table: Survey::class,
+                                    modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                                ),
                         ]);
                     })
                     ->beforeReplicaSaved(function (Survey $replica, array $data): void {

--- a/app-modules/survey/tests/Tenant/Filament/Resources/Surveys/Pages/CreateSurveyTest.php
+++ b/app-modules/survey/tests/Tenant/Filament/Resources/Surveys/Pages/CreateSurveyTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Survey\Filament\Resources\Surveys\Pages\CreateSurvey;
+use AdvisingApp\Survey\Models\Survey;
+use App\Settings\LicenseSettings;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+beforeEach(function () {
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->onlineSurveys = true;
+    $settings->save();
+
+    asSuperAdmin();
+});
+
+it('can create a survey', function () {
+    livewire(CreateSurvey::class)
+        ->fillForm(['name' => 'My Survey'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    assertDatabaseHas(Survey::class, ['name' => 'My Survey']);
+});
+
+it('prevents creating a survey with a case-insensitively duplicate name', function () {
+    Survey::factory()->create(['name' => 'Existing Survey']);
+
+    livewire(CreateSurvey::class)
+        ->fillForm(['name' => 'existing survey'])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'unique']);
+});
+
+it('allows reusing the name of a soft-deleted survey', function () {
+    Survey::factory()->create(['name' => 'Reusable Name'])->delete();
+
+    livewire(CreateSurvey::class)
+        ->fillForm(['name' => 'reusable name'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    assertDatabaseHas(Survey::class, ['name' => 'reusable name']);
+});

--- a/app-modules/survey/tests/Tenant/Filament/Resources/Surveys/Pages/EditSurveyTest.php
+++ b/app-modules/survey/tests/Tenant/Filament/Resources/Surveys/Pages/EditSurveyTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Survey\Filament\Resources\Surveys\Pages\EditSurvey;
+use AdvisingApp\Survey\Models\Survey;
+use App\Settings\LicenseSettings;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+beforeEach(function () {
+    $settings = app(LicenseSettings::class);
+    $settings->data->addons->onlineSurveys = true;
+    $settings->save();
+
+    asSuperAdmin();
+});
+
+it('can update a survey', function () {
+    $survey = Survey::factory()->create(['name' => 'Original Name']);
+
+    livewire(EditSurvey::class, ['record' => $survey->id])
+        ->fillForm(['name' => 'Updated Name'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    assertDatabaseHas(Survey::class, [
+        'id' => $survey->id,
+        'name' => 'Updated Name',
+    ]);
+});
+
+it('allows saving a survey without changing its own name', function () {
+    $survey = Survey::factory()->create(['name' => 'Keep Name']);
+
+    livewire(EditSurvey::class, ['record' => $survey->id])
+        ->fillForm(['name' => 'keep name'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+});
+
+it('prevents renaming a survey to a case-insensitive duplicate', function () {
+    $survey = Survey::factory()->create(['name' => 'First Survey']);
+    Survey::factory()->create(['name' => 'Second Survey']);
+
+    livewire(EditSurvey::class, ['record' => $survey->id])
+        ->fillForm(['name' => 'second survey'])
+        ->call('save')
+        ->assertHasFormErrors(['name' => 'unique']);
+});
+
+it('allows renaming a survey to the name of a soft-deleted survey', function () {
+    $survey = Survey::factory()->create(['name' => 'Active Survey']);
+    Survey::factory()->create(['name' => 'Archived Survey'])->delete();
+
+    livewire(EditSurvey::class, ['record' => $survey->id])
+        ->fillForm(['name' => 'archived survey'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    assertDatabaseHas(Survey::class, [
+        'id' => $survey->id,
+        'name' => 'archived survey',
+    ]);
+});

--- a/app-modules/survey/tests/Tenant/Filament/Resources/Surveys/Pages/ListSurveysTest.php
+++ b/app-modules/survey/tests/Tenant/Filament/Resources/Surveys/Pages/ListSurveysTest.php
@@ -130,3 +130,17 @@ it('will not duplicate survey submissions if they exist', function () {
 
     expect($duplicatedSurvey->submissions()->count())->toBe(0);
 });
+
+it('prevents duplicating a survey to a case-insensitive duplicate name', function () {
+    asSuperAdmin();
+
+    $survey = Survey::factory()->create();
+    Survey::factory()->create(['name' => 'Taken Name']);
+
+    livewire(ListSurveys::class)
+        ->assertStatus(200)
+        ->callTableAction('Duplicate', $survey, data: ['name' => 'taken name'])
+        ->assertHasTableActionErrors(['name' => 'unique']);
+
+    expect(Survey::count())->toBe(2);
+});

--- a/database/migrations/Concerns/FixesDuplicateNames.php
+++ b/database/migrations/Concerns/FixesDuplicateNames.php
@@ -41,7 +41,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
-/** @phpstan-ignore trait.unused */
 trait FixesDuplicateNames
 {
     /**

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -128,3 +128,35 @@ test('2026_04_08_145038_rename_campaign_action_id_to_source_morph_on_engagements
         }
     );
 });
+
+describe('survey name citext change', function () {
+    it('deduplicates case-insensitive survey names before converting the column', function () {
+        isolatedMigration(
+            '2026_09_01_122143_convert_surveys_name_to_citext',
+            function () {
+                // Setup data before migration. A plain, case-sensitive unique index
+                // allows these three names to coexist prior to the citext conversion.
+                $survey1 = (string) Str::uuid();
+                $survey2 = (string) Str::uuid();
+                $survey3 = (string) Str::uuid();
+
+                DB::table('surveys')->insert([
+                    ['id' => $survey1, 'name' => 'Survey', 'created_at' => now()->subMinutes(3), 'updated_at' => now()],
+                    ['id' => $survey2, 'name' => 'survey', 'created_at' => now()->subMinutes(2), 'updated_at' => now()],
+                    ['id' => $survey3, 'name' => 'SURVEY', 'created_at' => now()->subMinutes(1), 'updated_at' => now()],
+                ]);
+
+                // Run the migration
+                $migrate = Artisan::call('migrate', ['--path' => 'app-modules/survey/database/migrations/2026_09_01_122143_convert_surveys_name_to_citext.php']);
+
+                // Confirm migration ran successfully
+                expect($migrate)->toBe(Command::SUCCESS);
+
+                // The oldest record keeps its name, later duplicates are suffixed.
+                expect(DB::table('surveys')->where('id', $survey1)->value('name'))->toBe('Survey');
+                expect(DB::table('surveys')->where('id', $survey2)->value('name'))->toBe('survey-2');
+                expect(DB::table('surveys')->where('id', $survey3)->value('name'))->toBe('SURVEY-3');
+            }
+        );
+    });
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2940

### Technical Description

- Implement duplicate name handling for surveys and add related tests

### Any deployment steps required?

No

### Cleanup Tasks

- Cleanup Task: .cleanup-tasks/2026_09_01_rename_surveys_duplicate_name.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
