### PR TITLE
[ADVAPP-2942]: Prevent duplicate tag names

### DIFF
--- a/.cleanup-tasks/2026_09_02_convert_tag_name_to_citext.md
+++ b/.cleanup-tasks/2026_09_02_convert_tag_name_to_citext.md
@@ -1,0 +1,12 @@
+---
+title: Convert Tag Name To Citext
+created: 2026-09-02
+---
+
+## Feature Flags
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+Search for `TODO: Cleanup Task TagCitextCleanup`

--- a/app-modules/prospect/src/Filament/Resources/ProspectTags/Pages/CreateProspectTag.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectTags/Pages/CreateProspectTag.php
@@ -41,6 +41,7 @@ use App\Enums\TagType;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class CreateProspectTag extends CreateRecord
 {
@@ -54,7 +55,11 @@ class CreateProspectTag extends CreateRecord
                     ->label('Name')
                     ->required()
                     ->maxLength(255)
-                    ->string(),
+                    ->unique(
+                        table: 'tags',
+                        column: 'name',
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    ),
             ]);
     }
 

--- a/app-modules/prospect/src/Filament/Resources/ProspectTags/Pages/CreateProspectTag.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectTags/Pages/CreateProspectTag.php
@@ -58,7 +58,7 @@ class CreateProspectTag extends CreateRecord
                     ->unique(
                         table: 'tags',
                         column: 'name',
-                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->where('type', TagType::Prospect)->withoutTrashed(),
                     ),
             ]);
     }

--- a/app-modules/prospect/src/Filament/Resources/ProspectTags/Pages/EditProspectTag.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectTags/Pages/EditProspectTag.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\Prospect\Filament\Resources\ProspectTags\Pages;
 
 use AdvisingApp\Prospect\Filament\Resources\ProspectTags\ProspectTagResource;
+use App\Enums\TagType;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
@@ -59,7 +60,7 @@ class EditProspectTag extends EditRecord
                         table: 'tags',
                         column: 'name',
                         ignoreRecord: true,
-                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->where('type', TagType::Prospect)->withoutTrashed(),
                     ),
             ]);
     }

--- a/app-modules/prospect/src/Filament/Resources/ProspectTags/Pages/EditProspectTag.php
+++ b/app-modules/prospect/src/Filament/Resources/ProspectTags/Pages/EditProspectTag.php
@@ -41,6 +41,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class EditProspectTag extends EditRecord
 {
@@ -54,7 +55,12 @@ class EditProspectTag extends EditRecord
                     ->label('Name')
                     ->required()
                     ->maxLength(255)
-                    ->string(),
+                    ->unique(
+                        table: 'tags',
+                        column: 'name',
+                        ignoreRecord: true,
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    ),
             ]);
     }
 

--- a/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/CreateProspectTagTest.php
+++ b/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/CreateProspectTagTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Prospect\Filament\Resources\ProspectTags\Pages\CreateProspectTag;
 use App\Enums\TagType;
 use App\Models\Tag;

--- a/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/CreateProspectTagTest.php
+++ b/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/CreateProspectTagTest.php
@@ -57,3 +57,27 @@ test('CreateProspectTag does not allow for duplicate names of non-deleted prospe
         ->call('create')
         ->assertHasFormErrors(['name' => 'unique']);
 });
