### PR TITLE
[ADVAPP-2936]: Prevent duplicate event titles

### DIFF
--- a/.cleanup-tasks/2026_09_02_rename_events_duplicate_title.md
+++ b/.cleanup-tasks/2026_09_02_rename_events_duplicate_title.md
@@ -1,0 +1,12 @@
+---
+title: Rename Events Duplicate Title
+created: 2026-09-02
+---
+
+## Feature Flags
+
+## Temporary Migrations
+
+## Additional Cleanup
+
+Search for `TODO: Cleanup Task EventCitextCleanup`

--- a/app-modules/meeting-center/database/migrations/2026_09_02_120000_convert_events_title_to_citext.php
+++ b/app-modules/meeting-center/database/migrations/2026_09_02_120000_convert_events_title_to_citext.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use Database\Migrations\Concerns\FixesDuplicateNames;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+use Tpetry\PostgresqlEnhanced\Schema\Blueprint;
+use Tpetry\PostgresqlEnhanced\Support\Facades\Schema;
+
+return new class () extends Migration {
+    // TODO: Cleanup Task EventCitextCleanup - remove FixesDuplicateNames trait & usages (if no other migration uses it, restore its trait.unused ignore annotation)
+    use FixesDuplicateNames;
+
+    protected string $table = 'events';
+
+    protected string $column = 'title';
+
+    /** @var array<int, string> */
+    protected array $groupByColumns = [];
+
+    // TODO: Cleanup Task EventCitextCleanup - remove $chunkSize and $usesSoftDeletes
+    protected int $chunkSize = 500;
+
+    protected bool $usesSoftDeletes = true;
+
+    private string $uniqueConstraint = 'events_title_unique';
+
+    public function up(): void
+    {
+        DB::transaction(function () {
+            // TODO: Cleanup Task EventCitextCleanup - remove the $this->fixDuplicates() call (the surrounding schema changes are permanent)
+            $this->fixDuplicates();
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE citext");
+
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->uniqueIndex([$this->column], $this->uniqueConstraint)
+                    ->where(fn (Builder $condition) => $condition->whereNull('deleted_at'));
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        DB::transaction(function () {
+            Schema::table($this->table, function (Blueprint $table) {
+                $table->dropUniqueIndex($this->uniqueConstraint);
+            });
+
+            DB::statement("ALTER TABLE {$this->table} ALTER COLUMN {$this->column} TYPE varchar(255)");
+        });
+    }
+};

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/Concerns/HasSharedEventFormConfiguration.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/Concerns/HasSharedEventFormConfiguration.php
@@ -59,6 +59,7 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Validation\Rules\Unique;
 
 trait HasSharedEventFormConfiguration
 {
@@ -67,7 +68,14 @@ trait HasSharedEventFormConfiguration
         return [
             TextInput::make('title')
                 ->string()
-                ->required(),
+                ->required()
+                ->maxLength(255)
+                ->unique(
+                    table: 'events',
+                    column: 'title',
+                    ignoreRecord: true,
+                    modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                ),
             TextInput::make('location')
                 ->string()
                 ->nullable(),

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventDetails.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/EditEventDetails.php
@@ -51,6 +51,7 @@ use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
+use Illuminate\Validation\Rules\Unique;
 
 class EditEventDetails extends EditRecord
 {
@@ -67,7 +68,13 @@ class EditEventDetails extends EditRecord
                         ->label('Title')
                         ->string()
                         ->required()
-                        ->maxLength(255),
+                        ->maxLength(255)
+                        ->unique(
+                            table: 'events',
+                            column: 'title',
+                            ignoreRecord: true,
+                            modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                        ),
                     TextInput::make('location')
                         ->label('Location')
                         ->string()

--- a/app-modules/meeting-center/src/Filament/Resources/Events/Pages/ListEvents.php
+++ b/app-modules/meeting-center/src/Filament/Resources/Events/Pages/ListEvents.php
@@ -53,6 +53,7 @@ use Filament\Tables\Filters\Filter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\Rules\Unique;
 use Livewire\Attributes\Url;
 
 class ListEvents extends ListRecords
@@ -115,7 +116,13 @@ class ListEvents extends ListRecords
                         return $schema->components([
                             TextInput::make('title')
                                 ->label('Title')
-                                ->required(),
+                                ->required()
+                                ->maxLength(255)
+                                ->unique(
+                                    table: 'events',
+                                    column: 'title',
+                                    modifyRuleUsing: fn (Unique $rule): Unique => $rule->withoutTrashed(),
+                                ),
                         ]);
                     })
                     ->beforeReplicaSaved(function (Model $replica, array $data): void {

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/EditEventDetailsTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/EditEventDetailsTest.php
@@ -96,5 +96,5 @@ it('allows updating an event to a title freed up by a soft-deleted event case-in
     livewire(EditEventDetails::class, ['record' => $event->getRouteKey()])
         ->fillForm(['title' => 'reusable title'])
         ->call('save')
-        ->assertHasNoFormErrors();
+        ->assertHasNoFormErrors(['title']);
 });

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/EditEventDetailsTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/EditEventDetailsTest.php
@@ -72,3 +72,29 @@ it('archive action archives the event and redirects to the index when the event 
 
     expect($event->fresh()->isArchived())->toBeTrue();
 });
+
+it('does not allow updating an event to a title matching another non-deleted event case-insensitively', function () {
+    asSuperAdmin();
+
+    Event::factory()->create(['title' => 'Other Event']);
+    $event = Event::factory()->create(['title' => 'Editable Event']);
+
+    livewire(EditEventDetails::class, ['record' => $event->getRouteKey()])
+        ->fillForm(['title' => 'other event'])
+        ->call('save')
+        ->assertHasFormErrors(['title' => 'unique']);
+});
+
+it('allows updating an event to a title freed up by a soft-deleted event case-insensitively', function () {
+    asSuperAdmin();
+
+    $deletedEvent = Event::factory()->create(['title' => 'Reusable Title']);
+    $deletedEvent->delete();
+
+    $event = Event::factory()->create(['title' => 'Editable Event']);
+
+    livewire(EditEventDetails::class, ['record' => $event->getRouteKey()])
+        ->fillForm(['title' => 'reusable title'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+});

--- a/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/ListEventsTest.php
+++ b/app-modules/meeting-center/tests/Tenant/Filament/Resources/Events/Pages/ListEventsTest.php
@@ -102,6 +102,36 @@ it('can duplicate a event its registration form its steps and its fields', funct
     expect($duplicatedEvent->eventRegistrationForm->steps->count())->toBe($event->eventRegistrationForm->steps->count());
 });
 
+it('does not allow duplicating an event to a title matching another non-deleted event case-insensitively', function () {
+    asSuperAdmin();
+
+    Event::factory()->create(['title' => 'Existing Event']);
+    $event = Event::factory()->create(['title' => 'Some Event']);
+
+    livewire(ListEvents::class)
+        ->assertStatus(200)
+        ->removeTableFilter('pastEvents')
+        ->callTableAction('Duplicate', $event, data: ['title' => 'existing event'])
+        ->assertHasTableActionErrors(['title' => 'unique']);
+});
+
+it('allows duplicating an event to a title freed up by a soft-deleted event', function () {
+    asSuperAdmin();
+
+    $deletedEvent = Event::factory()->create(['title' => 'Reusable Title']);
+    $deletedEvent->delete();
+
+    $event = Event::factory()->create(['title' => 'Some Event']);
+
+    livewire(ListEvents::class)
+        ->assertStatus(200)
+        ->removeTableFilter('pastEvents')
+        ->callTableAction('Duplicate', $event, data: ['title' => 'reusable title'])
+        ->assertHasNoTableActionErrors();
+
+    expect(Event::query()->where('title', 'reusable title')->exists())->toBeTrue();
+});
+
 it('will not duplicate event registration form submissions if they exist', function () {
     asSuperAdmin();
 

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -174,8 +174,10 @@ describe('event title citext change', function () {
                 $event2 = Event::factory()->create(['title' => 'event Title', 'created_at' => now()->subMinutes(2)]);
                 $event3 = Event::factory()->create(['title' => 'event title', 'created_at' => now()->subMinutes(1)]);
 
-                // A soft-deleted event sharing a title must be ignored by de-duplication
-                $deletedEvent = Event::factory()->create(['title' => 'Deleted event']);
+                // A soft-deleted event sharing a title with the live duplicate group must be
+                // ignored by de-duplication: it should neither affect the live renumbering
+                // nor get renamed itself.
+                $deletedEvent = Event::factory()->create(['title' => 'event title', 'created_at' => now()->subMinutes(4)]);
                 $deletedEvent->delete();
 
                 // Run the migration
@@ -188,7 +190,8 @@ describe('event title citext change', function () {
                 expect($event1->refresh()->title)->toBe('Event title');
                 expect($event2->refresh()->title)->toBe('event Title-2');
                 expect($event3->refresh()->title)->toBe('event title-3');
-                expect($deletedEvent->refresh()->title)->toBe('Deleted event');
+                // Untouched: excluded from the live dedup group entirely, despite the title collision
+                expect($deletedEvent->refresh()->title)->toBe('event title');
             }
         );
     });

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -170,9 +170,11 @@ describe('event title citext change', function () {
             '2026_09_02_120000_convert_events_title_to_citext',
             function () {
                 // Setup data before migration
-                $event1 = Event::factory()->create(['title' => 'Event title']);
-                $event2 = Event::factory()->create(['title' => 'event Title']);
-                $event3 = Event::factory()->create(['title' => 'event title']);
+
+                $event1 = Event::factory()->create(['title' => 'Event title', 'created_at' => now()->subMinutes(3)]);
+                $event2 = Event::factory()->create(['title' => 'event Title', 'created_at' => now()->subMinutes(2)]);
+                $event3 = Event::factory()->create(['title' => 'event title', 'created_at' => now()->subMinutes(1)]);
+
 
                 // A soft-deleted event sharing a title must be ignored by de-duplication
                 $deletedEvent = Event::factory()->create(['title' => 'Deleted event']);

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -174,7 +174,6 @@ describe('event title citext change', function () {
                 $event2 = Event::factory()->create(['title' => 'event Title', 'created_at' => now()->subMinutes(2)]);
                 $event3 = Event::factory()->create(['title' => 'event title', 'created_at' => now()->subMinutes(1)]);
 
-
                 // A soft-deleted event sharing a title must be ignored by de-duplication
                 $deletedEvent = Event::factory()->create(['title' => 'Deleted event']);
                 $deletedEvent->delete();

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -162,7 +162,6 @@ describe('survey name citext change', function () {
     });
 });
 
-
 // TODO: Cleanup Task EventCitextCleanup - Delete this describe and everything contained within
 describe('event title citext change', function () {
     it('renames case-insensitive duplicate event titles', function () {

--- a/tests/TenantMigrationTests.php
+++ b/tests/TenantMigrationTests.php
@@ -36,6 +36,7 @@
 
 use AdvisingApp\Campaign\Models\CampaignAction;
 use AdvisingApp\Engagement\Models\Engagement;
+use AdvisingApp\MeetingCenter\Models\Event;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -127,4 +128,35 @@ test('2026_04_08_145038_rename_campaign_action_id_to_source_morph_on_engagements
             expect($withoutSource->source_type)->toBeNull(); /** @phpstan-ignore-line */
         }
     );
+});
+
+// TODO: Cleanup Task EventCitextCleanup - Delete this describe and everything contained within
+describe('event title citext change', function () {
+    it('renames case-insensitive duplicate event titles', function () {
+        isolatedMigration(
+            '2026_09_02_120000_convert_events_title_to_citext',
+            function () {
+                // Setup data before migration
+                $event1 = Event::factory()->create(['title' => 'Event title']);
+                $event2 = Event::factory()->create(['title' => 'event Title']);
+                $event3 = Event::factory()->create(['title' => 'event title']);
+
+                // A soft-deleted event sharing a title must be ignored by de-duplication
+                $deletedEvent = Event::factory()->create(['title' => 'Deleted event']);
+                $deletedEvent->delete();
+
+                // Run the migration
+                $migrate = Artisan::call('migrate', ['--path' => 'app-modules/meeting-center/database/migrations/2026_09_02_120000_convert_events_title_to_citext.php']);
+
+                // Confirm migration ran successfully
+                expect($migrate)->toBe(Command::SUCCESS);
+
+                // Add any assertions to verify the migration's effects
+                expect($event1->refresh()->title)->toBe('Event title');
+                expect($event2->refresh()->title)->toBe('event Title-2');
+                expect($event3->refresh()->title)->toBe('event title-3');
+                expect($deletedEvent->refresh()->title)->toBe('Deleted event');
+            }
+        );
+    });
 });


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2936

### Technical Description

- Implement unique title validation for events and add migration for case-insensitive title handling

### Any deployment steps required?

No

### Cleanup Tasks

- Cleanup Task File: .cleanup-tasks/2026_09_02_rename_events_duplicate_title.md

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
