### PR TITLE
[ADVAPP-2939]: Prevent duplicate role names

### DIFF
--- a/.cleanup-tasks/2026_09_02_convert_role_name_to_citext.md
+++ b/.cleanup-tasks/2026_09_02_convert_role_name_to_citext.md
@@ -1,0 +1,12 @@
+---
+title: Convert Role Name To Citext
+created: 2026-09-02
+---
+
+## Feature Flags
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+Search for `TODO: Cleanup Task RoleCitextCleanup`

--- a/app-modules/authorization/database/migrations/2026_09_02_125430_convert_role_name_to_citext.php
+++ b/app-modules/authorization/database/migrations/2026_09_02_125430_convert_role_name_to_citext.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Database\Migrations\Concerns\FixesDuplicateNames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    // TODO: Cleanup Task RoleCitextCleanup - remove FixesDuplicateNames trait & usages
+    use FixesDuplicateNames;
+
+    protected string $table = 'roles';
+
+    protected string $column = 'name';
+
+    /** @var array<int, string> */
+    protected array $groupByColumns = ['guard_name'];
+
+    // TODO: Cleanup Task RoleCitextCleanup - remove $chunkSize and $usesSoftDeletes
+    protected int $chunkSize = 500;
+
+    protected bool $usesSoftDeletes = false;
+
+    private string $uniqueConstraint = 'roles_name_guard_name_unique';
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUnique($this->uniqueConstraint);
+            });
+
+            $this->fixDuplicates();
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->unique(['name', 'guard_name'], $this->uniqueConstraint);
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUnique($this->uniqueConstraint);
+            });
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->unique(['name', 'guard_name'], $this->uniqueConstraint);
+            });
+        });
+    }
+};

--- a/app-modules/authorization/src/Filament/Resources/Roles/Pages/ListRoles.php
+++ b/app-modules/authorization/src/Filament/Resources/Roles/Pages/ListRoles.php
@@ -51,6 +51,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rules\Unique;
 use Throwable;
 
 class ListRoles extends ListRecords
