### PR TITLE
[ADVAPP-2941]: Prevent duplicate system user names

### DIFF
--- a/.cleanup-tasks/2026_09_02_convert_system_user_name_to_citext.md
+++ b/.cleanup-tasks/2026_09_02_convert_system_user_name_to_citext.md
@@ -1,0 +1,12 @@
+---
+title: Convert System User Name To Citext
+created: 2026-09-02
+---
+
+## Feature Flags
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+Search for `TODO: Cleanup Task SystemUserCitextCleanup`

--- a/app/Filament/Resources/SystemUsers/Pages/CreateSystemUser.php
+++ b/app/Filament/Resources/SystemUsers/Pages/CreateSystemUser.php
@@ -40,6 +40,7 @@ use App\Filament\Resources\SystemUsers\SystemUserResource;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class CreateSystemUser extends CreateRecord
 {
@@ -52,6 +53,11 @@ class CreateSystemUser extends CreateRecord
         return $schema->components([
             TextInput::make('name')
                 ->required()
+                ->unique(
+                    table: 'system_users',
+                    column: 'name',
+                    modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                )
                 ->string(),
         ]);
     }

--- a/app/Filament/Resources/SystemUsers/Pages/CreateSystemUser.php
+++ b/app/Filament/Resources/SystemUsers/Pages/CreateSystemUser.php
@@ -53,6 +53,7 @@ class CreateSystemUser extends CreateRecord
         return $schema->components([
             TextInput::make('name')
                 ->required()
+                ->maxLength(255)
                 ->unique(
                     table: 'system_users',
                     column: 'name',

--- a/app/Filament/Resources/SystemUsers/Pages/EditSystemUser.php
+++ b/app/Filament/Resources/SystemUsers/Pages/EditSystemUser.php
@@ -43,6 +43,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class EditSystemUser extends EditRecord
 {
@@ -55,6 +56,12 @@ class EditSystemUser extends EditRecord
         return $schema->components([
             TextInput::make('name')
                 ->required()
+                ->unique(
+                    table: 'system_users',
+                    column: 'name',
+                    ignoreRecord: true,
+                    modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                )
                 ->string(),
             TextInput::make('token')
                 ->hint('Please copy the token, it will only be shown once.')

--- a/app/Filament/Resources/SystemUsers/Pages/EditSystemUser.php
+++ b/app/Filament/Resources/SystemUsers/Pages/EditSystemUser.php
@@ -56,6 +56,7 @@ class EditSystemUser extends EditRecord
         return $schema->components([
             TextInput::make('name')
                 ->required()
+                ->maxLength(255)
                 ->unique(
                     table: 'system_users',
                     column: 'name',

--- a/database/migrations/2026_09_02_062437_convert_system_user_name_to_citext.php
+++ b/database/migrations/2026_09_02_062437_convert_system_user_name_to_citext.php
@@ -1,0 +1,58 @@
+<?php
+
+use Database\Migrations\Concerns\FixesDuplicateNames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    // TODO: Cleanup Task SystemUserCitextCleanup - remove FixesDuplicateNames trait & usages
+    use FixesDuplicateNames;
+
+    protected string $table = 'system_users';
+
+    protected string $column = 'name';
+
+    /** @var array<int, string> */
+    protected array $groupByColumns = [];
+
+    // TODO: Cleanup Task SystemUserCitextCleanup - remove $chunkSize and $usesSoftDeletes
+    protected int $chunkSize = 500;
+
+    protected bool $usesSoftDeletes = true;
+
+    private string $uniqueConstraint = 'system_users_name_unique';
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUnique($this->uniqueConstraint);
+            });
+
+            $this->fixDuplicates();
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->uniqueIndex([...$this->groupByColumns, $this->column], $this->uniqueConstraint)
+                    ->where(fn (Builder $condition) => $condition->whereNull('deleted_at'));
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUniqueIndex($this->uniqueConstraint);
+
+                $table->unique([...$this->groupByColumns, $this->column], $this->uniqueConstraint);
+            });
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+        });
+    }
+};

--- a/database/migrations/2026_09_02_062437_convert_system_user_name_to_citext.php
+++ b/database/migrations/2026_09_02_062437_convert_system_user_name_to_citext.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Database\Migrations\Concerns\FixesDuplicateNames;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Builder;

--- a/database/migrations/2026_09_02_062437_convert_system_user_name_to_citext.php
+++ b/database/migrations/2026_09_02_062437_convert_system_user_name_to_citext.php
@@ -82,11 +82,13 @@ return new class () extends Migration {
         DB::transaction(function () {
             Schema::table($this->table, function (Blueprint $table) {
                 $table->dropUniqueIndex($this->uniqueConstraint);
-
-                $table->unique([...$this->groupByColumns, $this->column], $this->uniqueConstraint);
             });
 
             DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->unique([...$this->groupByColumns, $this->column], $this->uniqueConstraint);
+            });
         });
     }
 };

