### PR TITLE
[ADVAPP-2922]: Prevent duplicate Resource Hub article titles and setting names

### DIFF
--- a/.cleanup-tasks/2026_09_02_convert_resource_hub_title_and_names_to_citext.md
+++ b/.cleanup-tasks/2026_09_02_convert_resource_hub_title_and_names_to_citext.md
@@ -9,4 +9,4 @@ created: 2026-09-02
 
 ## Additional Cleanup
 
-earch for `TODO: Cleanup Task ResourceHubCitextCleanup`
+Search for `TODO: Cleanup Task ResourceHubCitextCleanup`

--- a/.cleanup-tasks/2026_09_02_convert_resource_hub_title_and_names_to_citext.md
+++ b/.cleanup-tasks/2026_09_02_convert_resource_hub_title_and_names_to_citext.md
@@ -1,0 +1,12 @@
+---
+title: Convert Resource Hub Title And Names To Citext
+created: 2026-09-02
+---
+
+## Feature Flags
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+earch for `TODO: Cleanup Task ResourceHubCitextCleanup`

--- a/app-modules/resource-hub/database/factories/ResourceHubArticleFactory.php
+++ b/app-modules/resource-hub/database/factories/ResourceHubArticleFactory.php
@@ -54,9 +54,9 @@ class ResourceHubArticleFactory extends Factory
             'title' => $this->faker->sentence(),
             'article_details' => ['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => $this->faker->paragraph()]]]]],
             'notes' => $this->faker->paragraph(),
-            'quality_id' => ResourceHubQuality::factory(),
-            'status_id' => ResourceHubStatus::factory(),
-            'category_id' => ResourceHubCategory::factory(),
+            'quality_id' => fn (): mixed => ResourceHubQuality::query()->firstOr(fn () => ResourceHubQuality::factory()->create())->getKey(),
+            'status_id' => fn (): mixed => ResourceHubStatus::query()->firstOr(fn () => ResourceHubStatus::factory()->create())->getKey(),
+            'category_id' => fn (): mixed => ResourceHubCategory::query()->firstOr(fn () => ResourceHubCategory::factory()->create())->getKey(),
         ];
     }
 

--- a/app-modules/resource-hub/database/migrations/2026_09_01_220856_convert_resource_hub_article_title_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_01_220856_convert_resource_hub_article_title_to_citext.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Database\Migrations\Concerns\FixesDuplicateNames;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Builder;

--- a/app-modules/resource-hub/database/migrations/2026_09_01_220856_convert_resource_hub_article_title_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_01_220856_convert_resource_hub_article_title_to_citext.php
@@ -1,0 +1,52 @@
+<?php
+
+use Database\Migrations\Concerns\FixesDuplicateNames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    // TODO: Cleanup Task ResourceHubCitextCleanup - remove FixesDuplicateNames trait & usages
+    use FixesDuplicateNames;
+
+    protected string $table = 'resource_hub_articles';
+
+    protected string $column = 'title';
+
+    /** @var array<int, string> */
+    protected array $groupByColumns = ['title'];
+
+    // TODO: Cleanup Task ResourceHubCitextCleanup - remove $chunkSize and $usesSoftDeletes
+    protected int $chunkSize = 500;
+
+    protected bool $usesSoftDeletes = true;
+
+    private string $uniqueConstraint = 'resource_hub_articles_title_unique';
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            $this->fixDuplicates();
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->uniqueIndex([...$this->groupByColumns, $this->column], $this->uniqueConstraint)
+                    ->where(fn (Builder $condition) => $condition->whereNull('deleted_at'));
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUniqueIndex($this->uniqueConstraint);
+            });
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+        });
+    }
+};

--- a/app-modules/resource-hub/database/migrations/2026_09_01_220856_convert_resource_hub_article_title_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_01_220856_convert_resource_hub_article_title_to_citext.php
@@ -50,7 +50,7 @@ return new class () extends Migration {
     protected string $column = 'title';
 
     /** @var array<int, string> */
-    protected array $groupByColumns = ['title'];
+    protected array $groupByColumns = [];
 
     // TODO: Cleanup Task ResourceHubCitextCleanup - remove $chunkSize and $usesSoftDeletes
     protected int $chunkSize = 500;

--- a/app-modules/resource-hub/database/migrations/2026_09_02_034833_convert_resource_hub_categories_name_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_02_034833_convert_resource_hub_categories_name_to_citext.php
@@ -1,0 +1,52 @@
+<?php
+
+use Database\Migrations\Concerns\FixesDuplicateNames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    // TODO: Cleanup Task ResourceHubCitextCleanup - remove FixesDuplicateNames trait & usages
+    use FixesDuplicateNames;
+
+    protected string $table = 'resource_hub_categories';
+
+    protected string $column = 'name';
+
+    /** @var array<int, string> */
+    protected array $groupByColumns = ['name'];
+
+    // TODO: Cleanup Task ResourceHubCitextCleanup - remove $chunkSize and $usesSoftDeletes
+    protected int $chunkSize = 500;
+
+    protected bool $usesSoftDeletes = true;
+
+    private string $uniqueConstraint = 'resource_hub_categories_name_unique';
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            $this->fixDuplicates();
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->uniqueIndex([...$this->groupByColumns, $this->column], $this->uniqueConstraint)
+                    ->where(fn (Builder $condition) => $condition->whereNull('deleted_at'));
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUniqueIndex($this->uniqueConstraint);
+            });
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+        });
+    }
+};

--- a/app-modules/resource-hub/database/migrations/2026_09_02_034833_convert_resource_hub_categories_name_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_02_034833_convert_resource_hub_categories_name_to_citext.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Database\Migrations\Concerns\FixesDuplicateNames;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Builder;

