### PR TITLE
[ADVAPP-2955]: Correctly process forwarded inbound emails so they create engagement responses

### DIFF
--- a/app-modules/engagement/src/Console/Commands/RetryFailedSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Console/Commands/RetryFailedSesS3InboundEmail.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+namespace AdvisingApp\Engagement\Console\Commands;
+
+use AdvisingApp\Engagement\Jobs\ProcessSesS3InboundEmail;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class RetryFailedSesS3InboundEmail extends Command
+{
+    protected $signature = 'engagement:retry-failed-inbound-email {path : Path to the failed inbound email on the s3-inbound-email disk (e.g. failed/<id>)}';
+
+    protected $description = 'Move a failed inbound email back out of the failed folder and queue it for reprocessing';
+
+    public function handle(): int
+    {
+        $path = $this->normalizePath((string) $this->argument('path'));
+
+        $disk = Storage::disk('s3-inbound-email');
+
+        if (! $disk->exists($path)) {
+            $this->error("File not found on the s3-inbound-email disk: {$path}");
+
+            return static::FAILURE;
+        }
+
+        // Move the file back to the disk root (its original pending location) so that a re-failure
+        // lands at `failed/<id>` rather than nesting under `failed/failed/<id>`, and so the queued
+        // job shares the same unique id the scheduled gatherer would use — letting the job's
+        // ShouldBeUnique lock dedupe the two and prevent double-processing.
+        $originalPath = Str::startsWith($path, 'failed/') ? Str::after($path, 'failed/') : $path;
+
+        if ($originalPath !== $path) {
+            $disk->move($path, $originalPath);
+        }
+
+        // Queued (not run synchronously) so the ShouldBeUnique lock applies. The job may still
+        // instantly re-fail and land back in `failed/`, so this only reports that it was queued.
+        dispatch(new ProcessSesS3InboundEmail($originalPath));
+
+        $this->info("Queued inbound email for reprocessing: {$originalPath}");
+
+        return static::SUCCESS;
+    }
+
+    protected function normalizePath(string $path): string
+    {
+        $path = trim($path);
+
+        // Reduce an s3://<bucket>/<key> URI down to just the object key.
+        if (Str::startsWith($path, 's3://')) {
+            $path = Str::after(Str::after($path, 's3://'), '/');
+        }
+
+        $path = ltrim($path, '/');
+
+        // Strip the disk root prefix when a full object key was provided.
+        $root = trim(Config::string('filesystems.disks.s3-inbound-email.root'), '/');
+
+        if ($root !== '' && Str::startsWith($path, "{$root}/")) {
+            $path = Str::after($path, "{$root}/");
+        }
+
+        return $path;
+    }
+}

--- a/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
+++ b/app-modules/engagement/src/Jobs/ProcessSesS3InboundEmail.php
@@ -52,6 +52,7 @@ use Aws\S3\S3Client;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use PhpMimeMailParser\Attachment;
@@ -91,8 +92,7 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                 new SesS3InboundSpamOrVirusDetected($this->emailFilePath, $parser->getHeader('X-SES-Spam-Verdict'), $parser->getHeader('X-SES-Virus-Verdict')),
             );
 
-            $matchedTenants = collect($parser->getAddresses('to'))
-                ->pluck('address')
+            $matchedTenants = $this->recipientCandidates($parser)
                 ->map(function (string $address) {
                     $localPart = filter_var($address, FILTER_VALIDATE_EMAIL) ? explode('@', $address)[0] : null;
 
@@ -108,7 +108,9 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
                         )
                         ->first();
                 })