@@ -112,7 +113,15 @@ class ListRoles extends ListRecords
                     ->schema([
                         TextInput::make('name')
                             ->label('New Role Name')
-                            ->required(),
+                            ->required()
+                            ->maxLength(125)
+                            ->unique(
+                                table: 'roles',
+                                column: 'name',
+                                modifyRuleUsing: function (Unique $rule, Role $record) {
+                                    $rule->where('guard_name', $record->guard_name);
+                                }
+                            ),
                     ])
                     ->action(function (Role $record, array $data) {
                         try {

--- a/app-modules/authorization/tests/Tenant/Feature/Filament/Resources/Roles/CreateRoleTest.php
+++ b/app-modules/authorization/tests/Tenant/Feature/Filament/Resources/Roles/CreateRoleTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Authorization\Filament\Resources\Roles\Pages\CreateRole;
+use AdvisingApp\Authorization\Models\Role;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+test('CreateRole does not allow duplicate role names case insensitively within a guard', function () {
+    asSuperAdmin();
+
+    Role::factory()->create(['name' => 'Support Team', 'guard_name' => 'web']);
+
+    // The same name under a different guard is allowed.
+    livewire(CreateRole::class)
+        ->fillForm(['name' => 'support team', 'guard_name' => 'api'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    // A case-insensitive duplicate under the same guard is rejected.
+    livewire(CreateRole::class)
+        ->fillForm(['name' => 'SUPPORT team', 'guard_name' => 'web'])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'unique']);
+});

--- a/app-modules/authorization/tests/Tenant/Feature/Filament/Resources/Roles/EditRoleTest.php
+++ b/app-modules/authorization/tests/Tenant/Feature/Filament/Resources/Roles/EditRoleTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Authorization\Filament\Resources\Roles\Pages\EditRole;
+use AdvisingApp\Authorization\Models\Role;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+test('EditRole does not allow duplicate role names case insensitively within a guard', function () {
+    asSuperAdmin();
+
+    $role = Role::factory()->create(['name' => 'First Role', 'guard_name' => 'web']);
+    Role::factory()->create(['name' => 'Second Role', 'guard_name' => 'web']);
+
+    // Editing a role to its own name in a different case is allowed (record is ignored).
+    livewire(EditRole::class, ['record' => $role->getRouteKey()])
+        ->fillForm(['name' => 'first role'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    // Colliding with another role's name case-insensitively is rejected.
+    livewire(EditRole::class, ['record' => $role->getRouteKey()])
+        ->fillForm(['name' => 'SECOND role'])
+        ->call('save')
+        ->assertHasFormErrors(['name' => 'unique']);
+});

--- a/app-modules/authorization/tests/Tenant/Feature/Filament/Resources/Roles/ListRolesTest.php
+++ b/app-modules/authorization/tests/Tenant/Feature/Filament/Resources/Roles/ListRolesTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Authorization\Filament\Resources\Roles\Pages\ListRoles;
+use AdvisingApp\Authorization\Models\Role;
+use Filament\Actions\Testing\TestAction;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+test('duplicateRole action does not allow duplicate role names case insensitively within a guard', function () {
+    asSuperAdmin();
+
+    $role = Role::factory()->create(['name' => 'Original Role', 'guard_name' => 'web']);
+    Role::factory()->create(['name' => 'Taken Role', 'guard_name' => 'web']);
+
+    livewire(ListRoles::class)
+        ->callAction(TestAction::make('duplicateRole')->table($role), data: ['name' => 'taken ROLE'])
+        ->assertHasActionErrors(['name' => 'unique']);
+
+    livewire(ListRoles::class)
+        ->callAction(TestAction::make('duplicateRole')->table($role), data: ['name' => 'Fresh Role'])
+        ->assertHasNoActionErrors();
+
+    expect(Role::query()->where('guard_name', 'web')->where('name', 'Fresh Role')->exists())->toBeTrue();
+});

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -34,6 +34,7 @@
 </COPYRIGHT>
 */
 
+use AdvisingApp\Authorization\Models\Role;
 use AdvisingApp\Campaign\Models\CampaignAction;
 use AdvisingApp\Engagement\Models\Engagement;
 use Illuminate\Console\Command;
@@ -127,4 +128,33 @@ test('2026_04_08_145038_rename_campaign_action_id_to_source_morph_on_engagements
             expect($withoutSource->source_type)->toBeNull(); /** @phpstan-ignore-line */
         }
     );
+});
+
+// TODO: Cleanup Task RoleCitextCleanup - Delete this describe and everything contained within
+describe('role citext change', function () {
+    it('properly deduplicates role names case insensitively per guard', function () {
+        isolatedMigration(
+            '2026_09_02_000000_convert_role_name_to_citext',
+            function () {
+                // Setup data before migration
+                $role1 = Role::factory()->create(['name' => 'Role', 'guard_name' => 'web']);
+                $role2 = Role::factory()->create(['name' => 'role', 'guard_name' => 'web']);
+                $role3 = Role::factory()->create(['name' => 'ROLE', 'guard_name' => 'web']);
+                // A matching name under a different guard must be left untouched
+                $role4 = Role::factory()->create(['name' => 'role', 'guard_name' => 'api']);
+
+                // Run the migration
+                $migrate = Artisan::call('migrate', ['--path' => 'app-modules/authorization/database/migrations/2026_09_02_000000_convert_role_name_to_citext.php']);
+
+                // Confirm migration ran successfully
+                expect($migrate)->toBe(Command::SUCCESS);
+
+                // The first record keeps its name, the rest are suffixed within the guard
+                expect($role1->refresh()->name)->toBe('Role');
+                expect($role2->refresh()->name)->toBe('role-2');
+                expect($role3->refresh()->name)->toBe('ROLE-3');
+                expect($role4->refresh()->name)->toBe('role');
+            }
+        );
+    });
 });

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -162,7 +162,6 @@ describe('survey name citext change', function () {
     });
 });
 
-
 // TODO: Cleanup Task RoleCitextCleanup - Delete this describe and everything contained within
 describe('role citext change', function () {
     it('properly deduplicates role names case insensitively per guard', function () {

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -134,7 +134,7 @@ test('2026_04_08_145038_rename_campaign_action_id_to_source_morph_on_engagements
 describe('role citext change', function () {
     it('properly deduplicates role names case insensitively per guard', function () {
         isolatedMigration(
-            '2026_09_02_000000_convert_role_name_to_citext',
+            '2026_09_02_125430_convert_role_name_to_citext',
             function () {
                 // Setup data before migration
                 $role1 = Role::factory()->create(['name' => 'Role', 'guard_name' => 'web']);
@@ -144,7 +144,7 @@ describe('role citext change', function () {
                 $role4 = Role::factory()->create(['name' => 'role', 'guard_name' => 'api']);
 
                 // Run the migration
-                $migrate = Artisan::call('migrate', ['--path' => 'app-modules/authorization/database/migrations/2026_09_02_000000_convert_role_name_to_citext.php']);
+                $migrate = Artisan::call('migrate', ['--path' => 'app-modules/authorization/database/migrations/2026_09_02_125430_convert_role_name_to_citext.php']);
 
                 // Confirm migration ran successfully
                 expect($migrate)->toBe(Command::SUCCESS);


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2939

### Technical Description

- Add migration and tests for converting role names to citext with case-insensitive uniqueness

### Any deployment steps required?

No

### Cleanup Tasks

- Cleanup File: .cleanup-tasks/2026_09_02_convert_role_name_to_citext.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