--- a/app-modules/resource-hub/database/migrations/2026_09_02_034833_convert_resource_hub_categories_name_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_02_034833_convert_resource_hub_categories_name_to_citext.php
@@ -50,7 +50,7 @@ return new class () extends Migration {
     protected string $column = 'name';
 
     /** @var array<int, string> */
-    protected array $groupByColumns = ['name'];
+    protected array $groupByColumns = [];
 
     // TODO: Cleanup Task ResourceHubCitextCleanup - remove $chunkSize and $usesSoftDeletes
     protected int $chunkSize = 500;

--- a/app-modules/resource-hub/database/migrations/2026_09_02_034854_convert_resource_hub_qualities_name_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_02_034854_convert_resource_hub_qualities_name_to_citext.php
@@ -1,0 +1,52 @@
+<?php
+
+use Database\Migrations\Concerns\FixesDuplicateNames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    // TODO: Cleanup Task ResourceHubCitextCleanup - remove FixesDuplicateNames trait & usages
+    use FixesDuplicateNames;
+
+    protected string $table = 'resource_hub_qualities';
+
+    protected string $column = 'name';
+
+    /** @var array<int, string> */
+    protected array $groupByColumns = ['name'];
+
+    // TODO: Cleanup Task ResourceHubCitextCleanup - remove $chunkSize and $usesSoftDeletes
+    protected int $chunkSize = 500;
+
+    protected bool $usesSoftDeletes = true;
+
+    private string $uniqueConstraint = 'resource_hub_qualities_name_unique';
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            $this->fixDuplicates();
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->uniqueIndex([...$this->groupByColumns, $this->column], $this->uniqueConstraint)
+                    ->where(fn (Builder $condition) => $condition->whereNull('deleted_at'));
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUniqueIndex($this->uniqueConstraint);
+            });
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+        });
+    }
+};

--- a/app-modules/resource-hub/database/migrations/2026_09_02_034854_convert_resource_hub_qualities_name_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_02_034854_convert_resource_hub_qualities_name_to_citext.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Database\Migrations\Concerns\FixesDuplicateNames;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Builder;

--- a/app-modules/resource-hub/database/migrations/2026_09_02_034854_convert_resource_hub_qualities_name_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_02_034854_convert_resource_hub_qualities_name_to_citext.php
@@ -50,7 +50,7 @@ return new class () extends Migration {
     protected string $column = 'name';
 
     /** @var array<int, string> */
-    protected array $groupByColumns = ['name'];
+    protected array $groupByColumns = [];
 
     // TODO: Cleanup Task ResourceHubCitextCleanup - remove $chunkSize and $usesSoftDeletes
     protected int $chunkSize = 500;

--- a/app-modules/resource-hub/database/migrations/2026_09_02_034904_convert_resource_hub_statuses_name_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_02_034904_convert_resource_hub_statuses_name_to_citext.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Database\Migrations\Concerns\FixesDuplicateNames;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Builder;

--- a/app-modules/resource-hub/database/migrations/2026_09_02_034904_convert_resource_hub_statuses_name_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_02_034904_convert_resource_hub_statuses_name_to_citext.php
@@ -50,7 +50,7 @@ return new class () extends Migration {
     protected string $column = 'name';
 
     /** @var array<int, string> */
-    protected array $groupByColumns = ['name'];
+    protected array $groupByColumns = [];
 
     // TODO: Cleanup Task ResourceHubCitextCleanup - remove $chunkSize and $usesSoftDeletes
     protected int $chunkSize = 500;

--- a/app-modules/resource-hub/database/migrations/2026_09_02_034904_convert_resource_hub_statuses_name_to_citext.php
+++ b/app-modules/resource-hub/database/migrations/2026_09_02_034904_convert_resource_hub_statuses_name_to_citext.php
@@ -1,0 +1,52 @@
+<?php
+
+use Database\Migrations\Concerns\FixesDuplicateNames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    // TODO: Cleanup Task ResourceHubCitextCleanup - remove FixesDuplicateNames trait & usages
+    use FixesDuplicateNames;
+
+    protected string $table = 'resource_hub_statuses';
+
+    protected string $column = 'name';
+
+    /** @var array<int, string> */
+    protected array $groupByColumns = ['name'];
+
+    // TODO: Cleanup Task ResourceHubCitextCleanup - remove $chunkSize and $usesSoftDeletes
+    protected int $chunkSize = 500;
+
+    protected bool $usesSoftDeletes = true;
+
+    private string $uniqueConstraint = 'resource_hub_statuses_name_unique';
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            $this->fixDuplicates();
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->uniqueIndex([...$this->groupByColumns, $this->column], $this->uniqueConstraint)
+                    ->where(fn (Builder $condition) => $condition->whereNull('deleted_at'));
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUniqueIndex($this->uniqueConstraint);
+            });
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+        });
+    }
+};

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/CreateResourceHubArticle.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/CreateResourceHubArticle.php
@@ -63,6 +63,7 @@ class CreateResourceHubArticle extends CreateRecord
                         TextInput::make('title')
                             ->label('Article Title')
                             ->required()
+                            ->maxLength(255)
                             ->unique(
                                 table: 'resource_hub_articles',
                                 column: 'title',

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/CreateResourceHubArticle.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/CreateResourceHubArticle.php
@@ -48,6 +48,7 @@ use Filament\Forms\Components\Toggle;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class CreateResourceHubArticle extends CreateRecord
 {
@@ -62,6 +63,11 @@ class CreateResourceHubArticle extends CreateRecord
                         TextInput::make('title')
                             ->label('Article Title')
                             ->required()
+                            ->unique(
+                                table: 'resource_hub_articles',
+                                column: 'title',
+                                modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                            )
                             ->string(),
                         Toggle::make('public')
                             ->label('Public')

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/CreateResourceHubArticle.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/CreateResourceHubArticle.php
@@ -68,8 +68,7 @@ class CreateResourceHubArticle extends CreateRecord
                                 table: 'resource_hub_articles',
                                 column: 'title',
                                 modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
-                            )
-                            ->string(),
+                            ),
                         Toggle::make('public')
                             ->label('Public')
                             ->default(false)

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/EditResourceHubArticle.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/EditResourceHubArticle.php
@@ -102,7 +102,7 @@ class EditResourceHubArticle extends EditRecord
                                 TextInput::make('title')
                                     ->label('Article Title')
                                     ->required()