-                ->filter();
+                ->filter()
+                ->unique(fn (Tenant $tenant): string => (string) $tenant->getKey())
+                ->values();
 
             throw_if(
                 $matchedTenants->isEmpty(),
@@ -308,6 +310,61 @@ class ProcessSesS3InboundEmail implements ShouldQueue, ShouldBeUnique, NotTenant
     protected function moveFile(string $destination): void
     {
         Storage::disk('s3-inbound-email')->move($this->emailFilePath, $destination . '/' . $this->emailFilePath);
+    }
+
+    /**
+     * Build the list of candidate recipient addresses to route on.
+     *
+     * The MIME `To:` header is unreliable for forwarded mail (forward-only forwarding leaves the
+     * original mailbox in `To:`), so the SES envelope recipient from the trusted `Received … for …`
+     * header it stamps on delivery is included as well.
+     *
+     * @return Collection<int, string>
+     */
+    protected function recipientCandidates(Parser $parser): Collection
+    {
+        $candidates = collect($parser->getAddresses('to'))
+            ->pluck('address');
+
+        $sesRecipient = $this->extractSesDeliveryRecipient($parser);
+
+        if ($sesRecipient !== null) {
+            $candidates->push($sesRecipient);
+        }
+
+        return $candidates
+            ->filter(fn (string $address): bool => trim($address) !== '')
+            ->map(fn (string $address): string => trim($address))
+            ->unique(fn (string $address): string => mb_strtolower($address))
+            ->values();
+    }
+
+    /**
+     * Extract the envelope recipient SES delivered to from the
+     * `Received … by inbound-smtp.<region>.amazonaws.com … for <addr>;` header.
+     */
+    protected function extractSesDeliveryRecipient(Parser $parser): ?string
+    {
+        $rawHeaders = str_replace("\r\n", "\n", $parser->getHeadersRaw());
+
+        // Unfold folded header lines (continuation lines begin with whitespace) so each header is a single line.
+        $unfolded = preg_replace('/\n[ \t]+/', ' ', $rawHeaders) ?? $rawHeaders;
+
+        foreach (preg_split('/\n(?=\S)/', $unfolded) ?: [] as $header) {
+            if (! str_starts_with(mb_strtolower($header), 'received:')) {
+                continue;
+            }
+
+            if (! preg_match('/by\s+inbound-smtp\.[^\s]*\bamazonaws\.com\b/i', $header)) {
+                continue;
+            }
+
+            if (preg_match('/\bfor\s+<?([^\s;<>]+@[^\s;<>]+)>?\s*;/i', $header, $matches)) {
+                return $matches[1];
+            }
+        }
+
+        return null;
     }
 
     protected function getContent(): string

--- a/app-modules/engagement/tests/Fixtures/s3_email_forward_only
+++ b/app-modules/engagement/tests/Fixtures/s3_email_forward_only
@@ -1,0 +1,19 @@
+Return-Path: <mbchildress@campbellsville.edu>
+Received: from pdx1-sub0-mail-mx201.dreamhost.com (fltr-in2.mail.dreamhost.com [64.90.62.164])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 2v0ukgo33s1n1lm9a32oap3opclbc3viorqmcm01
+ for test@mail-dev.advising.app;
+ Thu, 10 Sep 2026 23:58:33 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received: from SN4PR0501CU005.outbound.protection.outlook.com (mail-southcentralusazon11021101.outbound.protection.outlook.com [40.93.194.101])
+	by pdx1-sub0-mail-mx201.dreamhost.com (Postfix) with ESMTPS id 4hTSY43CSdz8DBN
+	for <support@campusconcourse.com>; Thu, 10 Sep 2026 16:58:32 -0700 (PDT)
+From: "Ullyott, Kevin" <kevin.ullyott@canyongbs.com>
+To: "support@campusconcourse.com" <support@campusconcourse.com>
+Subject: This is a test
+Date: Thu, 10 Sep 2026 23:58:27 +0000
+Message-ID: <DS7PR07MB774971A63DCEC64D32538E76C3A02@DS7PR07MB7749.namprd07.prod.outlook.com>
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+
+Hello there! This should be put in S3!

--- a/app-modules/engagement/tests/Fixtures/s3_email_forward_same_local_part
+++ b/app-modules/engagement/tests/Fixtures/s3_email_forward_same_local_part
@@ -1,0 +1,19 @@
+Return-Path: <kevin.ullyott@canyongbs.com>
+Received: from pdx1-sub0-mail-mx201.dreamhost.com (fltr-in2.mail.dreamhost.com [64.90.62.164])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 7k2pfnr44t2o2mn0b43pbq4pqdmcd4wjpsrndn12
+ for test@mail-dev.advising.app;
+ Thu, 10 Sep 2026 23:58:33 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received: from SN4PR0501CU005.outbound.protection.outlook.com (mail-southcentralusazon11021101.outbound.protection.outlook.com [40.93.194.101])
+	by pdx1-sub0-mail-mx201.dreamhost.com (Postfix) with ESMTPS id 5jUTZ54DTez9ECO
+	for <test@oldschool.edu>; Thu, 10 Sep 2026 16:58:32 -0700 (PDT)
+From: "Ullyott, Kevin" <kevin.ullyott@canyongbs.com>
+To: "test@oldschool.edu" <test@oldschool.edu>
+Subject: Forwarded with a matching local part
+Date: Thu, 10 Sep 2026 23:58:27 +0000
+Message-ID: <DS7PR07MB774971A63DCEC64D32538E76C3A03@DS7PR07MB7749.namprd07.prod.outlook.com>
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+
+Hello there! This should be put in S3!

--- a/app-modules/engagement/tests/Landlord/Feature/Console/Commands/RetryFailedSesS3InboundEmailTest.php
+++ b/app-modules/engagement/tests/Landlord/Feature/Console/Commands/RetryFailedSesS3InboundEmailTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+<COPYRIGHT>
+
+    Copyright © 2016-2026, Canyon GBS Inc. All rights reserved.
+
+    Advising App® is licensed under the Elastic License 2.0. For more details,
+    see https://github.com/canyongbs/advisingapp/blob/main/LICENSE.
+
+    Notice:
+
+    - You may not provide the software to third parties as a hosted or managed
+      service, where the service provides users with access to any substantial set of
+      the features or functionality of the software.
+    - You may not move, change, disable, or circumvent the license key functionality
+      in the software, and you may not remove or obscure any functionality in the
+      software that is protected by the license key.
+    - You may not alter, remove, or obscure any licensing, copyright, or other notices
+      of the licensor in the software. Any use of the licensor’s trademarks is subject
+      to applicable law.
+    - Canyon GBS Inc. respects the intellectual property rights of others and expects the
+      same in return. Canyon GBS® and Advising App® are registered trademarks of
+      Canyon GBS Inc., and we are committed to enforcing and protecting our trademarks
+      vigorously.
+    - The software solution, including services, infrastructure, and code, is offered as a
+      Software as a Service (SaaS) by Canyon GBS Inc.
+    - Use of this software implies agreement to the license terms and conditions as stated
+      in the Elastic License 2.0.
+
+    For more information or inquiries please visit our website at
+    https://www.canyongbs.com or contact us via email at legal@canyongbs.com.
+
+</COPYRIGHT>
+*/
+
+use AdvisingApp\Engagement\Jobs\ProcessSesS3InboundEmail;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
+
+use function Pest\Laravel\artisan;
+
+it('moves a failed inbound email back out of the failed folder and queues it for reprocessing from its original path', function () {
+    Bus::fake();
+
+    $filesystem = Storage::fake('s3-inbound-email');
+
+    $filesystem->putFileAs('failed', UploadedFile::fake()->createWithContent('s3_email', 'raw'), 's3_email');
+
+    $filesystem->assertExists('failed/s3_email');
+
+    artisan('engagement:retry-failed-inbound-email', ['path' => 'failed/s3_email'])
+        ->assertSuccessful();
+
+    $filesystem->assertExists('s3_email');
+    $filesystem->assertMissing('failed/s3_email');
+
+    Bus::assertDispatched(
+        ProcessSesS3InboundEmail::class,
+        // @phpstan-ignore-next-line
+        fn (ProcessSesS3InboundEmail $job): bool => invade($job)->emailFilePath === 's3_email',
+    );
+});
+
+it('normalizes a full s3 object key including the disk root and a leading slash', function () {
+    Bus::fake();
+
+    config()->set('filesystems.disks.s3-inbound-email.root', 'some-root/inbound-email');
+
+    $filesystem = Storage::fake('s3-inbound-email');
+
+    $filesystem->putFileAs('failed', UploadedFile::fake()->createWithContent('s3_email', 'raw'), 's3_email');
+
+    artisan('engagement:retry-failed-inbound-email', ['path' => 's3://some-bucket/some-root/inbound-email/failed/s3_email'])
+        ->assertSuccessful();
+
+    $filesystem->assertExists('s3_email');
+    $filesystem->assertMissing('failed/s3_email');
+
+    Bus::assertDispatched(
+        ProcessSesS3InboundEmail::class,
+        // @phpstan-ignore-next-line
+        fn (ProcessSesS3InboundEmail $job): bool => invade($job)->emailFilePath === 's3_email',
+    );
+});
+
+it('fails and dispatches nothing when the file does not exist', function () {
+    Bus::fake();
+
+    Storage::fake('s3-inbound-email');
+
+    artisan('engagement:retry-failed-inbound-email', ['path' => 'failed/missing'])
+        ->assertFailed();
+
+    Bus::assertNothingDispatched();
+});

--- a/app-modules/engagement/tests/Tenant/Feature/Jobs/ProcessSesS3InboundEmailTest.php
+++ b/app-modules/engagement/tests/Tenant/Feature/Jobs/ProcessSesS3InboundEmailTest.php
@@ -55,6 +55,8 @@ use function Pest\Laravel\assertDatabaseCount;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Laravel\partialMock;
 
+use PhpMimeMailParser\Parser;
+
 it('handles spam verdict failure properly', function () {
     Storage::fake('s3');
     Storage::fake('s3-inbound-email');
@@ -201,6 +203,128 @@ it('properly creates an EngagementResponse for an inbound email matching a Stude
 
     $filesystem->assertMissing('s3_email');
 });
+
+it('routes forward-only mail on the SES delivery recipient when the To header is the original mailbox', function () {
+    $student = Student::factory()->create();
+
+    StudentEmailAddress::factory()
+        ->for($student, 'student')
+        ->create(['address' => 'kevin.ullyott@canyongbs.com']);
+
+    Storage::fake('s3');
+    $filesystem = Storage::fake('s3-inbound-email');
+
+    $modulePath = resolve(ModulePath::class);
+
+    $content = file_get_contents($modulePath('engagement', 'tests/Fixtures/s3_email_forward_only'));
+
+    $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+    $filesystem->putFileAs('', $file, 's3_email');
+
+    $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+        $mock->shouldAllowMockingProtectedMethods();
+        // @phpstan-ignore-next-line
+        $mock->shouldReceive('getContent')->once()->andReturn($content);
+    });
+
+    assert($mock instanceof ProcessSesS3InboundEmail);
+
+    // @phpstan-ignore-next-line
+    invade($mock)->emailFilePath = 's3_email';
+
+    $filesystem->assertExists('s3_email');
+
+    $mock->handle();
+
+    $engagementResponses = EngagementResponse::all();
+
+    expect($engagementResponses)->toHaveCount(1);
+
+    $engagementResponse = $engagementResponses->first();
+
+    assert($engagementResponse instanceof EngagementResponse);
+
+    expect($engagementResponse->subject)->toBe('This is a test')
+        ->and($engagementResponse->sender->is($student))->toBeTrue()
+        ->and($engagementResponse->type)->toBe(EngagementResponseType::Email)
+        ->and($engagementResponse->status)->toBe(EngagementResponseStatus::New)
+        ->and($engagementResponse->raw)->toBe($content)
+        ->and($engagementResponse->raw)->toContain('Hello there! This should be put in S3!');
+
+    $filesystem->assertMissing('s3_email');
+});
+
+it('does not create duplicate EngagementResponses when the To header and the SES delivery recipient both resolve to the tenant', function () {
+    $student = Student::factory()->create();
+
+    StudentEmailAddress::factory()
+        ->for($student, 'student')
+        ->create(['address' => 'kevin.ullyott@canyongbs.com']);
+
+    Storage::fake('s3');
+    $filesystem = Storage::fake('s3-inbound-email');
+
+    $modulePath = resolve(ModulePath::class);
+
+    $content = file_get_contents($modulePath('engagement', 'tests/Fixtures/s3_email'));
+
+    $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+    $filesystem->putFileAs('', $file, 's3_email');
+
+    $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+        $mock->shouldAllowMockingProtectedMethods();
+        // @phpstan-ignore-next-line
+        $mock->shouldReceive('getContent')->once()->andReturn($content);
+    });
+
+    assert($mock instanceof ProcessSesS3InboundEmail);
+
+    // @phpstan-ignore-next-line
+    invade($mock)->emailFilePath = 's3_email';
+
+    $mock->handle();
+
+    $engagementResponses = EngagementResponse::all();
+
+    expect($engagementResponses)->toHaveCount(1);
+
+    $engagementResponse = $engagementResponses->first();
+
+    assert($engagementResponse instanceof EngagementResponse);
+
+    expect($engagementResponse->sender->is($student))->toBeTrue()
+        ->and($engagementResponse->raw)->toBe($content);
+
+    $filesystem->assertMissing('s3_email');
+});
+
+it('extracts the SES delivery recipient from the Received header', function (string $rawHeaders, ?string $expected) {
+    $parser = (new Parser())->setText($rawHeaders . "\r\n\r\nbody");
+
+    $job = new ProcessSesS3InboundEmail('s3_email');
+
+    // @phpstan-ignore-next-line
+    expect(invade($job)->extractSesDeliveryRecipient($parser))->toBe($expected);
+})->with([
+    'folded header' => [
+        "Received: from mail.example.com (mail.example.com [10.0.0.1])\r\n by inbound-smtp.us-west-2.amazonaws.com with SMTP id abc123\r\n for test@mail-dev.advising.app;\r\n Thu, 20 Feb 2025 20:25:41 +0000 (UTC)\r\nFrom: sender@example.com\r\nTo: support@campusconcourse.com",
+        'test@mail-dev.advising.app',
+    ],
+    'mixed case and angle brackets' => [
+        "RECEIVED: from mail.example.com BY Inbound-SMTP.eu-west-1.AmazonAWS.com with SMTP id abc123 FOR <Test@mail-dev.advising.app>; Thu, 20 Feb 2025 20:25:41 +0000 (UTC)\r\nTo: support@campusconcourse.com",
+        'Test@mail-dev.advising.app',
+    ],
+    'ignores non-SES hops' => [
+        "Received: from a.example.com by b.example.com with SMTP id abc123 for other@example.com; Thu, 20 Feb 2025 20:25:41 +0000 (UTC)\r\nReceived: from mail.example.com by inbound-smtp.us-west-2.amazonaws.com with SMTP id abc123 for test@mail-dev.advising.app; Thu, 20 Feb 2025 20:25:41 +0000 (UTC)\r\nTo: support@campusconcourse.com",
+        'test@mail-dev.advising.app',
+    ],
+    'no SES hop' => [
+        "Received: from a.example.com by b.example.com with SMTP id abc123 for other@example.com; Thu, 20 Feb 2025 20:25:41 +0000 (UTC)\r\nTo: support@campusconcourse.com",
+        null,
+    ],
+]);
 
 it('properly creates an EngagementResponse for an inbound email matching a Prospect', function () {
     Storage::fake('s3');

--- a/app-modules/engagement/tests/Tenant/Feature/Jobs/ProcessSesS3InboundEmailTest.php
+++ b/app-modules/engagement/tests/Tenant/Feature/Jobs/ProcessSesS3InboundEmailTest.php
@@ -255,7 +255,7 @@ it('routes forward-only mail on the SES delivery recipient when the To header is
     $filesystem->assertMissing('s3_email');
 });
 
-it('does not create duplicate EngagementResponses when the To header and the SES delivery recipient both resolve to the tenant', function () {
+it('does not create duplicate EngagementResponses when the To header and the SES delivery recipient are the same address', function () {
     $student = Student::factory()->create();
 
     StudentEmailAddress::factory()
@@ -295,6 +295,52 @@ it('does not create duplicate EngagementResponses when the To header and the SES
     assert($engagementResponse instanceof EngagementResponse);
 
     expect($engagementResponse->sender->is($student))->toBeTrue()
+        ->and($engagementResponse->raw)->toBe($content);
+
+    $filesystem->assertMissing('s3_email');
+});
+
+it('does not create duplicate EngagementResponses when forwarding preserves the local part across domains', function () {
+    $student = Student::factory()->create();
+
+    StudentEmailAddress::factory()
+        ->for($student, 'student')
+        ->create(['address' => 'kevin.ullyott@canyongbs.com']);
+
+    Storage::fake('s3');
+    $filesystem = Storage::fake('s3-inbound-email');
+
+    $modulePath = resolve(ModulePath::class);
+
+    $content = file_get_contents($modulePath('engagement', 'tests/Fixtures/s3_email_forward_same_local_part'));
+
+    $file = UploadedFile::fake()->createWithContent('s3_email', $content);
+
+    $filesystem->putFileAs('', $file, 's3_email');
+
+    $mock = partialMock(ProcessSesS3InboundEmail::class, function (MockInterface $mock) use ($content) {
+        $mock->shouldAllowMockingProtectedMethods();
+        // @phpstan-ignore-next-line
+        $mock->shouldReceive('getContent')->once()->andReturn($content);
+    });
+
+    assert($mock instanceof ProcessSesS3InboundEmail);
+
+    // @phpstan-ignore-next-line
+    invade($mock)->emailFilePath = 's3_email';
+
+    $mock->handle();
+
+    $engagementResponses = EngagementResponse::all();
+
+    expect($engagementResponses)->toHaveCount(1);
+
+    $engagementResponse = $engagementResponses->first();
+
+    assert($engagementResponse instanceof EngagementResponse);
+
+    expect($engagementResponse->subject)->toBe('Forwarded with a matching local part')
+        ->and($engagementResponse->sender->is($student))->toBeTrue()
         ->and($engagementResponse->raw)->toBe($content);
 
     $filesystem->assertMissing('s3_email');


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2955

### Technical Description

> Fixes an issue where system forwarded emails to Advising App are not correctly routed to the right Tenant and do not create an engagement response. For forward-only forwarded mail the `To:` header still contains the original mailbox, so tenant detection now also uses the SES envelope recipient from the `Received … for …` header.

> Also adds an `engagement:retry-failed-inbound-email` command to be able to retry the processing of an inbound email sitting in the `failed/` folder. The command moves the file back to the disk root and queues the job, so its unique lock prevents double-processing against the scheduled gatherer.

### Any deployment steps required?

> No

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
