### PR TITLE
[ADVAPP-2899]: Apply notification branding consistently across all system emails

### DIFF
--- a/.cleanup-tasks/2026_09_01_theme_logo_public_disk.md
+++ b/.cleanup-tasks/2026_09_01_theme_logo_public_disk.md
@@ -1,0 +1,14 @@
+---
+title: Theme Logo Public Disk Cleanup
+created: 2026-09-01
+---
+
+## Feature Flags
+
+- App\Features\ThemeLogoPublicDiskFeature
+
+## Temporary Migrations
+
+- database/migrations/2026_09_01_000000_tmp_move_theme_logos_to_public_disk.php
+
+## Additional Cleanup

--- a/app-modules/ai/src/Notifications/AssistantTranscriptNotification.php
+++ b/app-modules/ai/src/Notifications/AssistantTranscriptNotification.php
@@ -44,7 +44,6 @@ use AdvisingApp\Notification\Models\Contracts\Message;
 use AdvisingApp\Notification\Notifications\Contracts\HasAfterSendHook;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use App\Models\User;
-use App\Settings\NotificationSettings;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\AnonymousNotifiable;
@@ -70,7 +69,6 @@ class AssistantTranscriptNotification extends Notification implements ShouldQueu
     public function toMail(object $notifiable): MailMessage
     {
         $message = MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->greeting("Hello {$notifiable->name},");
 
         $senderIsNotifiable = $this->sender->is($notifiable);

--- a/app-modules/application/src/Notifications/ApplicationSubmissionNotification.php
+++ b/app-modules/application/src/Notifications/ApplicationSubmissionNotification.php
@@ -47,7 +47,6 @@ use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Filament\Resources\Students\StudentResource;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\User;
-use App\Settings\NotificationSettings;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -82,7 +81,6 @@ class ApplicationSubmissionNotification extends Notification implements ShouldQu
         $data = $this->buildViewData($notifiable);
 
         return (new MailMessage())
-            ->settings(app(NotificationSettings::class))
             ->subject("New Application Submission: {$data['applicationName']}")
             ->markdown('application::mail.application-submission', $data);
     }

--- a/app-modules/authorization/src/Notifications/OneTimeLoginNotification.php
+++ b/app-modules/authorization/src/Notifications/OneTimeLoginNotification.php
@@ -40,7 +40,6 @@ use AdvisingApp\Authorization\Actions\GenerateOneTimeLoginCode;
 use AdvisingApp\Notification\Notifications\Attributes\SystemNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use App\Models\User;
-use App\Settings\NotificationSettings;
 use Carbon\CarbonInterface;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -69,7 +68,6 @@ class OneTimeLoginNotification extends Notification implements ShouldQueue
         $code = app(GenerateOneTimeLoginCode::class)($notifiable, $this->expiresAt);
 
         return MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->subject('Your one-time login link')
             ->line('Use the button below to sign in to your account.')
             ->action('Log in', $this->link)

--- a/app-modules/engagement/src/Notifications/EngagementBatchFinishedNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementBatchFinishedNotification.php
@@ -39,7 +39,6 @@ namespace AdvisingApp\Engagement\Notifications;
 use AdvisingApp\Engagement\Models\EngagementBatch;
 use AdvisingApp\Notification\Enums\NotificationChannel;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