-                                    ->string()
+                                    ->maxLength(255)
                                     ->unique(
                                         table: 'resource_hub_articles',
                                         column: 'title',

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/EditResourceHubArticle.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/EditResourceHubArticle.php
@@ -117,6 +117,16 @@ class EditResourceHubArticle extends EditRecord
                                                     return;
                                                 }
 
+                                                if ($record->newQuery()->where('title', $state)->whereKeyNot($record->getKey())->exists()) {
+                                                    Notification::make()
+                                                        ->title('That title is already in use')
+                                                        ->danger()
+                                                        ->duration(3000)
+                                                        ->send();
+
+                                                    return;
+                                                }
+
                                                 $record->update([
                                                     'title' => $state,
                                                 ]);

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/EditResourceHubArticle.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubArticles/Pages/EditResourceHubArticle.php
@@ -57,6 +57,7 @@ use Filament\Schemas\Components\Tabs;
 use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Schema;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\Rules\Unique;
 
 class EditResourceHubArticle extends EditRecord
 {
@@ -102,6 +103,12 @@ class EditResourceHubArticle extends EditRecord
                                     ->label('Article Title')
                                     ->required()
                                     ->string()
+                                    ->unique(
+                                        table: 'resource_hub_articles',
+                                        column: 'title',
+                                        ignoreRecord: true,
+                                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                                    )
                                     ->suffixAction(
                                         BaseAction::make('saveArticleTitle')
                                             ->icon('heroicon-o-check')

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategories/Pages/CreateResourceHubCategory.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategories/Pages/CreateResourceHubCategory.php
@@ -42,6 +42,7 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class CreateResourceHubCategory extends CreateRecord
 {
@@ -54,6 +55,11 @@ class CreateResourceHubCategory extends CreateRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->unique(
+                        table: 'resource_hub_categories',
+                        column: 'name',
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    )
                     ->string(),
                 IconSelect::make('icon'),
                 Textarea::make('description')

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategories/Pages/CreateResourceHubCategory.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategories/Pages/CreateResourceHubCategory.php
@@ -55,6 +55,7 @@ class CreateResourceHubCategory extends CreateRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->maxLength(255)
                     ->unique(
                         table: 'resource_hub_categories',
                         column: 'name',

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategories/Pages/EditResourceHubCategory.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategories/Pages/EditResourceHubCategory.php
@@ -44,6 +44,7 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class EditResourceHubCategory extends EditRecord
 {
@@ -56,6 +57,12 @@ class EditResourceHubCategory extends EditRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->unique(
+                        table: 'resource_hub_categories',
+                        column: 'name',
+                        ignoreRecord: true,
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    )
                     ->string(),
                 IconSelect::make('icon'),
                 Textarea::make('description')

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategories/Pages/EditResourceHubCategory.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubCategories/Pages/EditResourceHubCategory.php
@@ -57,6 +57,7 @@ class EditResourceHubCategory extends EditRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->maxLength(255)
                     ->unique(
                         table: 'resource_hub_categories',
                         column: 'name',

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/CreateResourceHubQuality.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/CreateResourceHubQuality.php
@@ -53,6 +53,7 @@ class CreateResourceHubQuality extends CreateRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->maxLength(255)
                     ->unique(
                         table: 'resource_hub_qualities',
                         column: 'name',

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/CreateResourceHubQuality.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/CreateResourceHubQuality.php
@@ -54,10 +54,10 @@ class CreateResourceHubQuality extends CreateRecord
                     ->label('Name')
                     ->required()
                     ->unique(
-                                table: 'resource_hub_qualities',
-                                column: 'name',
-                                modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
-                            )
+                        table: 'resource_hub_qualities',
+                        column: 'name',
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    )
                     ->string(),
             ]);
     }

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/CreateResourceHubQuality.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/CreateResourceHubQuality.php
@@ -40,6 +40,7 @@ use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubQualities\ResourceHubQ
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class CreateResourceHubQuality extends CreateRecord
 {
@@ -52,6 +53,11 @@ class CreateResourceHubQuality extends CreateRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->unique(
+                                table: 'resource_hub_qualities',
+                                column: 'name',
+                                modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                            )
                     ->string(),
             ]);
     }

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/EditResourceHubQuality.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/EditResourceHubQuality.php
@@ -42,6 +42,7 @@ use Filament\Actions\ViewAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class EditResourceHubQuality extends EditRecord
 {
@@ -54,6 +55,12 @@ class EditResourceHubQuality extends EditRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->unique(
+                        table: 'resource_hub_qualities',
+                        column: 'name',
+                        ignoreRecord: true,
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    )
                     ->string(),
             ]);
     }

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/EditResourceHubQuality.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubQualities/Pages/EditResourceHubQuality.php
@@ -55,6 +55,7 @@ class EditResourceHubQuality extends EditRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->maxLength(255)
                     ->unique(
                         table: 'resource_hub_qualities',
                         column: 'name',

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/CreateResourceHubStatus.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/CreateResourceHubStatus.php
@@ -54,10 +54,10 @@ class CreateResourceHubStatus extends CreateRecord
                     ->label('Name')
                     ->required()
                     ->unique(
-                                table: 'resource_hub_statuses',
-                                column: 'name',
-                                modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
-                            )
+                        table: 'resource_hub_statuses',
+                        column: 'name',
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    )
                     ->string(),
             ]);
     }

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/CreateResourceHubStatus.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/CreateResourceHubStatus.php
@@ -40,6 +40,7 @@ use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubStatuses\ResourceHubSt
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class CreateResourceHubStatus extends CreateRecord
 {
@@ -52,6 +53,11 @@ class CreateResourceHubStatus extends CreateRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->unique(
+                                table: 'resource_hub_statuses',
+                                column: 'name',
+                                modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                            )
                     ->string(),
             ]);
     }

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/CreateResourceHubStatus.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/CreateResourceHubStatus.php
@@ -53,6 +53,7 @@ class CreateResourceHubStatus extends CreateRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->maxLength(255)
                     ->unique(
                         table: 'resource_hub_statuses',
                         column: 'name',

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/EditResourceHubStatus.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/EditResourceHubStatus.php
@@ -55,6 +55,7 @@ class EditResourceHubStatus extends EditRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->maxLength(255)
                     ->unique(
                         table: 'resource_hub_statuses',
                         column: 'name',

--- a/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/EditResourceHubStatus.php
+++ b/app-modules/resource-hub/src/Filament/Resources/ResourceHubStatuses/Pages/EditResourceHubStatus.php
@@ -42,6 +42,7 @@ use Filament\Actions\ViewAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class EditResourceHubStatus extends EditRecord
 {
@@ -54,6 +55,12 @@ class EditResourceHubStatus extends EditRecord
                 TextInput::make('name')
                     ->label('Name')
                     ->required()
+                    ->unique(
+                        table: 'resource_hub_statuses',
+                        column: 'name',
+                        ignoreRecord: true,
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    )
                     ->string(),
             ]);
     }

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/CreateResourceHubArticleTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/CreateResourceHubArticleTest.php
@@ -45,6 +45,7 @@ use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertCount;
+use function Tests\asSuperAdmin;
 
 // TODO: Write CreateResourceHubArticle tests
 //test('A successful action on the CreateResourceHubArticle page', function () {});
