### PR TITLE
[ADVAPP-2943]: Prevent duplicate team names

### DIFF
--- a/.cleanup-tasks/2026_09_02_convert_department_to_citext.md
+++ b/.cleanup-tasks/2026_09_02_convert_department_to_citext.md
@@ -1,0 +1,12 @@
+---
+title: Convert Department To Citext
+created: 2026-09-02
+---
+
+## Feature Flags
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+Search for `TODO: Cleanup Task DepartmentCitextCleanup`

--- a/app-modules/team/database/migrations/2026_09_02_151101_convert_teams_name_to_citext.php
+++ b/app-modules/team/database/migrations/2026_09_02_151101_convert_teams_name_to_citext.php
@@ -1,5 +1,39 @@
 <?php
 
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
 use Database\Migrations\Concerns\FixesDuplicateNames;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Builder;
@@ -48,7 +82,7 @@ return new class () extends Migration {
         DB::transaction(function () {
             Schema::table($this->table, function (Blueprint $table) {
                 $table->dropUniqueIndex($this->uniqueConstraint);
-                
+
                 $table->unique([...$this->groupByColumns, $this->column], $this->uniqueConstraint);
             });
 

--- a/app-modules/team/database/migrations/2026_09_02_151101_convert_teams_name_to_citext.php
+++ b/app-modules/team/database/migrations/2026_09_02_151101_convert_teams_name_to_citext.php
@@ -1,0 +1,58 @@
+<?php
+
+use Database\Migrations\Concerns\FixesDuplicateNames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    // TODO: Cleanup Task DepartmentCitextCleanup - remove FixesDuplicateNames trait & usages
+    use FixesDuplicateNames;
+
+    protected string $table = 'teams';
+
+    protected string $column = 'name';
+
+    /** @var array<int, string> */
+    protected array $groupByColumns = [];
+
+    // TODO: Cleanup Task DepartmentCitextCleanup - remove $chunkSize and $usesSoftDeletes
+    protected int $chunkSize = 500;
+
+    protected bool $usesSoftDeletes = true;
+
+    private string $uniqueConstraint = 'teams_name_unique';
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUnique($this->uniqueConstraint);
+            });
+
+            $this->fixDuplicates();
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->uniqueIndex([...$this->groupByColumns, $this->column], $this->uniqueConstraint)
+                    ->where(fn (Builder $condition) => $condition->whereNull('deleted_at'));
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUniqueIndex($this->uniqueConstraint);
+                
+                $table->unique([...$this->groupByColumns, $this->column], $this->uniqueConstraint);
+            });
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+        });
+    }
+};