+
+test('CreateProspectTag does allow for non-duplicate names of non-deleted prospect tags', function () {
+    asSuperAdmin();
+
+    Tag::factory(['name' => 'Prospect Tag 1', 'type' => TagType::Prospect])->create();
+    $tag = Tag::factory(['name' => 'Prospect Tag 2', 'type' => TagType::Prospect])->create();
+    $tag->delete();
+
+    livewire(CreateProspectTag::class)
+        ->fillForm(['name' => 'Prospect Tag 2'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+});
+
+test('CreateProspectTag does allow for duplicate names of student tags', function () {
+    asSuperAdmin();
+
+    Tag::factory(['name' => 'Tag', 'type' => TagType::Student])->create();
+
+    livewire(CreateProspectTag::class)
+        ->fillForm(['name' => 'Tag'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+});

--- a/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/CreateProspectTagTest.php
+++ b/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/CreateProspectTagTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use AdvisingApp\Prospect\Filament\Resources\ProspectTags\Pages\CreateProspectTag;
+use App\Enums\TagType;
+use App\Models\Tag;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+test('CreateProspectTag does not allow for duplicate names of non-deleted prospect tags case insensitively', function () {
+    asSuperAdmin();
+
+    $tag = Tag::factory(['name' => 'Prospect Tag', 'type' => TagType::Prospect])->create();
+    $tag->delete();
+
+    livewire(CreateProspectTag::class)
+        ->fillForm(['name' => 'prospect TAG'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    livewire(CreateProspectTag::class)
+        ->fillForm(['name' => 'prospect tag'])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'unique']);
+});

--- a/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/EditProspectTagTest.php
+++ b/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/EditProspectTagTest.php
@@ -45,18 +45,43 @@ test('EditProspectTag does not allow for duplicate names of non-deleted prospect
     asSuperAdmin();
 
     $deletedTag = Tag::factory(['name' => 'Prospect Tag', 'type' => TagType::Prospect])->create();
-    $systemUser = Tag::factory(['name' => 'Test Prospect Tag',  'type' => TagType::Prospect])->create();
+    $tag = Tag::factory(['name' => 'Test Prospect Tag',  'type' => TagType::Prospect])->create();
     Tag::factory(['name' => 'Other Prospect Tag',  'type' => TagType::Prospect])->create();
 
     $deletedTag->delete();
 
-    livewire(EditProspectTag::class, ['record' => $systemUser->getRouteKey()])
+    livewire(EditProspectTag::class, ['record' => $tag->getRouteKey()])
         ->fillForm(['name' => 'prospect tag'])
         ->call('save')
         ->assertHasNoFormErrors();
 
-    livewire(EditProspectTag::class, ['record' => $systemUser->getRouteKey()])
+    livewire(EditProspectTag::class, ['record' => $tag->getRouteKey()])
         ->fillForm(['name' => 'OTHER Prospect tag'])
         ->call('save')
         ->assertHasFormErrors(['name' => 'unique']);
+});
+
+test('EditProspectTag does allow for non-duplicate names of non-deleted prospect tags', function () {
+    asSuperAdmin();
+
+    $tag = Tag::factory(['name' => 'Prospect Tag 1', 'type' => TagType::Prospect])->create();
+    $deletedTag = Tag::factory(['name' => 'Prospect Tag 2', 'type' => TagType::Prospect])->create();
+    $deletedTag->delete();
+
+    livewire(EditProspectTag::class, ['record' => $tag->getRouteKey()])
+        ->fillForm(['name' => 'Prospect Tag 2'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+});
+
+test('EditProspectTag does allow for duplicate names of student tags', function () {
+    asSuperAdmin();
+
+    Tag::factory(['name' => 'Tag', 'type' => TagType::Student])->create();
+    $tag = Tag::factory(['name' => 'Prospect Tag', 'type' => TagType::Prospect])->create();
+
+    livewire(EditProspectTag::class, ['record' => $tag->getRouteKey()])
+        ->fillForm(['name' => 'Tag'])
+        ->call('save')
+        ->assertHasNoFormErrors();
 });

--- a/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/EditProspectTagTest.php
+++ b/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/EditProspectTagTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use AdvisingApp\Prospect\Filament\Resources\ProspectTags\Pages\EditProspectTag;
+use App\Enums\TagType;
+use App\Models\Tag;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+test('EditProspectTag does not allow for duplicate names of non-deleted prospect tags case insensitively', function () {
+    asSuperAdmin();
+
+    $deletedTag = Tag::factory(['name' => 'Prospect Tag', 'type' => TagType::Prospect])->create();
+    $systemUser = Tag::factory(['name' => 'Test Prospect Tag',  'type' => TagType::Prospect])->create();
+    Tag::factory(['name' => 'Other Prospect Tag',  'type' => TagType::Prospect])->create();
+
+    $deletedTag->delete();
+
+    livewire(EditProspectTag::class, ['record' => $systemUser->getRouteKey()])
+        ->fillForm(['name' => 'prospect tag'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    livewire(EditProspectTag::class, ['record' => $systemUser->getRouteKey()])
+        ->fillForm(['name' => 'OTHER Prospect tag'])
+        ->call('save')
+        ->assertHasFormErrors(['name' => 'unique']);
+});

--- a/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/EditProspectTagTest.php
+++ b/app-modules/prospect/tests/Tenant/Filament/Resources/ProspectTags/Pages/EditProspectTagTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\Prospect\Filament\Resources\ProspectTags\Pages\EditProspectTag;
 use App\Enums\TagType;
 use App\Models\Tag;

--- a/app-modules/student-data-model/src/Filament/Resources/StudentTags/Pages/CreateStudentTag.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentTags/Pages/CreateStudentTag.php
@@ -58,7 +58,7 @@ class CreateStudentTag extends CreateRecord
                     ->unique(
                         table: 'tags',
                         column: 'name',
-                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->where('type', TagType::Student)->withoutTrashed(),
                     ),
             ]);
     }

--- a/app-modules/student-data-model/src/Filament/Resources/StudentTags/Pages/CreateStudentTag.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentTags/Pages/CreateStudentTag.php
@@ -41,6 +41,7 @@ use App\Enums\TagType;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class CreateStudentTag extends CreateRecord
 {
@@ -54,7 +55,11 @@ class CreateStudentTag extends CreateRecord
                     ->label('Name')
                     ->required()
                     ->maxLength(255)
-                    ->string(),
+                    ->unique(
+                        table: 'tags',
+                        column: 'name',
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    ),
             ]);
     }
 

--- a/app-modules/student-data-model/src/Filament/Resources/StudentTags/Pages/EditStudentTag.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentTags/Pages/EditStudentTag.php
@@ -37,6 +37,7 @@
 namespace AdvisingApp\StudentDataModel\Filament\Resources\StudentTags\Pages;
 
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentTags\StudentTagResource;
+use App\Enums\TagType;
 use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
@@ -59,7 +60,7 @@ class EditStudentTag extends EditRecord
                         table: 'tags',
                         column: 'name',
                         ignoreRecord: true,
-                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->where('type', TagType::Student)->withoutTrashed(),
                     ),
             ]);
     }