@@ -117,4 +118,22 @@ test('CreateResourceHubArticle is gated with proper feature access control', fun
     $data = $request->toArray();
 
     assertDatabaseHas(ResourceHubArticle::class, $data);
+});
+
+test('CreateResourceHubArticle does not allow for duplicate article titles of non-deleted articles case insensitively', function () {
+    asSuperAdmin();
+
+    $article = ResourceHubArticle::factory(['title' => 'Article Title'])->create();
+    $request1 = collect(CreateResourceHubArticleRequestFactory::new(['title' => 'article TITLE'])->create());
+    $request2 = collect(CreateResourceHubArticleRequestFactory::new(['title' => 'article title'])->create());
+
+    $article->delete();
+
+    livewire(ListResourceHubArticles::class)
+        ->callAction('create', $request1->toArray())
+        ->assertHasNoActionErrors();
+
+    livewire(ListResourceHubArticles::class)
+        ->callAction('create', $request2->toArray())
+        ->assertHasFormErrors(['title' => 'unique']);
 });

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/CreateResourceHubArticleTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/CreateResourceHubArticleTest.php
@@ -131,7 +131,7 @@ test('CreateResourceHubArticle does not allow for duplicate article titles of no
 
     livewire(ListResourceHubArticles::class)
         ->callAction('create', $request1->toArray())
-        ->assertHasNoActionErrors();
+        ->assertHasNoFormErrors();
 
     livewire(ListResourceHubArticles::class)
         ->callAction('create', $request2->toArray())

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/EditResourceHubArticleTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/EditResourceHubArticleTest.php
@@ -139,7 +139,7 @@ test('EditResourceHubArticle does not allow for duplicate article titles of non-
         ->fillForm($request1->toArray())
         ->call('save')
         ->assertHasNoFormErrors();
-    
+
     livewire(EditResourceHubArticle::class, ['record' => $article->getRouteKey()])
         ->fillForm($request2->toArray())
         ->call('save')

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/EditResourceHubArticleTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/EditResourceHubArticleTest.php
@@ -38,12 +38,14 @@ use AdvisingApp\Authorization\Enums\LicenseType;
 use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubArticles\Pages\EditResourceHubArticle;
 use AdvisingApp\ResourceHub\Filament\Resources\ResourceHubArticles\ResourceHubArticleResource;
 use AdvisingApp\ResourceHub\Models\ResourceHubArticle;
+use AdvisingApp\ResourceHub\Tests\Tenant\ResourceHubArticle\RequestFactories\EditResourceHubArticleRequestFactory;
 use App\Models\User;
 use App\Settings\LicenseSettings;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
 use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
 
 // TODO: Write EditResourceHubArticle tests
 //test('A successful action on the EditResourceHubArticle page', function () {});
@@ -120,4 +122,26 @@ test('EditResourceHubArticle is gated with proper feature access control', funct
     )->assertSuccessful();
 
     // TODO Restore testing the edit form
+});
+
+test('EditResourceHubArticle does not allow for duplicate article titles of non-deleted articles case insensitively', function () {
+    asSuperAdmin();
+
+    $deletedArticle = ResourceHubArticle::factory(['title' => 'Article Title'])->create();
+    $article = ResourceHubArticle::factory(['title' => 'Test Title'])->create();
+    ResourceHubArticle::factory(['title' => 'Other Title'])->create();
+    $request1 = collect(EditResourceHubArticleRequestFactory::new(['title' => 'article title'])->create());
+    $request2 = collect(EditResourceHubArticleRequestFactory::new(['title' => 'OTHER title'])->create());
+
+    $deletedArticle->delete();
+
+    livewire(EditResourceHubArticle::class, ['record' => $article->getRouteKey()])
+        ->fillForm($request1->toArray())
+        ->call('save')
+        ->assertHasNoFormErrors();
+    
+    livewire(EditResourceHubArticle::class, ['record' => $article->getRouteKey()])
+        ->fillForm($request2->toArray())
+        ->call('save')
+        ->assertHasFormErrors(['title' => 'unique']);
 });

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/RequestFactories/CreateResourceHubArticleRequestFactory.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubArticle/RequestFactories/CreateResourceHubArticleRequestFactory.php
@@ -49,9 +49,9 @@ class CreateResourceHubArticleRequestFactory extends RequestFactory
             'title' => fake()->words(5, true),
             'public' => fake()->boolean(),
             'notes' => fake()->paragraph(),
-            'quality_id' => ResourceHubQuality::factory()->create()->id,
-            'status_id' => ResourceHubStatus::factory()->create()->id,
-            'category_id' => ResourceHubCategory::factory()->create()->id,
+            'quality_id' => ResourceHubQuality::query()->firstOr(fn () => ResourceHubQuality::factory()->create())->getKey(),
+            'status_id' => ResourceHubStatus::query()->firstOr(fn () => ResourceHubStatus::factory()->create())->getKey(),
+            'category_id' => ResourceHubCategory::query()->firstOr(fn () => ResourceHubCategory::factory()->create())->getKey(),
         ];
     }
 }

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/CreateResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/CreateResourceHubCategoryTest.php
@@ -46,6 +46,7 @@ use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertCount;
+use function Tests\asSuperAdmin;
 
 // TODO: Write CreateResourceHubCategory tests
 //test('A successful action on the CreateResourceHubCategory page', function () {});