-use App\Settings\NotificationSettings;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -63,8 +62,7 @@ class EngagementBatchFinishedNotification extends Notification implements Should
 
     public function toMail(object $notifiable): MailMessage
     {
-        $message = MailMessage::make()
-            ->settings(app(NotificationSettings::class));
+        $message = MailMessage::make();
 
         if ($this->engagementBatch->successful_engagements < $this->engagementBatch->total_engagements) {
             return $message

--- a/app-modules/engagement/src/Notifications/EngagementBatchStartedNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementBatchStartedNotification.php
@@ -39,7 +39,6 @@ namespace AdvisingApp\Engagement\Notifications;
 use AdvisingApp\Engagement\Models\EngagementBatch;
 use AdvisingApp\Notification\Enums\NotificationChannel;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
-use App\Settings\NotificationSettings;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -64,7 +63,6 @@ class EngagementBatchStartedNotification extends Notification implements ShouldQ
     public function toMail(object $notifiable): MailMessage
     {
         return MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->subject(match ($this->engagementBatch->channel) {
                 NotificationChannel::Email => 'Bulk email started processing',
                 NotificationChannel::Sms => 'Bulk SMS started processing',

--- a/app-modules/engagement/src/Notifications/EngagementFailedNotification.php
+++ b/app-modules/engagement/src/Notifications/EngagementFailedNotification.php
@@ -40,7 +40,6 @@ use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
-use App\Settings\NotificationSettings;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -81,7 +80,6 @@ class EngagementFailedNotification extends Notification implements ShouldQueue
         };
 
         return MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->subject("Delivery Failed: {$this->engagement->getSubject()}")
             ->markdown('engagement::mail.engagement-failed-notification', [
                 'from' => "{$fromName} <{$fromEmail}>",

--- a/app-modules/engagement/tests/Tenant/Feature/Notifications/EngagementNotificationTest.php
+++ b/app-modules/engagement/tests/Tenant/Feature/Notifications/EngagementNotificationTest.php
@@ -38,6 +38,7 @@ use AdvisingApp\Engagement\Enums\EngagementResponseType;
 use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\Engagement\Models\EngagementResponse;
 use AdvisingApp\Engagement\Notifications\EngagementNotification;
+use AdvisingApp\Engagement\Settings\EngagementSettings;
 use AdvisingApp\IntegrationAwsSesEventHandling\Settings\SesSettings;
 use AdvisingApp\IntegrationTwilio\Settings\TwilioSettings;
 use AdvisingApp\Notification\Enums\EmailType;
@@ -46,6 +47,8 @@ use AdvisingApp\Notification\Models\EmailMessage;
 use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\Tenant;
+use App\Models\User;
+use App\Settings\NotificationSettings;
 
 it('getEmailType returns the engagement email_type value', function () {
     $engagement = Engagement::factory()
@@ -107,6 +110,48 @@ it('creates an EmailMessage with email_type transactional when engagement is tra
 
     expect($emailMessage)->not->toBeNull()
         ->and($emailMessage->email_type)->toBe(EmailType::Transactional);
+});
+
+it('uses the notification settings from name when dynamic engagements are disabled', function () {
+    $settings = app(NotificationSettings::class);
+    $settings->from_name = 'Advising Team';
+    $settings->save();
+
+    $engagementSettings = app(EngagementSettings::class);
+    $engagementSettings->are_dynamic_engagements_enabled = false;
+    $engagementSettings->save();
+
+    $engagement = Engagement::factory()
+        ->forProspect()
+        ->email()
+        ->create();
+
+    $mailMessage = (new EngagementNotification($engagement))->toMail($engagement->recipient);
+
+    expect($mailMessage->from[1])->toBe('Advising Team');
+});
+
+it('uses the engagement user as the from name when dynamic engagements are enabled', function () {
+    $settings = app(NotificationSettings::class);
+    $settings->from_name = 'Advising Team';
+    $settings->save();
+
+    $engagementSettings = app(EngagementSettings::class);
+    $engagementSettings->are_dynamic_engagements_enabled = true;
+    $engagementSettings->save();
+
+    $user = User::factory()->create(['name' => 'Case Manager']);
+
+    $engagement = Engagement::factory()
+        ->forProspect()
+        ->email()
+        ->for($user)
+        ->create();
+
+    $mailMessage = (new EngagementNotification($engagement))->toMail($engagement->recipient);
+
+    expect($mailMessage->from[1])->toBe('Case Manager')
+        ->and($mailMessage->viewData['settings'])->toBe($settings);
 });
 
 it('creates a proper Engagement Response for emails when demo mode is turned on', function () {

--- a/app-modules/form/src/Notifications/FormSubmissionNotification.php
+++ b/app-modules/form/src/Notifications/FormSubmissionNotification.php
@@ -47,7 +47,6 @@ use AdvisingApp\Prospect\Models\Prospect;
 use AdvisingApp\StudentDataModel\Filament\Resources\Students\StudentResource;
 use AdvisingApp\StudentDataModel\Models\Student;
 use App\Models\User;
-use App\Settings\NotificationSettings;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -82,7 +81,6 @@ class FormSubmissionNotification extends Notification implements ShouldQueue
         $data = $this->buildViewData($notifiable);
 
         return (new MailMessage())
-            ->settings(app(NotificationSettings::class))
             ->subject("New Form Submission: {$data['formName']}")
             ->markdown('form::mail.form-submission', $data);
     }

--- a/app-modules/form/src/Notifications/FormSubmissionRequestNotification.php
+++ b/app-modules/form/src/Notifications/FormSubmissionRequestNotification.php
@@ -38,7 +38,6 @@ namespace AdvisingApp\Form\Notifications;
 
 use AdvisingApp\Form\Models\FormSubmission;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
-use App\Settings\NotificationSettings;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -62,7 +61,6 @@ class FormSubmissionRequestNotification extends Notification implements ShouldQu
     public function toMail(object $notifiable): MailMessage
     {
         return MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->subject("Request to Complete: {$this->submission->submissible->name}")
             ->greeting('Hello ' . $this->submission->author->display_name . '!')
             ->line("Please complete the attached form: {$this->submission->submissible->name}")

--- a/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnectNotification.php
+++ b/app-modules/meeting-center/src/Notifications/CalendarRequiresReconnectNotification.php
@@ -39,7 +39,6 @@ namespace AdvisingApp\MeetingCenter\Notifications;
 use AdvisingApp\MeetingCenter\Filament\Resources\CalendarEvents\CalendarEventResource;
 use AdvisingApp\MeetingCenter\Models\Calendar;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
-use App\Settings\NotificationSettings;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
@@ -63,7 +62,6 @@ class CalendarRequiresReconnectNotification extends Notification implements Shou
     public function toMail(object $notifiable): MailMessage
     {
         return MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->line('The calendar connection for your account needs to be reconnected.')
             ->line('Please reconnect your calendar connection to continue using the calendar for schedules and appointments.')
             ->action('View Schedule and Appointments', CalendarEventResource::getUrl());

--- a/app-modules/meeting-center/src/Notifications/RegistrationLinkToEventAttendeeNotification.php
+++ b/app-modules/meeting-center/src/Notifications/RegistrationLinkToEventAttendeeNotification.php
@@ -39,7 +39,6 @@ namespace AdvisingApp\MeetingCenter\Notifications;
 use AdvisingApp\MeetingCenter\Models\Event;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use App\Models\User;
-use App\Settings\NotificationSettings;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -64,7 +63,6 @@ class RegistrationLinkToEventAttendeeNotification extends Notification implement
     public function toMail(object $notifiable): MailMessage
     {
         return MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->subject('You have been invited to an event!')
             ->line("You have been invited to {$this->event->title}.")
             ->action('Register', route('event-registration.show', ['event' => $this->event]));

--- a/app-modules/notification/src/Notifications/Messages/MailMessage.php
+++ b/app-modules/notification/src/Notifications/Messages/MailMessage.php
@@ -43,6 +43,11 @@ class MailMessage extends BaseMailMessage
 {
     protected ?string $recipientEmailAddress = null;
 
+    public function __construct(?NotificationSettings $settings = null)
+    {
+        $this->settings($settings ?? app(NotificationSettings::class));
+    }
+
     public static function make(): static
     {
         return app(static::class);

--- a/app-modules/notification/tests/Fixtures/TestEmailSettingFromNameNotification.php
+++ b/app-modules/notification/tests/Fixtures/TestEmailSettingFromNameNotification.php
@@ -37,7 +37,6 @@
 namespace AdvisingApp\Notification\Tests\Fixtures;
 
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
-use App\Settings\NotificationSettings;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -57,7 +56,6 @@ class TestEmailSettingFromNameNotification extends Notification implements Shoul
     public function toMail(object $notifiable): MailMessage
     {
         return MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->subject('Test Subject')
             ->greeting('Test Greeting')
             ->content('This is a test email');

--- a/app-modules/notification/tests/Tenant/Notifications/Messages/MailMessageTest.php
+++ b/app-modules/notification/tests/Tenant/Notifications/Messages/MailMessageTest.php
@@ -34,11 +34,15 @@
 </COPYRIGHT>
 */
 
+use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use AdvisingApp\Notification\Tests\Fixtures\TestEmailSettingFromNameNotification;
+use AdvisingApp\Theme\Settings\ThemeSettings;
+use App\Features\ThemeLogoPublicDiskFeature;
 use App\Models\User;
 use App\Settings\NotificationSettings;
 use CanyonGBS\Common\Enums\Color;
 use Filament\Support\Colors\Color as FilamentColor;
+use Illuminate\Support\Facades\Storage;
 
 it('renders the notification mail with the configured `primary_color`', function () {
     $user = User::factory()->create();
@@ -54,4 +58,36 @@ it('renders the notification mail with the configured `primary_color`', function
 
     expect((string) (new TestEmailSettingFromNameNotification())->toMail($user)->render())
         ->toContain($expected);
+});
+
+it('applies notification settings when instantiated directly', function () {
+    $settings = app(NotificationSettings::class);
+    $settings->from_name = 'Advising Team';
+    $settings->save();
+
+    $mailMessage = new MailMessage();
+
+    expect($mailMessage->viewData['settings'])->toBe($settings)
+        ->and($mailMessage->from[1])->toBe('Advising Team');
+});
+
+it('renders the active theme logo fallback with a public media URL', function () {
+    Storage::fake('s3-public');
+
+    $themeSettings = app(ThemeSettings::class);
+    $themeSettings->is_logo_active = true;
+    $themeSettings->save();
+
+    $themeLogo = ThemeSettings::getSettingsPropertyModel('theme.is_logo_active');
+    $themeLogo
+        ->addMediaFromString('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>')
+        ->usingFileName('logo.svg')
+        ->toMediaCollection('logo', 's3-public');
+
+    $logoUrl = $themeLogo->getFirstMediaUrl('logo');
+
+    expect(ThemeLogoPublicDiskFeature::active())->toBeTrue()
+        ->and((string) view('vendor.mail.html.header', ['url' => url('/')])->render())
+        ->toContain($logoUrl)
+        ->not->toContain('X-Amz-Expires');
 });

--- a/app-modules/research/src/Notifications/ResearchTranscriptNotification.php
+++ b/app-modules/research/src/Notifications/ResearchTranscriptNotification.php
@@ -44,7 +44,6 @@ use AdvisingApp\Notification\Notifications\Messages\MailMessage;
 use AdvisingApp\Research\Filament\Pages\ManageResearchRequests;
 use AdvisingApp\Research\Models\ResearchRequest;
 use App\Models\User;
-use App\Settings\NotificationSettings;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\AnonymousNotifiable;
@@ -72,7 +71,6 @@ class ResearchTranscriptNotification extends Notification implements ShouldQueue
     public function toMail(object $notifiable): MailMessage
     {
         $message = MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->greeting("Hello {$notifiable->name},");
 
         $senderIsNotifiable = $this->sender->is($notifiable);

--- a/app-modules/task/src/Notifications/TaskAssignedToUserNotification.php
+++ b/app-modules/task/src/Notifications/TaskAssignedToUserNotification.php
@@ -44,7 +44,6 @@ use AdvisingApp\StudentDataModel\Filament\Resources\Students\Pages\ManageStudent
 use AdvisingApp\StudentDataModel\Filament\Resources\Students\Pages\ViewStudent;
 use AdvisingApp\StudentDataModel\Models\Student;
 use AdvisingApp\Task\Models\Task;
-use App\Settings\NotificationSettings;
 use Exception;
 use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Bus\Queueable;
@@ -72,7 +71,6 @@ class TaskAssignedToUserNotification extends Notification implements ShouldQueue
         $truncatedTaskDescription = str($this->task->description)->limit(50);
 
         return MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->subject('You have been assigned a new Task')
             ->line('You have been assigned the task: ')
             ->line("\"{$truncatedTaskDescription}\"");

--- a/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
+++ b/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
@@ -108,9 +108,9 @@ class ManageBrandConfigurationSettings extends SettingsPage
                     ->aside()
                     ->schema([
                         SpatieMediaLibraryFileUpload::make('logo')
-                            ->disk('s3')
+                            ->disk('s3-public')
                             ->collection('logo')
-                            ->visibility('private')
+                            ->visibility('public')
                             ->image()
                             ->model(
                                 ThemeSettings::getSettingsPropertyModel('theme.is_logo_active'),

--- a/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
+++ b/app-modules/theme/src/Filament/Pages/ManageBrandConfigurationSettings.php
@@ -38,6 +38,7 @@ namespace AdvisingApp\Theme\Filament\Pages;
 
 use AdvisingApp\Theme\Settings\ThemeSettings;
 use App\Enums\NavigationGroup;
+use App\Features\ThemeLogoPublicDiskFeature;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Multitenancy\DataTransferObjects\TenantConfig;
@@ -108,9 +109,9 @@ class ManageBrandConfigurationSettings extends SettingsPage
                     ->aside()
                     ->schema([
                         SpatieMediaLibraryFileUpload::make('logo')
-                            ->disk('s3-public')
+                            ->disk(ThemeLogoPublicDiskFeature::active() ? 's3-public' : 's3')
                             ->collection('logo')
-                            ->visibility('public')
+                            ->visibility(ThemeLogoPublicDiskFeature::active() ? 'public' : 'private')
                             ->image()
                             ->model(
                                 ThemeSettings::getSettingsPropertyModel('theme.is_logo_active'),

--- a/app-modules/theme/tests/Tenant/Filament/Pages/ManageBrandConfigurationSettingsTest.php
+++ b/app-modules/theme/tests/Tenant/Filament/Pages/ManageBrandConfigurationSettingsTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Theme\Filament\Pages\ManageBrandConfigurationSettings;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 

--- a/app-modules/theme/tests/Tenant/Filament/Pages/ManageBrandConfigurationSettingsTest.php
+++ b/app-modules/theme/tests/Tenant/Filament/Pages/ManageBrandConfigurationSettingsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use AdvisingApp\Theme\Filament\Pages\ManageBrandConfigurationSettings;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+it('stores the email-facing logo publicly and keeps browser-only assets private', function () {
+    asSuperAdmin();
+
+    livewire(ManageBrandConfigurationSettings::class)
+        ->assertFormFieldExists(
+            'logo',
+            checkFieldUsing: fn (SpatieMediaLibraryFileUpload $field): bool => $field->getDiskName() === 's3-public' && $field->getVisibility() === 'public'
+        )
+        ->assertFormFieldExists(
+            'dark_logo',
+            checkFieldUsing: fn (SpatieMediaLibraryFileUpload $field): bool => $field->getDiskName() === 's3' && $field->getVisibility() === 'private'
+        )
+        ->assertFormFieldExists(
+            'favicon',
+            checkFieldUsing: fn (SpatieMediaLibraryFileUpload $field): bool => $field->getDiskName() === 's3' && $field->getVisibility() === 'private'
+        );
+});

--- a/app/Features/ThemeLogoPublicDiskFeature.php
+++ b/app/Features/ThemeLogoPublicDiskFeature.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 namespace App\Features;
 
 use App\Support\AbstractFeatureFlag;

--- a/app/Features/ThemeLogoPublicDiskFeature.php
+++ b/app/Features/ThemeLogoPublicDiskFeature.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Features;
+
+use App\Support\AbstractFeatureFlag;
+
+class ThemeLogoPublicDiskFeature extends AbstractFeatureFlag
+{
+    public function resolve(mixed $scope): mixed
+    {
+        return false;
+    }
+}

--- a/app/Filament/Pages/ManageNotificationSettings.php
+++ b/app/Filament/Pages/ManageNotificationSettings.php
@@ -44,7 +44,6 @@ use CanyonGBS\Common\Filament\Forms\Components\ColorSelect;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
-use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Schema;

--- a/app/Filament/Pages/ManageNotificationSettings.php
+++ b/app/Filament/Pages/ManageNotificationSettings.php
@@ -76,16 +76,10 @@ class ManageNotificationSettings extends SettingsPage
             ->columns(1)
             ->disabled(! auth()->user()->can('settings.*.update'))
             ->components([
-                TextInput::make('name')
-                    ->string()
-                    ->required()
-                    ->autocomplete(false),
                 TextInput::make('from_name')
                     ->string()
                     ->maxLength(150)
                     ->autocomplete(false),
-                Textarea::make('description')
-                    ->string(),
                 ColorSelect::make('primary_color'),
                 SpatieMediaLibraryFileUpload::make('logo')
                     ->disk('s3-public')

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -38,7 +38,6 @@ namespace App\Notifications;
 
 use AdvisingApp\Notification\Notifications\Attributes\SystemNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
-use App\Settings\NotificationSettings;
 use Filament\Auth\Notifications\ResetPassword;
 
 #[SystemNotification]
@@ -50,7 +49,6 @@ class ResetPasswordNotification extends ResetPassword
     public function toMail($notifiable): MailMessage
     {
         return MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->subject('Reset your password')
             ->line(__('You are receiving this email because we received a password reset request for your account.'))
             ->action(__('Reset Password'), $this->resetUrl($notifiable))

--- a/app/Notifications/SetPasswordNotification.php
+++ b/app/Notifications/SetPasswordNotification.php
@@ -39,7 +39,6 @@ namespace App\Notifications;
 use AdvisingApp\Authorization\Actions\GenerateOneTimeLoginCode;
 use AdvisingApp\Notification\Notifications\Attributes\SystemNotification;
 use AdvisingApp\Notification\Notifications\Messages\MailMessage;
-use App\Settings\NotificationSettings;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -63,7 +62,6 @@ class SetPasswordNotification extends Notification implements ShouldQueue
         $expiresAt = now()->addDay();
 
         $message = MailMessage::make()
-            ->settings(app(NotificationSettings::class))
             ->subject('Set up your password')
             ->line('A new account has been created for you.')
             ->action('Set up your password', url(URL::temporarySignedRoute(

--- a/app/Settings/NotificationSettings.php
+++ b/app/Settings/NotificationSettings.php
@@ -41,11 +41,7 @@ use CanyonGBS\Common\Enums\Color;
 
 class NotificationSettings extends SettingsWithMedia
 {
-    public ?string $name = null;
-
     public ?string $from_name = null;
-
-    public ?string $description = null;
 
     public null $logo = null;
 

--- a/database/migrations/2026_09_01_000000_tmp_move_theme_logos_to_public_disk.php
+++ b/database/migrations/2026_09_01_000000_tmp_move_theme_logos_to_public_disk.php
@@ -1,0 +1,46 @@
+<?php
+
+use AdvisingApp\Theme\Settings\SettingsProperties\ThemeSettingsProperty;
+use App\Features\ThemeLogoPublicDiskFeature;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        DB::transaction(function (): void {
+            $this->moveThemeLogos(fromDisk: 's3', toDisk: 's3-public');
+
+            ThemeLogoPublicDiskFeature::activate();
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function (): void {
+            ThemeLogoPublicDiskFeature::deactivate();
+
+            $this->moveThemeLogos(fromDisk: 's3-public', toDisk: 's3');
+        });
+    }
+
+    private function moveThemeLogos(string $fromDisk, string $toDisk): void
+    {
+        Media::query()
+            ->where('model_type', ThemeSettingsProperty::class)
+            ->where('collection_name', 'logo')
+            ->where('disk', $fromDisk)
+            ->chunkById(100, function (Collection $mediaItems) use ($toDisk): void {
+                $mediaItems->each(function (Media $media) use ($toDisk): void {
+                    if (! $media->model instanceof HasMedia) {
+                        return;
+                    }
+
+                    $media->move($media->model, 'logo', $toDisk, $media->file_name);
+                });
+            });
+    }
+};

--- a/database/migrations/2026_09_01_000000_tmp_move_theme_logos_to_public_disk.php
+++ b/database/migrations/2026_09_01_000000_tmp_move_theme_logos_to_public_disk.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Theme\Settings\SettingsProperties\ThemeSettingsProperty;
 use App\Features\ThemeLogoPublicDiskFeature;
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2026_09_01_000000_tmp_move_theme_logos_to_public_disk.php
+++ b/database/migrations/2026_09_01_000000_tmp_move_theme_logos_to_public_disk.php
@@ -37,16 +37,13 @@
 use AdvisingApp\Theme\Settings\SettingsProperties\ThemeSettingsProperty;
 use App\Features\ThemeLogoPublicDiskFeature;
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use Spatie\MediaLibrary\HasMedia;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 return new class () extends Migration {
     public function up(): void
     {
         DB::transaction(function (): void {
-            $this->moveThemeLogos(fromDisk: 's3', toDisk: 's3-public');
+            $this->moveThemeLogo('s3', 's3-public');
 
             ThemeLogoPublicDiskFeature::activate();
         });
@@ -57,24 +54,24 @@ return new class () extends Migration {
         DB::transaction(function (): void {
             ThemeLogoPublicDiskFeature::deactivate();
 
-            $this->moveThemeLogos(fromDisk: 's3-public', toDisk: 's3');
+            $this->moveThemeLogo('s3-public', 's3');
         });
     }
 
-    private function moveThemeLogos(string $fromDisk, string $toDisk): void
+    private function moveThemeLogo(string $fromDisk, string $toDisk): void
     {
-        Media::query()
-            ->where('model_type', ThemeSettingsProperty::class)
-            ->where('collection_name', 'logo')
-            ->where('disk', $fromDisk)
-            ->chunkById(100, function (Collection $mediaItems) use ($toDisk): void {
-                $mediaItems->each(function (Media $media) use ($toDisk): void {
-                    if (! $media->model instanceof HasMedia) {
-                        return;
-                    }
+        $settingsProperty = ThemeSettingsProperty::getInstance('theme.is_logo_active');
 
-                    $media->move($media->model, 'logo', $toDisk, $media->file_name);
-                });
-            });
+        if (is_null($settingsProperty)) {
+            return;
+        }
+
+        $logo = $settingsProperty->getFirstMedia('logo');
+
+        if (is_null($logo) || $logo->disk !== $fromDisk) {
+            return;
+        }
+
+        $logo->move($settingsProperty, 'logo', $toDisk, $logo->file_name);
     }
 };

--- a/database/migrations/2026_09_01_171712_drop_name_and_description_from_notification_settings.php
+++ b/database/migrations/2026_09_01_171712_drop_name_and_description_from_notification_settings.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        DB::transaction(function () {
+            $this->migrator->deleteIfExists('notifications.name');
+            $this->migrator->deleteIfExists('notifications.description');
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            try {
+                $this->migrator->add('notifications.name');
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+
+            try {
+                $this->migrator->add('notifications.description');
+            } catch (SettingAlreadyExists $exception) {
+                // do nothing
+            }
+        });
+    }
+};

--- a/database/migrations/2026_09_01_171712_drop_name_and_description_from_notification_settings.php
+++ b/database/migrations/2026_09_01_171712_drop_name_and_description_from_notification_settings.php
@@ -1,11 +1,44 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Illuminate\Support\Facades\DB;
 use Spatie\LaravelSettings\Exceptions\SettingAlreadyExists;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
-return new class extends SettingsMigration
-{
+return new class () extends SettingsMigration {
     public function up(): void
     {
         DB::transaction(function () {

--- a/resources/views/vendor/filament-panels/components/logo.blade.php
+++ b/resources/views/vendor/filament-panels/components/logo.blade.php
@@ -44,9 +44,9 @@
 
 @if ($themeSettings->is_logo_active && $logo)
     @php
-        $logoUrl = $logo->getTemporaryUrl(
-            expiration: now()->addMinutes(5),
-            conversionName: $logo->hasGeneratedConversion('logo-height-250px') ? 'logo-height-250px' : '',
+        $logoUrl = $settingsProperty->getFirstMediaUrl(
+            'logo',
+            $logo->hasGeneratedConversion('logo-height-250px') ? 'logo-height-250px' : '',
         );
     @endphp
     <img

--- a/resources/views/vendor/filament-panels/components/logo.blade.php
+++ b/resources/views/vendor/filament-panels/components/logo.blade.php
@@ -32,6 +32,7 @@
     </COPYRIGHT>
 --}}
 @php
+    use App\Features\ThemeLogoPublicDiskFeature;
     use AdvisingApp\Theme\Settings\ThemeSettings;
     use Illuminate\Support\Facades\Vite;
 
@@ -44,10 +45,16 @@
 
 @if ($themeSettings->is_logo_active && $logo)
     @php
-        $logoUrl = $settingsProperty->getFirstMediaUrl(
-            'logo',
-            $logo->hasGeneratedConversion('logo-height-250px') ? 'logo-height-250px' : '',
-        );
+        $logoUrl = ThemeLogoPublicDiskFeature::active() ?
+            $settingsProperty->getFirstMediaUrl(
+                'logo',
+                $logo->hasGeneratedConversion('logo-height-250px') ? 'logo-height-250px' : '',
+            ) :
+            $logo->getTemporaryUrl(
+                expiration: now()->addMinutes(5),
+                conversionName: $logo->hasGeneratedConversion('logo-height-250px') ? 'logo-height-250px' : '',
+            )
+            
     @endphp
     <img
         src="{{ $logoUrl }}"

--- a/resources/views/vendor/mail/html/header.blade.php
+++ b/resources/views/vendor/mail/html/header.blade.php
@@ -33,7 +33,7 @@
 --}}
 @props(['url', 'settings' => null])
 @php
-    use App\Models\SettingsProperty;
+    use App\Features\ThemeLogoPublicDiskFeature;
     use App\Settings\NotificationSettings;
     use AdvisingApp\Theme\Settings\ThemeSettings;
 
@@ -50,7 +50,7 @@
                      style="height: 75px; max-height: 75px; max-width: 100vw;"
                      alt="Logo">
             @elseif ($themeSettings->is_logo_active && $logo)
-                <img src="{{ $logo->getTemporaryUrl(now()->addDays(6)) }}"
+                 <img src="{{ ThemeLogoPublicDiskFeature::active() ? $logo->getUrl() : $logo->getTemporaryUrl(now()->addDays(6)) }}"
                      style="height: 75px; max-height: 75px; max-width: 100vw;"
                      alt="Logo">
             @else

--- a/tests/Tenant/Feature/Filament/Pages/ManageNotificationSettingsTest.php
+++ b/tests/Tenant/Feature/Filament/Pages/ManageNotificationSettingsTest.php
@@ -55,17 +55,11 @@ it('loads existing data into the form', function () {
     asSuperAdmin();
 
     $settings = app(NotificationSettings::class);
-    $settings->name = 'Existing Institution Name';
     $settings->from_name = 'Existing From Name';
-    $settings->description = 'Existing description.';
     $settings->save();
 
     livewire(ManageNotificationSettings::class)
-        ->assertSchemaStateSet([
-            'name' => 'Existing Institution Name',
-            'from_name' => 'Existing From Name',
-            'description' => 'Existing description.',
-        ]);
+        ->assertSchemaStateSet(['from_name' => 'Existing From Name']);
 });
 
 it('can update the notification settings', function () {
@@ -73,9 +67,7 @@ it('can update the notification settings', function () {
 
     livewire(ManageNotificationSettings::class)
         ->fillForm([
-            'name' => 'New Institution Name',
             'from_name' => 'New From Name',
-            'description' => 'New description.',
             'primary_color' => Color::Blue->value,
         ])
         ->call('save')
@@ -83,9 +75,7 @@ it('can update the notification settings', function () {
 
     $settings = app(NotificationSettings::class);
 
-    expect($settings->name)->toBe('New Institution Name')
-        ->and($settings->from_name)->toBe('New From Name')
-        ->and($settings->description)->toBe('New description.')
+    expect($settings->from_name)->toBe('New From Name')
         ->and($settings->primary_color)->toBe(Color::Blue);
 });
 
@@ -97,7 +87,6 @@ it('validates the inputs', function (array $state, array $errors) {
         ->call('save')
         ->assertHasFormErrors($errors);
 })->with([
-    'name required' => [['name' => null], ['name' => 'required']],
     'from_name max' => [['from_name' => str_repeat('a', 151)], ['from_name' => 'max']],
 ]);
 
@@ -126,32 +115,24 @@ describe('authorization', function () {
 
         livewire(ManageNotificationSettings::class)
             ->fillForm([
-                'name' => 'New Institution Name',
                 'from_name' => 'New From Name',
-                'description' => 'New description.',
                 'primary_color' => Color::Blue->value,
             ])
             ->call('save');
 
-        expect($settings->name)->not()->toBe('New Institution Name')
-            ->and($settings->from_name)->not()->toBe('New From Name')
-            ->and($settings->description)->not()->toBe('New description.')
+        expect($settings->from_name)->not()->toBe('New From Name')
             ->and($settings->primary_color)->not()->toBe(Color::Blue);
 
         $user->givePermissionTo('settings.*.update');
 
         livewire(ManageNotificationSettings::class)
             ->fillForm([
-                'name' => 'New Institution Name',
                 'from_name' => 'New From Name',
-                'description' => 'New description.',
                 'primary_color' => Color::Blue->value,
             ])
             ->call('save');
 
-        expect($settings->name)->toBe('New Institution Name')
-            ->and($settings->from_name)->toBe('New From Name')
-            ->and($settings->description)->toBe('New description.')
+        expect($settings->from_name)->toBe('New From Name')
             ->and($settings->primary_color)->toBe(Color::Blue);
     });
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2899

### Technical Description

Ensure that notification settings are used across all outbound emails. Store Brand logo publicly. Remove name and description fields from Notification Settings.

### Any deployment steps required?

No

### Cleanup Tasks

.cleanup-tasks/2026_09_01_theme_logo_public_disk.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