--- a/app-modules/team/src/Filament/Resources/Departments/Pages/CreateDepartment.php
+++ b/app-modules/team/src/Filament/Resources/Departments/Pages/CreateDepartment.php
@@ -41,6 +41,7 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class CreateDepartment extends CreateRecord
 {
@@ -52,7 +53,11 @@ class CreateDepartment extends CreateRecord
             ->components([
                 TextInput::make('name')
                     ->required()
-                    ->string()
+                    ->unique(
+                        table: 'teams',
+                        column: 'name',
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    )
                     ->maxLength(255),
                 Textarea::make('description')
                     ->required()

--- a/app-modules/team/src/Filament/Resources/Departments/Pages/CreateDepartment.php
+++ b/app-modules/team/src/Filament/Resources/Departments/Pages/CreateDepartment.php
@@ -53,6 +53,7 @@ class CreateDepartment extends CreateRecord
             ->components([
                 TextInput::make('name')
                     ->required()
+                    ->string()
                     ->unique(
                         table: 'teams',
                         column: 'name',

--- a/app-modules/team/src/Filament/Resources/Departments/Pages/EditDepartment.php
+++ b/app-modules/team/src/Filament/Resources/Departments/Pages/EditDepartment.php
@@ -54,6 +54,7 @@ class EditDepartment extends EditRecord
             ->components([
                 TextInput::make('name')
                     ->required()
+                    ->string()
                     ->unique(
                         table: 'teams',
                         column: 'name',

--- a/app-modules/team/src/Filament/Resources/Departments/Pages/EditDepartment.php
+++ b/app-modules/team/src/Filament/Resources/Departments/Pages/EditDepartment.php
@@ -42,6 +42,7 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class EditDepartment extends EditRecord
 {
@@ -53,7 +54,12 @@ class EditDepartment extends EditRecord
             ->components([
                 TextInput::make('name')
                     ->required()
-                    ->string()
+                    ->unique(
+                        table: 'teams',
+                        column: 'name',
+                        ignoreRecord: true,
+                        modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                    )
                     ->maxLength(255),
                 Textarea::make('description')
                     ->required()

--- a/app-modules/team/tests/Tenant/Teams/CreateDepartmentTest.php
+++ b/app-modules/team/tests/Tenant/Teams/CreateDepartmentTest.php
@@ -81,8 +81,7 @@ test('CreateDepartment is gated with proper access control', function () {
 test('CreateDepartment does not allow for duplicate names of non-deleted departments case insensitively', function () {
     asSuperAdmin();
 
-    $department = Department::factory(['name' => 'department'])->create();
-    $department->delete();
+    Department::factory(['name' => 'department', 'deleted_at' => now()])->create();
 
     livewire(CreateDepartment::class)
         ->fillForm(['name' => 'Department', 'description' => 'test'])

--- a/app-modules/team/tests/Tenant/Teams/CreateDepartmentTest.php
+++ b/app-modules/team/tests/Tenant/Teams/CreateDepartmentTest.php
@@ -43,6 +43,7 @@ use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Livewire\livewire;
 use function PHPUnit\Framework\assertCount;
+use function Tests\asSuperAdmin;
 
 // Permission Tests
 
@@ -75,4 +76,21 @@ test('CreateDepartment is gated with proper access control', function () {
     assertCount(1, Department::all());
 
     assertDatabaseHas(Department::class, $request->only(['name', 'description']));
+});
+
+test('CreateDepartment does not allow for duplicate names of non-deleted departments case insensitively', function () {
+    asSuperAdmin();
+
+    $department = Department::factory(['name' => 'department'])->create();
+    $department->delete();
+
+    livewire(CreateDepartment::class)
+        ->fillForm(['name' => 'Department', 'description' => 'test'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    livewire(CreateDepartment::class)
+        ->fillForm(['name' => 'DEPARTMENT', 'description' => 'test'])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'unique']);
 });

--- a/app-modules/team/tests/Tenant/Teams/EditDepartmentTest.php
+++ b/app-modules/team/tests/Tenant/Teams/EditDepartmentTest.php
@@ -46,6 +46,7 @@ use Filament\Forms\Components\Select;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
+use function Tests\asSuperAdmin;
 
 // Permission Tests
 
@@ -210,4 +211,24 @@ test('the associate action in the department users relation manager is gated by 
         'ownerRecord' => $department,
         'pageClass' => ViewDepartment::class,
     ])->assertTableActionVisible(AssociateAction::class);
+});
+
+test('EditDepartment does not allow for duplicate names of non-deleted departments case insensitively', function () {
+    asSuperAdmin();
+
+    $deletedDepartment = Department::factory(['name' => 'Department'])->create();
+    $department = Department::factory(['name' => 'Test Department'])->create();
+    Department::factory(['name' => 'Other Department'])->create();
+
+    $deletedDepartment->delete();
+
+    livewire(EditDepartment::class, ['record' => $department->getRouteKey()])
+        ->fillForm(['name' => 'Department'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    livewire(EditDepartment::class, ['record' => $department->getRouteKey()])
+        ->fillForm(['name' => 'OTHER Department'])
+        ->call('save')
+        ->assertHasFormErrors(['name' => 'unique']);
 });

--- a/app-modules/team/tests/Tenant/Teams/EditDepartmentTest.php
+++ b/app-modules/team/tests/Tenant/Teams/EditDepartmentTest.php
@@ -216,11 +216,9 @@ test('the associate action in the department users relation manager is gated by 
 test('EditDepartment does not allow for duplicate names of non-deleted departments case insensitively', function () {
     asSuperAdmin();
 
-    $deletedDepartment = Department::factory(['name' => 'Department'])->create();
+    Department::factory(['name' => 'Department', 'deleted_at' => now()])->create();
     $department = Department::factory(['name' => 'Test Department'])->create();
     Department::factory(['name' => 'Other Department'])->create();
-
-    $deletedDepartment->delete();
 
     livewire(EditDepartment::class, ['record' => $department->getRouteKey()])
         ->fillForm(['name' => 'Department'])

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -42,6 +42,7 @@ use AdvisingApp\ResourceHub\Models\ResourceHubArticle;
 use AdvisingApp\ResourceHub\Models\ResourceHubCategory;
 use AdvisingApp\ResourceHub\Models\ResourceHubQuality;
 use AdvisingApp\ResourceHub\Models\ResourceHubStatus;
+use AdvisingApp\Team\Models\Department;
 use App\Enums\TagType;
 use App\Models\Tag;
 use Illuminate\Console\Command;
@@ -340,6 +341,29 @@ describe('tag citext change', function () {
                 expect($prospectTag2->refresh()->name)->toBe('Prospect Tag-2');
                 expect($studentTag3->refresh()->name)->toBe('Student Tag-3');
                 expect($prospectTag3->refresh()->name)->toBe('Prospect Tag-3');
+            }
+        );
+    });
+});
+
+// TODO: Cleanup Task DepartmentCitextCleanup - Delete this describe and everything contained within
+describe('department citext change', function () {
+    it('properly changes department names', function () {
+        isolatedMigration(
+            '2026_09_02_151101_convert_teams_name_to_citext',
+            function () {
+                // Setup data before migration
+                $department1 = Department::factory(['name' => 'Department'])->create();
+                $department2 = Department::factory(['name' => 'department'])->create();
+                $department3 = Department::factory(['name' => 'DEPARTMENT'])->create();
+                // Run the migration
+                $migrate = Artisan::call('migrate', ['--path' => 'app-modules/team/database/migrations/2026_09_02_151101_convert_teams_name_to_citext.php']);
+                // Confirm migration ran successfully
+                expect($migrate)->toBe(Command::SUCCESS);
+                // Add any assertions to verify the migration's effects
+                expect($department1->refresh()->name)->toBe('Department');
+                expect($department2->refresh()->name)->toBe('department-2');
+                expect($department3->refresh()->name)->toBe('DEPARTMENT-3');
             }
         );
     });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2943

### Technical Description

Convert department names to citext; migrate existing ones to be distinct

### Any deployment steps required?

No

### Cleanup Tasks

.cleanup-tasks/2026_09_02_convert_department_to_citext.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
