### PR TITLE
[ADVAPP-2902]: Some users have experienced being able to perform actions that were supposed to be blocked as a super admin

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -38,10 +38,10 @@ namespace App\Providers;
 
 use App\Enums\Feature;
 use App\Models\Authenticatable;
-use App\Support\FeatureAccessResponse;
-use Illuminate\Auth\Access\Response;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
+use Spatie\Permission\Guard;
+use Spatie\Permission\PermissionRegistrar;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -59,14 +59,16 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        Gate::after(
-            function (Authenticatable $authenticatable, string $ability, bool|null|Response $result, mixed $arguments) {
-                return (
-                    (! $result instanceof FeatureAccessResponse)
-                    && ($authenticatable->isSuperAdmin() || $authenticatable->isPartnerAdmin())
-                )
-                    ? true
-                    : $result;
+        Gate::before(
+            function (Authenticatable $authenticatable, string $ability): ?bool {
+                if (! ($authenticatable->isSuperAdmin() || $authenticatable->isPartnerAdmin())) {
+                    return null;
+                }
+
+                return app(PermissionRegistrar::class)->getPermissions([
+                    'name' => $ability,
+                    'guard_name' => Guard::getDefaultName($authenticatable),
+                ], onlyOne: true)->isNotEmpty() ?: null;
             }
         );
 


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2902

### Technical Description

Only allow gate bypass if the check is for a permission string that exists in the app, else fall through to the policy. I have checked and couldn't find any policies in the app that would have a problem with this, as they all use permission checks or direct super admin checks. If a policy method in the future doesn't need a permission for normal users but super admin users are allowed, we can just check inside the policy if the user is a super admin and allow them.

### Any deployment steps required?

No

### Cleanup Tasks

N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