--- a/app-modules/student-data-model/src/Filament/Resources/StudentTags/Pages/EditStudentTag.php
+++ b/app-modules/student-data-model/src/Filament/Resources/StudentTags/Pages/EditStudentTag.php
@@ -41,6 +41,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class EditStudentTag extends EditRecord
 {
@@ -54,7 +55,12 @@ class EditStudentTag extends EditRecord
                     ->label('Name')
                     ->required()
                     ->maxLength(255)
-                    ->string(),
+                    ->unique(
+                        table: 'tags',
+                        column: 'name',
+                        ignoreRecord: true,
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    ),
             ]);
     }
 

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/CreateStudentTagTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/CreateStudentTagTest.php
@@ -57,3 +57,27 @@ test('CreateStudentTag does not allow for duplicate names of non-deleted student
         ->call('create')
         ->assertHasFormErrors(['name' => 'unique']);
 });
+
+test('CreateStudentTag does allow for non-duplicate names of non-deleted student tags', function () {
+    asSuperAdmin();
+
+    Tag::factory(['name' => 'Student Tag 1', 'type' => TagType::Student])->create();
+    $tag = Tag::factory(['name' => 'Student Tag 2', 'type' => TagType::Student])->create();
+    $tag->delete();
+
+    livewire(CreateStudentTag::class)
+        ->fillForm(['name' => 'Student Tag 2'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+});
+
+test('CreateStudentTag does allow for duplicate names of prospect tags', function () {
+    asSuperAdmin();
+
+    Tag::factory(['name' => 'Tag', 'type' => TagType::Prospect])->create();
+
+    livewire(CreateStudentTag::class)
+        ->fillForm(['name' => 'Tag'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+});

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/CreateStudentTagTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/CreateStudentTagTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentTags\Pages\CreateStudentTag;
 use App\Enums\TagType;
 use App\Models\Tag;

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/CreateStudentTagTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/CreateStudentTagTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use AdvisingApp\StudentDataModel\Filament\Resources\StudentTags\Pages\CreateStudentTag;
+use App\Enums\TagType;
+use App\Models\Tag;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+test('CreateStudentTag does not allow for duplicate names of non-deleted student tags case insensitively', function () {
+    asSuperAdmin();
+
+    $tag = Tag::factory(['name' => 'Student Tag', 'type' => TagType::Student])->create();
+    $tag->delete();
+
+    livewire(CreateStudentTag::class)
+        ->fillForm(['name' => 'student TAG'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    livewire(CreateStudentTag::class)
+        ->fillForm(['name' => 'student tag'])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'unique']);
+});

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/EditStudentTagTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/EditStudentTagTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use AdvisingApp\StudentDataModel\Filament\Resources\StudentTags\Pages\EditStudentTag;
+use App\Enums\TagType;
+use App\Models\Tag;
+
+use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
+
+test('EditStudentTag does not allow for duplicate names of non-deleted student tags case insensitively', function () {
+    asSuperAdmin();
+
+    $deletedTag = Tag::factory(['name' => 'Student Tag', 'type' => TagType::Student])->create();
+    $systemUser = Tag::factory(['name' => 'Test Student Tag',  'type' => TagType::Student])->create();
+    Tag::factory(['name' => 'Other Student Tag',  'type' => TagType::Student])->create();
+
+    $deletedTag->delete();
+
+    livewire(EditStudentTag::class, ['record' => $systemUser->getRouteKey()])
+        ->fillForm(['name' => 'student tag'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    livewire(EditStudentTag::class, ['record' => $systemUser->getRouteKey()])
+        ->fillForm(['name' => 'OTHER Student tag'])
+        ->call('save')
+        ->assertHasFormErrors(['name' => 'unique']);
+});

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/EditStudentTagTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/EditStudentTagTest.php
@@ -45,18 +45,43 @@ test('EditStudentTag does not allow for duplicate names of non-deleted student t
     asSuperAdmin();
 
     $deletedTag = Tag::factory(['name' => 'Student Tag', 'type' => TagType::Student])->create();
-    $systemUser = Tag::factory(['name' => 'Test Student Tag',  'type' => TagType::Student])->create();
+    $tag = Tag::factory(['name' => 'Test Student Tag',  'type' => TagType::Student])->create();
     Tag::factory(['name' => 'Other Student Tag',  'type' => TagType::Student])->create();
 
     $deletedTag->delete();
 
-    livewire(EditStudentTag::class, ['record' => $systemUser->getRouteKey()])
+    livewire(EditStudentTag::class, ['record' => $tag->getRouteKey()])
         ->fillForm(['name' => 'student tag'])
         ->call('save')
         ->assertHasNoFormErrors();
 
-    livewire(EditStudentTag::class, ['record' => $systemUser->getRouteKey()])
+    livewire(EditStudentTag::class, ['record' => $tag->getRouteKey()])
         ->fillForm(['name' => 'OTHER Student tag'])
         ->call('save')
         ->assertHasFormErrors(['name' => 'unique']);
+});
+
+test('EditStudentTag does allow for non-duplicate names of non-deleted student tags', function () {
+    asSuperAdmin();
+
+    $tag = Tag::factory(['name' => 'Student Tag 1', 'type' => TagType::Student])->create();
+    $deletedTag = Tag::factory(['name' => 'Student Tag 2', 'type' => TagType::Student])->create();
+    $deletedTag->delete();
+
+    livewire(EditStudentTag::class, ['record' => $tag->getRouteKey()])
+        ->fillForm(['name' => 'Student Tag 2'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+});
+
+test('EditStudentTag does allow for duplicate names of prospect tags', function () {
+    asSuperAdmin();
+
+    Tag::factory(['name' => 'Tag', 'type' => TagType::Prospect])->create();
+    $tag = Tag::factory(['name' => 'Student Tag', 'type' => TagType::Student])->create();
+
+    livewire(EditStudentTag::class, ['record' => $tag->getRouteKey()])
+        ->fillForm(['name' => 'Tag'])
+        ->call('save')
+        ->assertHasNoFormErrors();
 });

--- a/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/EditStudentTagTest.php
+++ b/app-modules/student-data-model/tests/Tenant/Filament/Resources/StudentTags/Pages/EditStudentTagTest.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use AdvisingApp\StudentDataModel\Filament\Resources\StudentTags\Pages\EditStudentTag;
 use App\Enums\TagType;
 use App\Models\Tag;

--- a/database/migrations/2026_09_02_135528_convert_tag_name_to_citext.php
+++ b/database/migrations/2026_09_02_135528_convert_tag_name_to_citext.php
@@ -50,14 +50,14 @@ return new class () extends Migration {
     protected string $column = 'name';
 
     /** @var array<int, string> */
-    protected array $groupByColumns = [];
+    protected array $groupByColumns = ['type'];
 
     // TODO: Cleanup Task TagCitextCleanup - remove $chunkSize and $usesSoftDeletes
     protected int $chunkSize = 500;
 
     protected bool $usesSoftDeletes = true;
 
-    private string $uniqueConstraint = 'tags_name_unique';
+    private string $uniqueConstraint = 'tags_name_type_unique';
 
     public function up(): void
     {

--- a/database/migrations/2026_09_02_135528_convert_tag_name_to_citext.php
+++ b/database/migrations/2026_09_02_135528_convert_tag_name_to_citext.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Database\Migrations\Concerns\FixesDuplicateNames;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Builder;

--- a/database/migrations/2026_09_02_135528_convert_tag_name_to_citext.php
+++ b/database/migrations/2026_09_02_135528_convert_tag_name_to_citext.php
@@ -1,0 +1,52 @@
+<?php
+
+use Database\Migrations\Concerns\FixesDuplicateNames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    // TODO: Cleanup Task TagCitextCleanup - remove FixesDuplicateNames trait & usages
+    use FixesDuplicateNames;
+
+    protected string $table = 'tags';
+
+    protected string $column = 'name';
+
+    /** @var array<int, string> */
+    protected array $groupByColumns = [];
+
+    // TODO: Cleanup Task TagCitextCleanup - remove $chunkSize and $usesSoftDeletes
+    protected int $chunkSize = 500;
+
+    protected bool $usesSoftDeletes = true;
+
+    private string $uniqueConstraint = 'tags_name_unique';
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            $this->fixDuplicates();
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->uniqueIndex([...$this->groupByColumns, $this->column], $this->uniqueConstraint)
+                    ->where(fn (Builder $condition) => $condition->whereNull('deleted_at'));
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUniqueIndex($this->uniqueConstraint);
+            });
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+        });
+    }
+};

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -42,6 +42,8 @@ use AdvisingApp\ResourceHub\Models\ResourceHubArticle;
 use AdvisingApp\ResourceHub\Models\ResourceHubCategory;
 use AdvisingApp\ResourceHub\Models\ResourceHubQuality;
 use AdvisingApp\ResourceHub\Models\ResourceHubStatus;
+use App\Enums\TagType;
+use App\Models\Tag;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -309,6 +311,35 @@ describe('resource hub citext change', function () {
                 expect($status1->refresh()->name)->toBe('Test Status');
                 expect($status2->refresh()->name)->toBe('Test Status-2');
                 expect($status3->refresh()->name)->toBe('Test Status-3');
+            }
+        );
+    });
+});
+
+// TODO: Cleanup Task TagCitextCleanup - Delete this describe and everything contained within
+describe('tag citext change', function () {
+    it('properly changes tag names', function () {
+        isolatedMigration(
+            '2026_09_02_135528_convert_tag_name_to_citext',
+            function () {
+                // Setup data before migration
+                $studentTag1 = Tag::factory(['name' => 'Student Tag', 'type' => TagType::Student])->create();
+                $prospectTag1 = Tag::factory(['name' => 'Prospect Tag', 'type' => TagType::Prospect])->create();
+                $studentTag2 = Tag::factory(['name' => 'Student Tag', 'type' => TagType::Student])->create();
+                $prospectTag2 = Tag::factory(['name' => 'Prospect Tag', 'type' => TagType::Prospect])->create();
+                $studentTag3 = Tag::factory(['name' => 'Student Tag', 'type' => TagType::Student])->create();
+                $prospectTag3 = Tag::factory(['name' => 'Prospect Tag', 'type' => TagType::Prospect])->create();
+                // Run the migration
+                $migrate = Artisan::call('migrate', ['--path' => 'database/migrations/2026_09_02_135528_convert_tag_name_to_citext.php']);
+                // Confirm migration ran successfully
+                expect($migrate)->toBe(Command::SUCCESS);
+                // Add any assertions to verify the migration's effects
+                expect($studentTag1->refresh()->name)->toBe('Student Tag');
+                expect($prospectTag1->refresh()->name)->toBe('Prospect Tag');
+                expect($studentTag2->refresh()->name)->toBe('Student Tag-2');
+                expect($prospectTag2->refresh()->name)->toBe('Prospect Tag-2');
+                expect($studentTag3->refresh()->name)->toBe('Student Tag-3');
+                expect($prospectTag3->refresh()->name)->toBe('Prospect Tag-3');
             }
         );
     });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2942

### Technical Description

Convert tag names to citext; migrate existing ones to be distinct

### Any deployment steps required?

No

### Cleanup Tasks

.cleanup-tasks/2026_09_02_convert_tag_name_to_citext.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
