### PR TITLE
[Chore]: Fix docs links and guide references

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,9 @@ Microsoft Azure
 
 ### Documentation
 
-- [Inbound-Webhooks](./docs/inbound-webhooks.md)
-- [Local Setup](./docs/local-setup.md)
-- [Roles and Permissions](./docs/roles-and-permissions.md)
-- [Inbound Webhooks](./docs/inbound-webhooks.md)
-- [Integrations: Twilio](./docs/integrations/twilio.md)
-- [Integrations: Azure OpenAI](./docs/integrations/azure_open_ai.md)
-- [Custom Metadata](./docs/custom-metadata.md)
+- [Local Setup](./docs/how-tos/local-setup.md)
+- [Integrations: Azure OpenAI](./docs/how-tos/integrations/azure_open_ai.md)
+- [Custom Metadata](./docs/explanations/custom-metadata.md)
 
 _Note: More documentation coming soon._
 

--- a/docs/how-tos/local-setup.md
+++ b/docs/how-tos/local-setup.md
@@ -56,7 +56,7 @@ Going forward this document will make reference to the `pls` command.
 
 The `pls` command is a custom-made script that acts as a tool to run our sometimes complex `docker compose` and other
 related commands. For installation and usage details, see the
-[pls installation guide](common/pls.md).
+[pls installation guide](https://github.com/canyongbs/common/blob/main/docs/how-tos/pls.md).
 This documentation will assume you have installed `pls` and it is available in your shell.
 
 #### 1. Initial setup

--- a/docs/how-tos/local-setup.md
+++ b/docs/how-tos/local-setup.md
@@ -176,7 +176,7 @@ of the box as long as `pls` is installed correctly. The configured command runs 
 
 - `${userHome}` is resolved by VS Code, so the absolute path to `pls` works on both macOS and Linux.
 - `pls` must be installed at the default location (`~/.pls/bin/pls`) — see the
-  [pls installation guide](common/pls.md).
+  [pls installation guide](https://github.com/canyongbs/common/blob/main/docs/how-tos/pls.md).
 - The `app` container must be running (`pls up -d`), since Boost executes inside it.
 
 #### Verifying it is running in VS Code


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- N/A

### Technical Description

This pull request updates the documentation structure and improves links to better organize and clarify the project's documentation resources. The primary focus is on reorganizing documentation files and updating references to point to the correct locations.

Documentation restructuring:

* Updated the `README.md` to reorganize documentation links, moving several guides to new locations under `how-tos` and `explanations` directories for improved clarity and structure.

Documentation link updates:

* Changed the link to the `pls` installation guide in `docs/how-tos/local-setup.md` to point to the canonical location in the `common` repository, ensuring users are directed to the most up-to-date instructions.

This directly resolves issues brought up in https://github.com/canyongbs/advisingapp/issues/2759

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