@@ -124,4 +125,24 @@ test('CreateResourceHubCategory is gated with proper feature access control', fu
     assertCount(1, ResourceHubCategory::all());
 
     assertDatabaseHas(ResourceHubCategory::class, $request->toArray());
+});
+
+test('CreateResourceHubCategory does not allow for duplicate names of non-deleted categories case insensitively', function () {
+    asSuperAdmin();
+
+    $category = ResourceHubCategory::factory(['name' => 'Category Name'])->create();
+    $request1 = collect(CreateResourceHubCategoryRequestFactory::new(['name' => 'category NAME'])->create());
+    $request2 = collect(CreateResourceHubCategoryRequestFactory::new(['name' => 'category name'])->create());
+
+    $category->delete();
+
+    livewire(CreateResourceHubCategory::class)
+        ->fillForm($request1->toArray())
+        ->call('create')
+        ->assertHasNoActionErrors();
+
+    livewire(CreateResourceHubCategory::class)
+        ->fillForm($request2->toArray())
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'unique']);
 });

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/EditResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/EditResourceHubCategoryTest.php
@@ -45,6 +45,7 @@ use App\Settings\LicenseSettings;
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertEquals;
+use function Tests\asSuperAdmin;
 
 // TODO: Write EditResourceHubCategory tests
 //test('A successful action on the EditResourceHubCategory page', function () {});
@@ -139,4 +140,26 @@ test('EditResourceHubCategory is gated with proper feature access control', func
         ->assertHasNoFormErrors();
 
     assertEquals($request['name'], $resourceHubCategory->fresh()->name);
+});
+
+test('EditResourceHubCategory does not allow for duplicate names of non-deleted categories case insensitively', function () {
+    asSuperAdmin();
+
+    $deletedCategory = ResourceHubCategory::factory(['name' => 'Category Name'])->create();
+    $category = ResourceHubCategory::factory(['name' => 'Test Name'])->create();
+    ResourceHubCategory::factory(['name' => 'Other Name'])->create();
+    $request1 = collect(EditResourceHubCategoryRequestFactory::new(['name' => 'category name'])->create());
+    $request2 = collect(EditResourceHubCategoryRequestFactory::new(['name' => 'OTHER name'])->create());
+
+    $deletedCategory->delete();
+
+    livewire(EditResourceHubCategory::class, ['record' => $category->getRouteKey()])
+        ->fillForm($request1->toArray())
+        ->call('save')
+        ->assertHasNoFormErrors();
+    
+    livewire(EditResourceHubCategory::class, ['record' => $category->getRouteKey()])
+        ->fillForm($request2->toArray())
+        ->call('save')
+        ->assertHasFormErrors(['name' => 'unique']);
 });

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/EditResourceHubCategoryTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubCategory/EditResourceHubCategoryTest.php
@@ -157,7 +157,7 @@ test('EditResourceHubCategory does not allow for duplicate names of non-deleted 
         ->fillForm($request1->toArray())
         ->call('save')
         ->assertHasNoFormErrors();
-    
+
     livewire(EditResourceHubCategory::class, ['record' => $category->getRouteKey()])
         ->fillForm($request2->toArray())
         ->call('save')

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/CreateResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/CreateResourceHubQualityTest.php
@@ -46,6 +46,7 @@ use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertCount;
+use function Tests\asSuperAdmin;
 
 // TODO: Write CreateResourceHubQuality tests
 //test('A successful action on the CreateResourceHubQuality page', function () {});
@@ -124,4 +125,24 @@ test('CreateResourceHubQuality is gated with proper feature ccess control', func
     assertCount(1, ResourceHubQuality::all());
 
     assertDatabaseHas(ResourceHubQuality::class, $request->toArray());
+});
+
+test('CreateResourceHubQuality does not allow for duplicate names of non-deleted qualities case insensitively', function () {
+    asSuperAdmin();
+
+    $quality = ResourceHubQuality::factory(['name' => 'Quality Name'])->create();
+    $request1 = collect(CreateResourceHubQualityRequestFactory::new(['name' => 'quality NAME'])->create());
+    $request2 = collect(CreateResourceHubQualityRequestFactory::new(['name' => 'quality name'])->create());
+
+    $quality->delete();
+
+    livewire(CreateResourceHubQuality::class)
+        ->fillForm($request1->toArray())
+        ->call('create')
+        ->assertHasNoActionErrors();
+
+    livewire(CreateResourceHubQuality::class)
+        ->fillForm($request2->toArray())
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'unique']);
 });

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/EditResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/EditResourceHubQualityTest.php
@@ -157,7 +157,7 @@ test('EditResourceHubQuality does not allow for duplicate names of non-deleted q
         ->fillForm($request1->toArray())
         ->call('save')
         ->assertHasNoFormErrors();
-    
+
     livewire(EditResourceHubQuality::class, ['record' => $quality->getRouteKey()])
         ->fillForm($request2->toArray())
         ->call('save')

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/EditResourceHubQualityTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubQuality/EditResourceHubQualityTest.php
@@ -45,6 +45,7 @@ use App\Settings\LicenseSettings;
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertEquals;
+use function Tests\asSuperAdmin;
 
 // TODO: Write EditResourceHubQuality tests
 //test('A successful action on the EditResourceHubQuality page', function () {});
@@ -139,4 +140,26 @@ test('EditResourceHubQuality is gated with proper feature access control', funct
         ->assertHasNoFormErrors();
 
     assertEquals($request['name'], $resourceHubQuality->fresh()->name);
+});
+
+test('EditResourceHubQuality does not allow for duplicate names of non-deleted qualities case insensitively', function () {
+    asSuperAdmin();
+
+    $deletedQuality = ResourceHubQuality::factory(['name' => 'Quality Name'])->create();
+    $quality = ResourceHubQuality::factory(['name' => 'Test Name'])->create();
+    ResourceHubQuality::factory(['name' => 'Other Name'])->create();
+    $request1 = collect(EditResourceHubQualityRequestFactory::new(['name' => 'quality name'])->create());
+    $request2 = collect(EditResourceHubQualityRequestFactory::new(['name' => 'OTHER name'])->create());
+
+    $deletedQuality->delete();
+
+    livewire(EditResourceHubQuality::class, ['record' => $quality->getRouteKey()])
+        ->fillForm($request1->toArray())
+        ->call('save')
+        ->assertHasNoFormErrors();
+    
+    livewire(EditResourceHubQuality::class, ['record' => $quality->getRouteKey()])
+        ->fillForm($request2->toArray())
+        ->call('save')
+        ->assertHasFormErrors(['name' => 'unique']);
 });

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/CreateResourceHubStatusTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/CreateResourceHubStatusTest.php
@@ -46,6 +46,7 @@ use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertCount;
+use function Tests\asSuperAdmin;
 
 // TODO: Write CreateResourceHubStatus tests
 //test('A successful action on the CreateResourceHubStatus page', function () {});
