### PR TITLE
[ADVAPP-2961]: Service request / portal forms fail to load when they contain an empty heading or column

### DIFF
--- a/app-modules/form/src/Actions/GenerateFormKitSchema.php
+++ b/app-modules/form/src/Actions/GenerateFormKitSchema.php
@@ -82,8 +82,8 @@ class GenerateFormKitSchema
             fn (array $component): array | string => match ($component['type'] ?? null) {
                 'bulletList' => ['$el' => 'ul', 'children' => $this->content($blocks, $component['content'] ?? [], $submissible, $fields)],
                 'grid' => $this->grid($blocks, $component, $fields, $submissible),
-                'gridColumn' => ['$el' => 'div', 'children' => $this->content($blocks, $component['content'], $submissible, $fields), 'attrs' => ['class' => ['grid-col' => true]]],
-                'heading' => ['$el' => "h{$component['attrs']['level']}", 'children' => $this->content($blocks, $component['content'], $submissible, $fields)],
+                'gridColumn' => ['$el' => 'div', 'children' => $this->content($blocks, $component['content'] ?? [], $submissible, $fields), 'attrs' => ['class' => ['grid-col' => true]]],
+                'heading' => ['$el' => "h{$component['attrs']['level']}", 'children' => $this->content($blocks, $component['content'] ?? [], $submissible, $fields)],
                 'horizontalRule' => ['$el' => 'hr'],
                 'listItem' => ['$el' => 'li', 'children' => $this->content($blocks, $component['content'] ?? [], $submissible, $fields)],
                 'orderedList' => ['$el' => 'ol', 'children' => $this->content($blocks, $component['content'] ?? [], $submissible, $fields)],

--- a/app-modules/form/tests/Tenant/Actions/GenerateFormKitSchemaTest.php
+++ b/app-modules/form/tests/Tenant/Actions/GenerateFormKitSchemaTest.php
@@ -72,3 +72,35 @@ it('generates standardized wizard navigation', function () {
         ->not->toContain('"$el":"ul"')
         ->not->toContain('$setActiveStep');
 });
+
+it('renders an empty heading block without throwing', function () {
+    $form = Form::factory()->make();
+
+    $schema = app(GenerateFormKitSchema::class)->content([], [
+        ['type' => 'heading', 'attrs' => ['level' => 2]],
+    ], $form);
+
+    expect($schema[0])->toBe(['$el' => 'h2', 'children' => []]);
+});
+
+it('renders an empty grid column block without throwing', function () {
+    $form = Form::factory()->make();
+
+    $schema = app(GenerateFormKitSchema::class)->content([], [
+        ['type' => 'gridColumn'],
+    ], $form);
+
+    expect($schema[0])->toBe(['$el' => 'div', 'children' => [], 'attrs' => ['class' => ['grid-col' => true]]]);
+});
+
+it('renders a heading and grid column with content', function () {
+    $form = Form::factory()->make();
+
+    $schema = app(GenerateFormKitSchema::class)->content([], [
+        ['type' => 'heading', 'attrs' => ['level' => 2], 'content' => [['type' => 'text', 'text' => 'Title']]],
+        ['type' => 'gridColumn', 'content' => [['type' => 'text', 'text' => 'Column content']]],
+    ], $form);
+
+    expect($schema[0])->toBe(['$el' => 'h2', 'children' => ['Title']])
+        ->and($schema[1])->toBe(['$el' => 'div', 'children' => ['Column content'], 'attrs' => ['class' => ['grid-col' => true]]]);
+});


### PR DESCRIPTION
### Ticket(s) or GitHub Issue

- https://canyongbs.atlassian.net/browse/ADVAPP-2961

### Technical Description

> Service request / portal forms fail to load when they contain an empty heading or column

### Any deployment steps required?

> NO

### Cleanup Tasks

> N/A

---

#### Before contributing and submitting this PR, make sure you have Read, agree, and are compliant with the [contributing guidelines](https://github.com/canyongbs/advisingapp/blob/main/README.md#contributing).