--- a/tests/Tenant/Feature/Filament/SystemUsers/CreateSystemUserTest.php
+++ b/tests/Tenant/Feature/Filament/SystemUsers/CreateSystemUserTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Filament\Resources\SystemUsers\Pages\CreateSystemUser;
+use App\Models\SystemUser;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+test('CreateSystemUser does not allow for duplicate names of non-deleted system users case insensitively', function () {
+    asSuperAdmin();
+
+    $systemUser = SystemUser::factory(['name' => 'System User'])->create();
+    $systemUser->delete();
+
+    livewire(CreateSystemUser::class)
+        ->fillForm(['name' => 'system USER'])
+        ->call('create')
+        ->assertHasNoActionErrors();
+
+    livewire(CreateSystemUser::class)
+        ->fillForm(['name' => 'system user'])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'unique']);
+});

--- a/tests/Tenant/Feature/Filament/SystemUsers/CreateSystemUserTest.php
+++ b/tests/Tenant/Feature/Filament/SystemUsers/CreateSystemUserTest.php
@@ -49,7 +49,7 @@ test('CreateSystemUser does not allow for duplicate names of non-deleted system 
     livewire(CreateSystemUser::class)
         ->fillForm(['name' => 'system USER'])
         ->call('create')
-        ->assertHasNoActionErrors();
+        ->assertHasNoFormErrors();
 
     livewire(CreateSystemUser::class)
         ->fillForm(['name' => 'system user'])

--- a/tests/Tenant/Feature/Filament/SystemUsers/CreateSystemUserTest.php
+++ b/tests/Tenant/Feature/Filament/SystemUsers/CreateSystemUserTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Filament\Resources\SystemUsers\Pages\CreateSystemUser;
 use App\Models\SystemUser;
 

--- a/tests/Tenant/Feature/Filament/SystemUsers/EditSystemUserTest.php
+++ b/tests/Tenant/Feature/Filament/SystemUsers/EditSystemUserTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Filament\Resources\SystemUsers\Pages\EditSystemUser;
+use App\Models\SystemUser;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+test('EditSystemUser does not allow for duplicate names of non-deleted system users case insensitively', function () {
+    asSuperAdmin();
+
+    $deletedSystemUser = SystemUser::factory(['name' => 'System User'])->create();
+    $systemUser = SystemUser::factory(['name' => 'Test System User'])->create();
+    SystemUser::factory(['name' => 'Other System User'])->create();
+
+    $deletedSystemUser->delete();
+
+    livewire(EditSystemUser::class, ['record' => $systemUser->getRouteKey()])
+        ->fillForm(['name' => 'system user'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    livewire(EditSystemUser::class, ['record' => $systemUser->getRouteKey()])
+        ->fillForm(['name' => 'OTHER System user'])
+        ->call('save')
+        ->assertHasFormErrors(['name' => 'unique']);
+});

--- a/tests/Tenant/Feature/Filament/SystemUsers/EditSystemUserTest.php
+++ b/tests/Tenant/Feature/Filament/SystemUsers/EditSystemUserTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use App\Filament\Resources\SystemUsers\Pages\EditSystemUser;
 use App\Models\SystemUser;
 

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -44,6 +44,7 @@ use AdvisingApp\ResourceHub\Models\ResourceHubQuality;
 use AdvisingApp\ResourceHub\Models\ResourceHubStatus;
 use AdvisingApp\Team\Models\Department;
 use App\Enums\TagType;
+use App\Models\SystemUser;
 use App\Models\Tag;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
@@ -364,6 +365,29 @@ describe('department citext change', function () {
                 expect($department1->refresh()->name)->toBe('Department');
                 expect($department2->refresh()->name)->toBe('department-2');
                 expect($department3->refresh()->name)->toBe('DEPARTMENT-3');
+            }
+        );
+    });
+});
+
+// TODO: Cleanup Task SystemUserCitextCleanup - Delete this describe and everything contained within
+describe('system user citext change', function () {
+    it('properly changes system user names', function () {
+        isolatedMigration(
+            '2026_09_02_062437_convert_system_user_name_to_citext',
+            function () {
+                // Setup data before migration
+                $systemUser1 = SystemUser::factory(['name' => 'System user'])->create();
+                $systemUser2 = SystemUser::factory(['name' => 'system User'])->create();
+                $systemUser3 = SystemUser::factory(['name' => 'system user'])->create();
+                // Run the migration
+                $migrate = Artisan::call('migrate', ['--path' => 'database/migrations/2026_09_02_062437_convert_system_user_name_to_citext.php']);
+                // Confirm migration ran successfully
+                expect($migrate)->toBe(Command::SUCCESS);
+                // Add any assertions to verify the migration's effects
+                expect($systemUser1->refresh()->name)->toBe('System user');
+                expect($systemUser2->refresh()->name)->toBe('system User-2');
+                expect($systemUser3->refresh()->name)->toBe('system user-3');
             }
         );
     });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2941

### Technical Description

Convert system user names to citext; migrate existing ones to be distinct

### Any deployment steps required?

No

### Cleanup Tasks

.cleanup-tasks/2026_09_02_convert_system_user_name_to_citext.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