@@ -124,4 +125,24 @@ test('CreateResourceHubStatus is gated with proper feature access control', func
     assertCount(1, ResourceHubStatus::all());
 
     assertDatabaseHas(ResourceHubStatus::class, $request->toArray());
+});
+
+test('CreateResourceHubStatus does not allow for duplicate names of non-deleted statuses case insensitively', function () {
+    asSuperAdmin();
+
+    $status = ResourceHubStatus::factory(['name' => 'Status Name'])->create();
+    $request1 = collect(CreateResourceHubStatusRequestFactory::new(['name' => 'status NAME'])->create());
+    $request2 = collect(CreateResourceHubStatusRequestFactory::new(['name' => 'status name'])->create());
+
+    $status->delete();
+
+    livewire(CreateResourceHubStatus::class)
+        ->fillForm($request1->toArray())
+        ->call('create')
+        ->assertHasNoActionErrors();
+
+    livewire(CreateResourceHubStatus::class)
+        ->fillForm($request2->toArray())
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'unique']);
 });

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/EditResourceHubStatusTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/EditResourceHubStatusTest.php
@@ -157,7 +157,7 @@ test('EditResourceHubStatus does not allow for duplicate names of non-deleted st
         ->fillForm($request1->toArray())
         ->call('save')
         ->assertHasNoFormErrors();
-    
+
     livewire(EditResourceHubStatus::class, ['record' => $status->getRouteKey()])
         ->fillForm($request2->toArray())
         ->call('save')

--- a/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/EditResourceHubStatusTest.php
+++ b/app-modules/resource-hub/tests/Tenant/ResourceHubStatus/EditResourceHubStatusTest.php
@@ -45,6 +45,7 @@ use App\Settings\LicenseSettings;
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertEquals;
+use function Tests\asSuperAdmin;
 
 // TODO: Write EditResourceHubStatus tests
 //test('A successful action on the EditResourceHubStatus page', function () {});
@@ -139,4 +140,26 @@ test('EditResourceHubStatus is gated with proper feature access control', functi
         ->assertHasNoFormErrors();
 
     assertEquals($request['name'], $resourceHubStatus->fresh()->name);
+});
+
+test('EditResourceHubStatus does not allow for duplicate names of non-deleted statuses case insensitively', function () {
+    asSuperAdmin();
+
+    $deletedStatus = ResourceHubStatus::factory(['name' => 'Status Name'])->create();
+    $status = ResourceHubStatus::factory(['name' => 'Test Name'])->create();
+    ResourceHubStatus::factory(['name' => 'Other Name'])->create();
+    $request1 = collect(EditResourceHubStatusRequestFactory::new(['name' => 'status name'])->create());
+    $request2 = collect(EditResourceHubStatusRequestFactory::new(['name' => 'OTHER name'])->create());
+
+    $deletedStatus->delete();
+
+    livewire(EditResourceHubStatus::class, ['record' => $status->getRouteKey()])
+        ->fillForm($request1->toArray())
+        ->call('save')
+        ->assertHasNoFormErrors();
+    
+    livewire(EditResourceHubStatus::class, ['record' => $status->getRouteKey()])
+        ->fillForm($request2->toArray())
+        ->call('save')
+        ->assertHasFormErrors(['name' => 'unique']);
 });

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,8 +22,6 @@ rules:
     - Orrison\MeliorStan\Rules\ForbidPestPhpOnly\ForbidPestPhpOnlyRule
 
 parameters:
-    parallel:
-        maximumNumberOfProcesses: 16
     # This can be removed once we have fixed all errors in our baseline. But need to be here now, so we don't have to rebuild it in every new PR.
     reportUnmatchedIgnoredErrors: false
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,6 +22,8 @@ rules:
     - Orrison\MeliorStan\Rules\ForbidPestPhpOnly\ForbidPestPhpOnlyRule
 
 parameters:
+    parallel:
+        maximumNumberOfProcesses: 16
     # This can be removed once we have fixed all errors in our baseline. But need to be here now, so we don't have to rebuild it in every new PR.
     reportUnmatchedIgnoredErrors: false
 

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -38,6 +38,10 @@ use AdvisingApp\Authorization\Models\Role;
 use AdvisingApp\Campaign\Models\CampaignAction;
 use AdvisingApp\Engagement\Models\Engagement;
 use AdvisingApp\MeetingCenter\Models\Event;
+use AdvisingApp\ResourceHub\Models\ResourceHubArticle;
+use AdvisingApp\ResourceHub\Models\ResourceHubCategory;
+use AdvisingApp\ResourceHub\Models\ResourceHubQuality;
+use AdvisingApp\ResourceHub\Models\ResourceHubStatus;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -225,4 +229,87 @@ describe('role citext change', function () {
             }
         );
     });
+});
+
+// TODO: Cleanup Task ResourceHubCitextCleanup - Delete this describe and everything contained within
+describe('resource hub citext change', function () {
+   it('properly changes article titles', function () {
+       isolatedMigration(
+           '2026_09_01_220856_convert_resource_hub_article_title_to_citext',
+           function () {
+               // Setup data before migration
+               $article1 = ResourceHubArticle::factory(['title' => 'Test Article'])->create();
+               $article2 = ResourceHubArticle::factory(['title' => 'Test Article'])->create();
+               $article3 = ResourceHubArticle::factory(['title' => 'Test Article'])->create();
+               // Run the migration
+               $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_01_220856_convert_resource_hub_article_title_to_citext.php']);
+               // Confirm migration ran successfully
+               expect($migrate)->toBe(Command::SUCCESS);
+               // Add any assertions to verify the migration's effects
+               expect($article1->refresh()->title)->toBe('Test Article');
+               expect($article2->refresh()->title)->toBe('Test Article-2');
+               expect($article3->refresh()->title)->toBe('Test Article-3');
+           }
+       );
+   });
+   
+   it('properly changes category names', function () {
+       isolatedMigration(
+           '2026_09_02_034833_convert_resource_hub_categories_name_to_citext',
+           function () {
+               // Setup data before migration
+               $category1 = ResourceHubCategory::factory(['name' => 'Test Category'])->create();
+               $category2 = ResourceHubCategory::factory(['name' => 'Test Category'])->create();
+               $category3 = ResourceHubCategory::factory(['name' => 'Test Category'])->create();
+               // Run the migration
+               $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_02_034833_convert_resource_hub_categories_name_to_citext.php']);
+               // Confirm migration ran successfully
+               expect($migrate)->toBe(Command::SUCCESS);
+               // Add any assertions to verify the migration's effects
+               expect($category1->refresh()->name)->toBe('Test Category');
+               expect($category2->refresh()->name)->toBe('Test Category-2');
+               expect($category3->refresh()->name)->toBe('Test Category-3');
+           }
+       );
+   });
+   
+   it('properly changes quality names', function () {
+       isolatedMigration(
+           '2026_09_02_034854_convert_resource_hub_qualities_name_to_citext',
+           function () {
+               // Setup data before migration
+               $quality1 = ResourceHubQuality::factory(['name' => 'Test Quality'])->create();
+               $quality2 = ResourceHubQuality::factory(['name' => 'Test Quality'])->create();
+               $quality3 = ResourceHubQuality::factory(['name' => 'Test Quality'])->create();
+               // Run the migration
+               $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_02_034854_convert_resource_hub_qualities_name_to_citext.php']);
+               // Confirm migration ran successfully
+               expect($migrate)->toBe(Command::SUCCESS);
+               // Add any assertions to verify the migration's effects
+               expect($quality1->refresh()->name)->toBe('Test Quality');
+               expect($quality2->refresh()->name)->toBe('Test Quality-2');
+               expect($quality3->refresh()->name)->toBe('Test Quality-3');
+           }
+       );
+   });
+   
+   it('properly changes status names', function () {
+       isolatedMigration(
+           '2026_09_02_034904_convert_resource_hub_statuses_name_to_citext',
+           function () {
+               // Setup data before migration
+               $status1 = ResourceHubStatus::factory(['name' => 'Test Status'])->create();
+               $status2 = ResourceHubStatus::factory(['name' => 'Test Status'])->create();
+               $status3 = ResourceHubStatus::factory(['name' => 'Test Status'])->create();
+               // Run the migration
+               $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_02_034904_convert_resource_hub_statuses_name_to_citext.php']);
+               // Confirm migration ran successfully
+               expect($migrate)->toBe(Command::SUCCESS);
+               // Add any assertions to verify the migration's effects
+               expect($status1->refresh()->name)->toBe('Test Status');
+               expect($status2->refresh()->name)->toBe('Test Status-2');
+               expect($status3->refresh()->name)->toBe('Test Status-3');
+           }
+       );
+   });
 });

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -233,83 +233,83 @@ describe('role citext change', function () {
 
 // TODO: Cleanup Task ResourceHubCitextCleanup - Delete this describe and everything contained within
 describe('resource hub citext change', function () {
-   it('properly changes article titles', function () {
-       isolatedMigration(
-           '2026_09_01_220856_convert_resource_hub_article_title_to_citext',
-           function () {
-               // Setup data before migration
-               $article1 = ResourceHubArticle::factory(['title' => 'Test Article'])->create();
-               $article2 = ResourceHubArticle::factory(['title' => 'Test Article'])->create();
-               $article3 = ResourceHubArticle::factory(['title' => 'Test Article'])->create();
-               // Run the migration
-               $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_01_220856_convert_resource_hub_article_title_to_citext.php']);
-               // Confirm migration ran successfully
-               expect($migrate)->toBe(Command::SUCCESS);
-               // Add any assertions to verify the migration's effects
-               expect($article1->refresh()->title)->toBe('Test Article');
-               expect($article2->refresh()->title)->toBe('Test Article-2');
-               expect($article3->refresh()->title)->toBe('Test Article-3');
-           }
-       );
-   });
-   
-   it('properly changes category names', function () {
-       isolatedMigration(
-           '2026_09_02_034833_convert_resource_hub_categories_name_to_citext',
-           function () {
-               // Setup data before migration
-               $category1 = ResourceHubCategory::factory(['name' => 'Test Category'])->create();
-               $category2 = ResourceHubCategory::factory(['name' => 'Test Category'])->create();
-               $category3 = ResourceHubCategory::factory(['name' => 'Test Category'])->create();
-               // Run the migration
-               $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_02_034833_convert_resource_hub_categories_name_to_citext.php']);
-               // Confirm migration ran successfully
-               expect($migrate)->toBe(Command::SUCCESS);
-               // Add any assertions to verify the migration's effects
-               expect($category1->refresh()->name)->toBe('Test Category');
-               expect($category2->refresh()->name)->toBe('Test Category-2');
-               expect($category3->refresh()->name)->toBe('Test Category-3');
-           }
-       );
-   });
-   
-   it('properly changes quality names', function () {
-       isolatedMigration(
-           '2026_09_02_034854_convert_resource_hub_qualities_name_to_citext',
-           function () {
-               // Setup data before migration
-               $quality1 = ResourceHubQuality::factory(['name' => 'Test Quality'])->create();
-               $quality2 = ResourceHubQuality::factory(['name' => 'Test Quality'])->create();
-               $quality3 = ResourceHubQuality::factory(['name' => 'Test Quality'])->create();
-               // Run the migration
-               $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_02_034854_convert_resource_hub_qualities_name_to_citext.php']);
-               // Confirm migration ran successfully
-               expect($migrate)->toBe(Command::SUCCESS);
-               // Add any assertions to verify the migration's effects
-               expect($quality1->refresh()->name)->toBe('Test Quality');
-               expect($quality2->refresh()->name)->toBe('Test Quality-2');
-               expect($quality3->refresh()->name)->toBe('Test Quality-3');
-           }
-       );
-   });
-   
-   it('properly changes status names', function () {
-       isolatedMigration(
-           '2026_09_02_034904_convert_resource_hub_statuses_name_to_citext',
-           function () {
-               // Setup data before migration
-               $status1 = ResourceHubStatus::factory(['name' => 'Test Status'])->create();
-               $status2 = ResourceHubStatus::factory(['name' => 'Test Status'])->create();
-               $status3 = ResourceHubStatus::factory(['name' => 'Test Status'])->create();
-               // Run the migration
-               $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_02_034904_convert_resource_hub_statuses_name_to_citext.php']);
-               // Confirm migration ran successfully
-               expect($migrate)->toBe(Command::SUCCESS);
-               // Add any assertions to verify the migration's effects
-               expect($status1->refresh()->name)->toBe('Test Status');
-               expect($status2->refresh()->name)->toBe('Test Status-2');
-               expect($status3->refresh()->name)->toBe('Test Status-3');
-           }
-       );
-   });
+    it('properly changes article titles', function () {
+        isolatedMigration(
+            '2026_09_01_220856_convert_resource_hub_article_title_to_citext',
+            function () {
+                // Setup data before migration
+                $article1 = ResourceHubArticle::factory(['title' => 'Test Article'])->create();
+                $article2 = ResourceHubArticle::factory(['title' => 'Test Article'])->create();
+                $article3 = ResourceHubArticle::factory(['title' => 'Test Article'])->create();
+                // Run the migration
+                $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_01_220856_convert_resource_hub_article_title_to_citext.php']);
+                // Confirm migration ran successfully
+                expect($migrate)->toBe(Command::SUCCESS);
+                // Add any assertions to verify the migration's effects
+                expect($article1->refresh()->title)->toBe('Test Article');
+                expect($article2->refresh()->title)->toBe('Test Article-2');
+                expect($article3->refresh()->title)->toBe('Test Article-3');
+            }
+        );
+    });
+
+    it('properly changes category names', function () {
+        isolatedMigration(
+            '2026_09_02_034833_convert_resource_hub_categories_name_to_citext',
+            function () {
+                // Setup data before migration
+                $category1 = ResourceHubCategory::factory(['name' => 'Test Category'])->create();
+                $category2 = ResourceHubCategory::factory(['name' => 'Test Category'])->create();
+                $category3 = ResourceHubCategory::factory(['name' => 'Test Category'])->create();
+                // Run the migration
+                $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_02_034833_convert_resource_hub_categories_name_to_citext.php']);
+                // Confirm migration ran successfully
+                expect($migrate)->toBe(Command::SUCCESS);
+                // Add any assertions to verify the migration's effects
+                expect($category1->refresh()->name)->toBe('Test Category');
+                expect($category2->refresh()->name)->toBe('Test Category-2');
+                expect($category3->refresh()->name)->toBe('Test Category-3');
+            }
+        );
+    });
+
+    it('properly changes quality names', function () {
+        isolatedMigration(
+            '2026_09_02_034854_convert_resource_hub_qualities_name_to_citext',
+            function () {
+                // Setup data before migration
+                $quality1 = ResourceHubQuality::factory(['name' => 'Test Quality'])->create();
+                $quality2 = ResourceHubQuality::factory(['name' => 'Test Quality'])->create();
+                $quality3 = ResourceHubQuality::factory(['name' => 'Test Quality'])->create();
+                // Run the migration
+                $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_02_034854_convert_resource_hub_qualities_name_to_citext.php']);
+                // Confirm migration ran successfully
+                expect($migrate)->toBe(Command::SUCCESS);
+                // Add any assertions to verify the migration's effects
+                expect($quality1->refresh()->name)->toBe('Test Quality');
+                expect($quality2->refresh()->name)->toBe('Test Quality-2');
+                expect($quality3->refresh()->name)->toBe('Test Quality-3');
+            }
+        );
+    });
+
+    it('properly changes status names', function () {
+        isolatedMigration(
+            '2026_09_02_034904_convert_resource_hub_statuses_name_to_citext',
+            function () {
+                // Setup data before migration
+                $status1 = ResourceHubStatus::factory(['name' => 'Test Status'])->create();
+                $status2 = ResourceHubStatus::factory(['name' => 'Test Status'])->create();
+                $status3 = ResourceHubStatus::factory(['name' => 'Test Status'])->create();
+                // Run the migration
+                $migrate = Artisan::call('migrate', ['--path' => 'app-modules/resource-hub/database/migrations/2026_09_02_034904_convert_resource_hub_statuses_name_to_citext.php']);
+                // Confirm migration ran successfully
+                expect($migrate)->toBe(Command::SUCCESS);
+                // Add any assertions to verify the migration's effects
+                expect($status1->refresh()->name)->toBe('Test Status');
+                expect($status2->refresh()->name)->toBe('Test Status-2');
+                expect($status3->refresh()->name)->toBe('Test Status-3');
+            }
+        );
+    });
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2922

### Technical Description

Convert resource hub article title, category, quality, and status names to citext; migrate existing ones to be distinct

### Any deployment steps required?

No

### Cleanup Tasks

.cleanup-tasks/2026_09_02_convert_resource_hub_title_and_names_to_citext.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
